### PR TITLE
let mfgaussian reuse methods

### DIFF
--- a/edward/variationals.py
+++ b/edward/variationals.py
@@ -278,7 +278,7 @@ class MFGaussian:
         """
         z ~ q(z | lambda)
         """
-        return sess.run(self.reparam(self.sample_noise(size)))
+        return self.reparam(self.sample_noise(size))
 
     def log_prob_zi(self, i, z):
         """log q(z_i | lambda_i)"""


### PR DESCRIPTION
#### Summary:

This lets `MFGaussian`'s sample method to reuse the `sample_noise()` and `reparam()` methods, rather than have duplicate code.

For some reason however, this is significantly slower than the previous code change (see below).
#### Intended Effect:

N/A
#### How to Verify:

Go to `examples/gaussian.py`. Change `inference.run(n_iter=10000)` to `inference.run(n_iter=1000, score=True)`. Run

```
time python gaussian.py
```

with this change and without this change. It took roughly 14 seconds on my PC before the change and 25 seconds on my PC after the change.
#### Side Effects:

N/A
#### Documentation:

N/A
#### Reviewer Suggestions:

N/A
