### PR TITLE
added sample function to MFGaussian

### DIFF
--- a/blackbox/variationals.py
+++ b/blackbox/variationals.py
@@ -142,6 +142,16 @@ class MFGaussian:
         s = self.transform_s(self.s_unconst)
         return m + eps * s
 
+    def sample(self, size, sess):
+        """
+        z ~ q(z | lambda)
+        """
+        m, s = sess.run([ \
+            self.transform_m(self.m_unconst),
+            self.transform_s(self.s_unconst)]) 
+
+        return m + s * norm.rvs(size=size)
+
     def log_prob_zi(self, i, z):
         """log q(z_i | lambda_i)"""
         if i >= self.num_vars:


### PR DESCRIPTION
#### Summary:

Adding `sample` function to MFGaussian, in case we ever want to use the score function gradient estimator with this variational family.
#### Intended Effect:

Allow us to use the score function gradient estimator with a mean-field Gaussian variational approximation.
#### How to Verify:

Visual inspection. 
#### Side Effects:

At the moment: none, since `blackbox` prefers the reparameterization approach.
#### Documentation:

?
#### Reviewer Suggestions:

@dustinvtran  
