### PR TITLE
Feature/fix pdfs

### DIFF
--- a/edward/stats/distributions.py
+++ b/edward/stats/distributions.py
@@ -109,6 +109,7 @@ class InvGamma:
                tf.mul(-alpha-1, tf.log(x)) - tf.truediv(beta, x)
 
 class Multinomial:
+    """There is no equivalent version implemented in SciPy."""
     def rvs(self, n, p, size=1):
         return np.random.multinomial(n, p, size=size)
 
@@ -117,18 +118,19 @@ class Multinomial:
         Arguments
         ----------
         x: np.array or tf.Tensor
-            vector
-        mean: np.array or tf.Tensor, optional
-            vector. Defaults to zero mean.
-        cov: np.array or tf.Tensor, optional
-            vector or matrix. Defaults to identity.
+            vector of length K, where x[i] is the number of outcomes
+            in the ith bucket
+        n: int or tf.Tensor
+            number of outcomes equal to sum x[i]
+        p: np.array or tf.Tensor
+            vector of probabilities summing to 1
         """
-        # TODO dimensions?
-        x = tf.squeeze(x)
-        n = tf.squeeze(n)
+        x = tf.cast(tf.squeeze(x), dtype=tf.float32)
+        n = tf.cast(tf.squeeze(n), dtype=tf.float32)
         p = tf.cast(tf.squeeze(p), dtype=tf.float32)
-        return tf.log(factorial(n)) - \
-               tf.log(tf.reduce_prod(factorial(x))) + \
+        one = tf.constant(1.0, dtype=tf.float32)
+        return log_gamma(n + one) - \
+               tf.reduce_sum(log_gamma(x + one)) + \
                tf.reduce_sum(tf.mul(x, tf.log(p)))
 
 class Multivariate_Normal:
@@ -267,7 +269,7 @@ dirichlet = Dirichlet()
 expon = Expon() # TODO unit test
 gamma = Gamma()
 invgamma = InvGamma()
-multinomial = Multinomial() # TODO unit test
+multinomial = Multinomial()
 multivariate_normal = Multivariate_Normal()
 norm = Norm()
 poisson = Poisson() # TODO unit test

--- a/edward/stats/distributions.py
+++ b/edward/stats/distributions.py
@@ -32,6 +32,11 @@ class Distribution:
         -------
         tf.Tensor
             scalar
+
+        Note
+        ----
+        The following distributions use scalar arguments unless
+        documented otherwise.
         """
         raise NotImplementedError()
 
@@ -59,6 +64,14 @@ class Dirichlet:
         return stats.dirichlet.rvs(alpha, size=size)
 
     def logpdf(self, x, alpha):
+        """
+        Arguments
+        ----------
+        x: np.array or tf.Tensor
+            vector
+        alpha: np.array or tf.Tensor
+            vector
+        """
         x = tf.cast(tf.squeeze(x), dtype=tf.float32)
         alpha = tf.cast(tf.squeeze(tf.convert_to_tensor(alpha)), dtype=tf.float32)
         return -multivariate_log_beta(alpha) + \
@@ -100,6 +113,16 @@ class Multinomial:
         return np.random.multinomial(n, p, size=size)
 
     def logpmf(self, x, n, p):
+        """
+        Arguments
+        ----------
+        x: np.array or tf.Tensor
+            vector
+        mean: np.array or tf.Tensor, optional
+            vector. Defaults to zero mean.
+        cov: np.array or tf.Tensor, optional
+            vector or matrix. Defaults to identity.
+        """
         # TODO dimensions?
         x = tf.squeeze(x)
         n = tf.squeeze(n)
@@ -122,26 +145,20 @@ class Multivariate_Normal:
             vector. Defaults to zero mean.
         cov: np.array or tf.Tensor, optional
             vector or matrix. Defaults to identity.
-
-        Returns
-        -------
-        tf.Tensor
-            scalar
         """
-        x = tf.cast(tf.squeeze(x), dtype=tf.float32)
+        x = tf.cast(tf.squeeze(tf.convert_to_tensor(x)), dtype=tf.float32)
         d = get_dims(x)[0]
         if mean is None:
             r = tf.ones([d]) * x
         else:
-            # TODO tf.convert_to_tensor
-            mean = tf.cast(tf.squeeze(mean), dtype=tf.float32)
+            mean = tf.cast(tf.squeeze(tf.convert_to_tensor(mean)), dtype=tf.float32)
             r = x - mean
 
-        if cov == 1:
+        if cov is 1:
             cov_inv = tf.diag(tf.ones([d]))
             det_cov = tf.constant(1.0)
         else:
-            cov = tf.cast(tf.squeeze(cov), dtype=tf.float32)
+            cov = tf.cast(tf.squeeze(tf.convert_to_tensor(cov)), dtype=tf.float32)
             if len(cov.get_shape()) == 1:
                 cov_inv = tf.diag(1.0 / cov)
                 det_cov = tf.reduce_prod(cov)
@@ -169,21 +186,16 @@ class Multivariate_Normal:
 
         Arguments
         ----------
-        mean: tf.Tensor, optional
+        mean: np.array or tf.Tensor, optional
             vector. Defaults to zero mean.
-        cov: tf.Tensor, optional
+        cov: np.array or tf.Tensor, optional
             vector or matrix. Defaults to identity.
-
-        Returns
-        -------
-        tf.Tensor
-            scalar
         """
-        if cov == 1:
+        if cov is 1:
             d = 1
             det_cov = 1.0
         else:
-            cov = tf.cast(cov, dtype=tf.float32)
+            cov = tf.cast(tf.squeeze(tf.convert_to_tensor(cov)), dtype=tf.float32)
             d = get_dims(cov)[0]
             if len(cov.get_shape()) == 1:
                 det_cov = tf.reduce_prod(cov)
@@ -252,13 +264,13 @@ class Wishart:
 bernoulli = Bernoulli()
 beta = Beta()
 dirichlet = Dirichlet()
-expon = Expon()
+expon = Expon() # TODO unit test
 gamma = Gamma()
 invgamma = InvGamma()
-multinomial = Multinomial()
+multinomial = Multinomial() # TODO unit test
 multivariate_normal = Multivariate_Normal()
 norm = Norm()
-poisson = Poisson()
-t = T()
-truncnorm = TruncNorm()
-wishart = Wishart()
+poisson = Poisson() # TODO unit test
+t = T() # TODO unit test
+truncnorm = TruncNorm() # TODO unit test
+wishart = Wishart() # TODO unit test

--- a/edward/stats/distributions.py
+++ b/edward/stats/distributions.py
@@ -98,15 +98,16 @@ class Gamma:
         return (a - 1.0) * tf.log(x) - x/scale - a * tf.log(scale) - log_gamma(a)
 
 class InvGamma:
-    def rvs(self, alpha, beta, size=1):
-        return stats.invgamma.rvs(alpha, scale=beta, size=size)
+    """Shape/scale parameterization"""
+    def rvs(self, alpha, scale=1, size=1):
+        return stats.invgamma.rvs(alpha, scale=scale, size=size)
 
-    def logpdf(self, x, alpha, beta):
+    def logpdf(self, x, alpha, scale=1):
         x = tf.cast(tf.squeeze(x), dtype=tf.float32)
         alpha = tf.cast(tf.squeeze(alpha), dtype=tf.float32)
-        beta = tf.cast(tf.squeeze(beta), dtype=tf.float32)
-        return tf.mul(alpha, tf.log(beta)) - log_gamma(alpha) + \
-               tf.mul(-alpha-1, tf.log(x)) - tf.truediv(beta, x)
+        scale = tf.cast(tf.squeeze(scale), dtype=tf.float32)
+        return tf.mul(alpha, tf.log(scale)) - log_gamma(alpha) + \
+               tf.mul(-alpha-1, tf.log(x)) - tf.truediv(scale, x)
 
 class Multinomial:
     """There is no equivalent version implemented in SciPy."""

--- a/edward/util.py
+++ b/edward/util.py
@@ -1,8 +1,6 @@
 import numpy as np
 import tensorflow as tf
 
-from scipy.special import factorial
-
 def set_seed(x):
     """
     Set seed for both NumPy and TensorFlow.
@@ -139,21 +137,6 @@ def kl_multivariate_normal(loc, scale):
     return -0.5 * tf.reduce_sum(1.0 + 2.0 * tf.log(scale + 1e-8) - \
                                 tf.square(loc) - tf.square(scale))
 
-def log_multinomial(x, n):
-    num = tf.reduce_prod(factorial(x))
-    denom = factorial(n)
-    return tf.log(tf.truediv(num, denom))
-
-
-def log_dirichlet(x):
-    num =  tf.reduce_prod(log_gamma(x))
-    denom = log_gamma(tf.reduce_sum(x))
-    return num/denom
-
-
-def log_inv_gamma(x, y):
-    return log_gamma(x) - tf.mul(x, tf.log(y))
-
 def log_gamma(x):
     """
     TensorFlow doesn't have special functions, so use a
@@ -162,7 +145,7 @@ def log_gamma(x):
     """
     logterm = tf.log(x * (1.0 + x) * (2.0 + x))
     xp3 = 3.0 + x
-    return -2.081061466 - x + 0.0833333 / xp3 - logterm + (2.5 + x) * tf.log (xp3)
+    return -2.081061466 - x + 0.0833333 / xp3 - logterm + (2.5 + x) * tf.log(xp3)
 
 def log_beta(x, y):
     """
@@ -187,6 +170,9 @@ def logit(x, clip_finite=True):
         log_jacobian = np.sum(np.log(jacobian))
 
     return transformed, log_jacobian
+
+def multivariate_log_beta(x):
+    return tf.reduce_sum(log_gamma(x)) - log_gamma(tf.reduce_sum(x))
 
 def rbf(x):
     """RBF kernel element-wise."""

--- a/tests/test_stats_bernoulli_logpmf.py
+++ b/tests/test_stats_bernoulli_logpmf.py
@@ -7,11 +7,9 @@ from scipy import stats
 
 sess = tf.Session()
 
-
 def _assert_eq(val_ed, val_true):
     with sess.as_default():
         assert np.allclose(val_ed.eval(), val_true)
-
 
 def _test_logpdf(scalar, param):
     x = tf.constant(scalar)
@@ -19,21 +17,17 @@ def _test_logpdf(scalar, param):
     _assert_eq(bernoulli.logpmf(x, tf.constant(param)), val_true)
     _assert_eq(bernoulli.logpmf(x, tf.constant([param])), val_true)
 
-
 def test_logpdf_int_scalar():
     _test_logpdf(0, 0.5)
     _test_logpdf(1, 0.75)
-
 
 def test_logpdf_float_scalar():
     _test_logpdf(0.0, 0.5)
     _test_logpdf(1.0, 0.75)
 
-
 def test_logpdf_int_1d():
     _test_logpdf([0], 0.5)
     _test_logpdf([1], 0.75)
-
 
 def test_logpdf_float_1d():
     _test_logpdf([0.0], 0.5)

--- a/tests/test_stats_bernoulli_logpmf.py
+++ b/tests/test_stats_bernoulli_logpmf.py
@@ -11,11 +11,11 @@ def _assert_eq(val_ed, val_true):
     with sess.as_default():
         assert np.allclose(val_ed.eval(), val_true)
 
-def _test_logpdf(scalar, param):
-    x = tf.constant(scalar)
-    val_true = stats.bernoulli.logpmf(scalar, param)
-    _assert_eq(bernoulli.logpmf(x, tf.constant(param)), val_true)
-    _assert_eq(bernoulli.logpmf(x, tf.constant([param])), val_true)
+def _test_logpdf(x, p):
+    xtf = tf.constant(x)
+    val_true = stats.bernoulli.logpmf(x, p)
+    _assert_eq(bernoulli.logpmf(xtf, tf.constant(p)), val_true)
+    _assert_eq(bernoulli.logpmf(xtf, tf.constant([p])), val_true)
 
 def test_logpdf_int_scalar():
     _test_logpdf(0, 0.5)

--- a/tests/test_stats_beta_logpdf.py
+++ b/tests/test_stats_beta_logpdf.py
@@ -13,13 +13,13 @@ def _assert_eq(val_ed, val_true):
         # only an approximation
         assert np.allclose(val_ed.eval(), val_true, atol=1e-4)
 
-def _test_logpdf_scalar(scalar, a=0.5, b=0.5):
-    x = tf.constant(scalar)
-    val_true = stats.beta.logpdf(scalar, a, b)
-    _assert_eq(beta.logpdf(x, tf.constant(a), tf.constant(b)), val_true)
-    _assert_eq(beta.logpdf(x, tf.constant([a]), tf.constant(b)), val_true)
-    _assert_eq(beta.logpdf(x, tf.constant(a), tf.constant([b])), val_true)
-    _assert_eq(beta.logpdf(x, tf.constant([a]), tf.constant([b])), val_true)
+def _test_logpdf_scalar(x, a=0.5, b=0.5):
+    xtf = tf.constant(x)
+    val_true = stats.beta.logpdf(x, a, b)
+    _assert_eq(beta.logpdf(xtf, tf.constant(a), tf.constant(b)), val_true)
+    _assert_eq(beta.logpdf(xtf, tf.constant([a]), tf.constant(b)), val_true)
+    _assert_eq(beta.logpdf(xtf, tf.constant(a), tf.constant([b])), val_true)
+    _assert_eq(beta.logpdf(xtf, tf.constant([a]), tf.constant([b])), val_true)
 
 def test_logpdf_scalar():
     _test_logpdf_scalar(0.3)
@@ -35,9 +35,10 @@ def test_logpdf_scalar():
     _test_logpdf_scalar(0.7, a=5.0, b=0.5)
 
 def test_logpdf_1d():
-    x = tf.constant([0.5])
-    val_true = stats.beta.logpdf([0.5], 0.5, 0.5)
-    _assert_eq(beta.logpdf(x, tf.constant(0.5), tf.constant(0.5)), val_true)
-    _assert_eq(beta.logpdf(x, tf.constant([0.5]), tf.constant(0.5)), val_true)
-    _assert_eq(beta.logpdf(x, tf.constant(0.5), tf.constant([0.5])), val_true)
-    _assert_eq(beta.logpdf(x, tf.constant([0.5]), tf.constant([0.5])), val_true)
+    x = [0.5]
+    xtf = tf.constant([0.5])
+    val_true = stats.beta.logpdf(x, 0.5, 0.5)
+    _assert_eq(beta.logpdf(xtf, tf.constant(0.5), tf.constant(0.5)), val_true)
+    _assert_eq(beta.logpdf(xtf, tf.constant([0.5]), tf.constant(0.5)), val_true)
+    _assert_eq(beta.logpdf(xtf, tf.constant(0.5), tf.constant([0.5])), val_true)
+    _assert_eq(beta.logpdf(xtf, tf.constant([0.5]), tf.constant([0.5])), val_true)

--- a/tests/test_stats_dirichlet_logpdf.py
+++ b/tests/test_stats_dirichlet_logpdf.py
@@ -13,11 +13,11 @@ def _assert_eq(val_ed, val_true):
         # only an approximation
         assert np.allclose(val_ed.eval(), val_true, atol=1e-4)
 
-def _test_logpdf_1d(vector, alpha=np.array([0.5, 0.5])):
-    x = tf.constant(vector)
-    val_true = stats.dirichlet.logpdf(vector, alpha)
-    _assert_eq(dirichlet.logpdf(x, alpha), val_true)
-    _assert_eq(dirichlet.logpdf(x, tf.convert_to_tensor(alpha)), val_true)
+def _test_logpdf_1d(x, alpha=np.array([0.5, 0.5])):
+    xtf = tf.constant(x)
+    val_true = stats.dirichlet.logpdf(x, alpha)
+    _assert_eq(dirichlet.logpdf(xtf, alpha), val_true)
+    _assert_eq(dirichlet.logpdf(xtf, tf.convert_to_tensor(alpha)), val_true)
 
 def test_logpdf_1d():
     _test_logpdf_1d(np.array([0.3, 0.7]))

--- a/tests/test_stats_dirichlet_logpdf.py
+++ b/tests/test_stats_dirichlet_logpdf.py
@@ -1,0 +1,33 @@
+from __future__ import print_function
+import numpy as np
+import tensorflow as tf
+
+from edward.stats import dirichlet
+from scipy import stats
+
+sess = tf.Session()
+
+def _assert_eq(val_ed, val_true):
+    with sess.as_default():
+        # NOTE: since Tensorflow has no special functions, the values here are
+        # only an approximation
+        assert np.allclose(val_ed.eval(), val_true, atol=1e-4)
+
+def _test_logpdf_1d(vector, alpha=np.array([0.5, 0.5])):
+    x = tf.constant(vector)
+    val_true = stats.dirichlet.logpdf(vector, alpha)
+    _assert_eq(dirichlet.logpdf(x, alpha), val_true)
+    _assert_eq(dirichlet.logpdf(x, tf.convert_to_tensor(alpha)), val_true)
+
+def test_logpdf_1d():
+    _test_logpdf_1d(np.array([0.3, 0.7]))
+    _test_logpdf_1d(np.array([0.2, 0.8]))
+
+    _test_logpdf_1d(np.array([0.3, 0.7]), alpha=np.array([1.0, 1.0]))
+    _test_logpdf_1d(np.array([0.2, 0.8]), alpha=np.array([1.0, 1.0]))
+
+    _test_logpdf_1d(np.array([0.3, 0.7]), alpha=np.array([0.5, 5.0]))
+    _test_logpdf_1d(np.array([0.2, 0.8]), alpha=np.array([0.5, 5.0]))
+
+    _test_logpdf_1d(np.array([0.3, 0.7]), alpha=np.array([5.0, 0.5]))
+    _test_logpdf_1d(np.array([0.2, 0.8]), alpha=np.array([5.0, 0.5]))

--- a/tests/test_stats_gamma_logpdf.py
+++ b/tests/test_stats_gamma_logpdf.py
@@ -13,13 +13,13 @@ def _assert_eq(val_ed, val_true):
         # only an approximation
         assert np.allclose(val_ed.eval(), val_true, atol=1e-4)
 
-def _test_logpdf_scalar(scalar, a=0.5, b=0.5):
-    x = tf.constant(scalar)
-    val_true = stats.gamma.logpdf(scalar, a, scale=b)
-    _assert_eq(gamma.logpdf(x, tf.constant(a), tf.constant(b)), val_true)
-    _assert_eq(gamma.logpdf(x, tf.constant([a]), tf.constant(b)), val_true)
-    _assert_eq(gamma.logpdf(x, tf.constant(a), tf.constant([b])), val_true)
-    _assert_eq(gamma.logpdf(x, tf.constant([a]), tf.constant([b])), val_true)
+def _test_logpdf_scalar(x, a=0.5, b=0.5):
+    xtf = tf.constant(x)
+    val_true = stats.gamma.logpdf(x, a, scale=b)
+    _assert_eq(gamma.logpdf(xtf, tf.constant(a), tf.constant(b)), val_true)
+    _assert_eq(gamma.logpdf(xtf, tf.constant([a]), tf.constant(b)), val_true)
+    _assert_eq(gamma.logpdf(xtf, tf.constant(a), tf.constant([b])), val_true)
+    _assert_eq(gamma.logpdf(xtf, tf.constant([a]), tf.constant([b])), val_true)
 
 def test_logpdf_scalar():
     _test_logpdf_scalar(0.3)
@@ -35,9 +35,10 @@ def test_logpdf_scalar():
     _test_logpdf_scalar(0.7, a=5.0, b=0.5)
 
 def test_logpdf_1d():
-    x = tf.constant([0.5])
-    val_true = stats.gamma.logpdf([0.5], 0.5, scale=0.5)
-    _assert_eq(gamma.logpdf(x, tf.constant(0.5), tf.constant(0.5)), val_true)
-    _assert_eq(gamma.logpdf(x, tf.constant([0.5]), tf.constant(0.5)), val_true)
-    _assert_eq(gamma.logpdf(x, tf.constant(0.5), tf.constant([0.5])), val_true)
-    _assert_eq(gamma.logpdf(x, tf.constant([0.5]), tf.constant([0.5])), val_true)
+    x = [0.5]
+    xtf = tf.constant([0.5])
+    val_true = stats.gamma.logpdf(x, 0.5, scale=0.5)
+    _assert_eq(gamma.logpdf(xtf, tf.constant(0.5), tf.constant(0.5)), val_true)
+    _assert_eq(gamma.logpdf(xtf, tf.constant([0.5]), tf.constant(0.5)), val_true)
+    _assert_eq(gamma.logpdf(xtf, tf.constant(0.5), tf.constant([0.5])), val_true)
+    _assert_eq(gamma.logpdf(xtf, tf.constant([0.5]), tf.constant([0.5])), val_true)

--- a/tests/test_stats_gamma_logpdf.py
+++ b/tests/test_stats_gamma_logpdf.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import numpy as np
 import tensorflow as tf
 
-from edward.stats import beta
+from edward.stats import gamma
 from scipy import stats
 
 sess = tf.Session()
@@ -15,11 +15,11 @@ def _assert_eq(val_ed, val_true):
 
 def _test_logpdf_scalar(scalar, a=0.5, b=0.5):
     x = tf.constant(scalar)
-    val_true = stats.beta.logpdf(scalar, a, b)
-    _assert_eq(beta.logpdf(x, tf.constant(a), tf.constant(b)), val_true)
-    _assert_eq(beta.logpdf(x, tf.constant([a]), tf.constant(b)), val_true)
-    _assert_eq(beta.logpdf(x, tf.constant(a), tf.constant([b])), val_true)
-    _assert_eq(beta.logpdf(x, tf.constant([a]), tf.constant([b])), val_true)
+    val_true = stats.gamma.logpdf(scalar, a, scale=b)
+    _assert_eq(gamma.logpdf(x, tf.constant(a), tf.constant(b)), val_true)
+    _assert_eq(gamma.logpdf(x, tf.constant([a]), tf.constant(b)), val_true)
+    _assert_eq(gamma.logpdf(x, tf.constant(a), tf.constant([b])), val_true)
+    _assert_eq(gamma.logpdf(x, tf.constant([a]), tf.constant([b])), val_true)
 
 def test_logpdf_scalar():
     _test_logpdf_scalar(0.3)
@@ -36,8 +36,8 @@ def test_logpdf_scalar():
 
 def test_logpdf_1d():
     x = tf.constant([0.5])
-    val_true = stats.beta.logpdf([0.5], 0.5, 0.5)
-    _assert_eq(beta.logpdf(x, tf.constant(0.5), tf.constant(0.5)), val_true)
-    _assert_eq(beta.logpdf(x, tf.constant([0.5]), tf.constant(0.5)), val_true)
-    _assert_eq(beta.logpdf(x, tf.constant(0.5), tf.constant([0.5])), val_true)
-    _assert_eq(beta.logpdf(x, tf.constant([0.5]), tf.constant([0.5])), val_true)
+    val_true = stats.gamma.logpdf([0.5], 0.5, scale=0.5)
+    _assert_eq(gamma.logpdf(x, tf.constant(0.5), tf.constant(0.5)), val_true)
+    _assert_eq(gamma.logpdf(x, tf.constant([0.5]), tf.constant(0.5)), val_true)
+    _assert_eq(gamma.logpdf(x, tf.constant(0.5), tf.constant([0.5])), val_true)
+    _assert_eq(gamma.logpdf(x, tf.constant([0.5]), tf.constant([0.5])), val_true)

--- a/tests/test_stats_invgamma_logpdf.py
+++ b/tests/test_stats_invgamma_logpdf.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import numpy as np
 import tensorflow as tf
 
-from edward.stats import beta
+from edward.stats import invgamma
 from scipy import stats
 
 sess = tf.Session()
@@ -15,11 +15,11 @@ def _assert_eq(val_ed, val_true):
 
 def _test_logpdf_scalar(scalar, a=0.5, b=0.5):
     x = tf.constant(scalar)
-    val_true = stats.beta.logpdf(scalar, a, b)
-    _assert_eq(beta.logpdf(x, tf.constant(a), tf.constant(b)), val_true)
-    _assert_eq(beta.logpdf(x, tf.constant([a]), tf.constant(b)), val_true)
-    _assert_eq(beta.logpdf(x, tf.constant(a), tf.constant([b])), val_true)
-    _assert_eq(beta.logpdf(x, tf.constant([a]), tf.constant([b])), val_true)
+    val_true = stats.invgamma.logpdf(scalar, a, scale=b)
+    _assert_eq(invgamma.logpdf(x, tf.constant(a), tf.constant(b)), val_true)
+    _assert_eq(invgamma.logpdf(x, tf.constant([a]), tf.constant(b)), val_true)
+    _assert_eq(invgamma.logpdf(x, tf.constant(a), tf.constant([b])), val_true)
+    _assert_eq(invgamma.logpdf(x, tf.constant([a]), tf.constant([b])), val_true)
 
 def test_logpdf_scalar():
     _test_logpdf_scalar(0.3)
@@ -36,8 +36,8 @@ def test_logpdf_scalar():
 
 def test_logpdf_1d():
     x = tf.constant([0.5])
-    val_true = stats.beta.logpdf([0.5], 0.5, 0.5)
-    _assert_eq(beta.logpdf(x, tf.constant(0.5), tf.constant(0.5)), val_true)
-    _assert_eq(beta.logpdf(x, tf.constant([0.5]), tf.constant(0.5)), val_true)
-    _assert_eq(beta.logpdf(x, tf.constant(0.5), tf.constant([0.5])), val_true)
-    _assert_eq(beta.logpdf(x, tf.constant([0.5]), tf.constant([0.5])), val_true)
+    val_true = stats.invgamma.logpdf([0.5], 0.5, scale=0.5)
+    _assert_eq(invgamma.logpdf(x, tf.constant(0.5), tf.constant(0.5)), val_true)
+    _assert_eq(invgamma.logpdf(x, tf.constant([0.5]), tf.constant(0.5)), val_true)
+    _assert_eq(invgamma.logpdf(x, tf.constant(0.5), tf.constant([0.5])), val_true)
+    _assert_eq(invgamma.logpdf(x, tf.constant([0.5]), tf.constant([0.5])), val_true)

--- a/tests/test_stats_invgamma_logpdf.py
+++ b/tests/test_stats_invgamma_logpdf.py
@@ -13,13 +13,13 @@ def _assert_eq(val_ed, val_true):
         # only an approximation
         assert np.allclose(val_ed.eval(), val_true, atol=1e-4)
 
-def _test_logpdf_scalar(scalar, a=0.5, b=0.5):
-    x = tf.constant(scalar)
-    val_true = stats.invgamma.logpdf(scalar, a, scale=b)
-    _assert_eq(invgamma.logpdf(x, tf.constant(a), tf.constant(b)), val_true)
-    _assert_eq(invgamma.logpdf(x, tf.constant([a]), tf.constant(b)), val_true)
-    _assert_eq(invgamma.logpdf(x, tf.constant(a), tf.constant([b])), val_true)
-    _assert_eq(invgamma.logpdf(x, tf.constant([a]), tf.constant([b])), val_true)
+def _test_logpdf_scalar(x, a=0.5, b=0.5):
+    xtf = tf.constant(x)
+    val_true = stats.invgamma.logpdf(x, a, scale=b)
+    _assert_eq(invgamma.logpdf(xtf, tf.constant(a), tf.constant(b)), val_true)
+    _assert_eq(invgamma.logpdf(xtf, tf.constant([a]), tf.constant(b)), val_true)
+    _assert_eq(invgamma.logpdf(xtf, tf.constant(a), tf.constant([b])), val_true)
+    _assert_eq(invgamma.logpdf(xtf, tf.constant([a]), tf.constant([b])), val_true)
 
 def test_logpdf_scalar():
     _test_logpdf_scalar(0.3)

--- a/tests/test_stats_invgamma_logpdf.py
+++ b/tests/test_stats_invgamma_logpdf.py
@@ -35,9 +35,10 @@ def test_logpdf_scalar():
     _test_logpdf_scalar(0.7, a=5.0, b=0.5)
 
 def test_logpdf_1d():
-    x = tf.constant([0.5])
-    val_true = stats.invgamma.logpdf([0.5], 0.5, scale=0.5)
-    _assert_eq(invgamma.logpdf(x, tf.constant(0.5), tf.constant(0.5)), val_true)
-    _assert_eq(invgamma.logpdf(x, tf.constant([0.5]), tf.constant(0.5)), val_true)
-    _assert_eq(invgamma.logpdf(x, tf.constant(0.5), tf.constant([0.5])), val_true)
-    _assert_eq(invgamma.logpdf(x, tf.constant([0.5]), tf.constant([0.5])), val_true)
+    x = [0.5]
+    xtf = tf.constant([0.5])
+    val_true = stats.invgamma.logpdf(x, 0.5, scale=0.5)
+    _assert_eq(invgamma.logpdf(xtf, tf.constant(0.5), tf.constant(0.5)), val_true)
+    _assert_eq(invgamma.logpdf(xtf, tf.constant([0.5]), tf.constant(0.5)), val_true)
+    _assert_eq(invgamma.logpdf(xtf, tf.constant(0.5), tf.constant([0.5])), val_true)
+    _assert_eq(invgamma.logpdf(xtf, tf.constant([0.5]), tf.constant([0.5])), val_true)

--- a/tests/test_stats_multinomial_logpmf.py
+++ b/tests/test_stats_multinomial_logpmf.py
@@ -1,0 +1,50 @@
+from __future__ import print_function
+import numpy as np
+import tensorflow as tf
+
+from edward.stats import multinomial
+from scipy.special import gammaln
+
+sess = tf.Session()
+
+def multinomial_logpmf(x, n, p):
+    """
+    Arguments
+    ----------
+    x: np.array
+        vector of length K, where x[i] is the number of outcomes
+        in the ith bucket
+    n: int
+        number of outcomes equal to sum x[i]
+    p: np.array
+        vector of probabilities summing to 1
+    """
+    return gammaln(n + 1.0) - \
+           np.sum(gammaln(x + 1.0)) + \
+           np.sum(x * np.log(p))
+
+def _assert_eq(val_ed, val_true):
+    with sess.as_default():
+        # NOTE: since Tensorflow has no special functions, the values here are
+        # only an approximation
+        assert np.allclose(val_ed.eval(), val_true, atol=1e-4)
+
+def _test_logpdf(x, n, p):
+    xtf = tf.constant(x)
+    val_true = multinomial_logpmf(x, n, p)
+    _assert_eq(multinomial.logpmf(xtf, n, p),
+               val_true)
+    _assert_eq(multinomial.logpmf(xtf, n, tf.constant(p, dtype=tf.float32)),
+               val_true)
+    _assert_eq(multinomial.logpmf(xtf, n, p),
+               val_true)
+    _assert_eq(multinomial.logpmf(xtf, n, tf.constant(p, dtype=tf.float32)),
+               val_true)
+
+def test_logpdf_int_1d():
+    _test_logpdf(np.array([0, 1]), 1, np.array([0.5, 0.5]))
+    _test_logpdf(np.array([1, 0]), 1, np.array([0.75, 0.25]))
+
+def test_logpdf_float_1d():
+    _test_logpdf(np.array([0.0, 1.0]), 1, np.array([0.5, 0.5]))
+    _test_logpdf(np.array([1.0, 0.0]), 1, np.array([0.75, 0.25]))

--- a/tests/test_stats_multivariate_normal_entropy.py
+++ b/tests/test_stats_multivariate_normal_entropy.py
@@ -23,8 +23,16 @@ def test_entropy_1d():
     _assert_eq(multivariate_normal.entropy(cov=np.diag(diag)),
                stats.multivariate_normal.entropy(cov=np.diag(diag)))
 
-def test_entropy_2d():
+def test_entropy_2d_diag():
     cm = [[1.0, 0.0], [0.0, 1.0]]
+    cov = tf.constant(cm)
+    _assert_eq(multivariate_normal.entropy(cov=cov),
+               stats.multivariate_normal.entropy(cov=np.array(cm)))
+    _assert_eq(multivariate_normal.entropy(cov=np.array(cm)),
+               stats.multivariate_normal.entropy(cov=np.array(cm)))
+
+def test_entropy_2d_full():
+    cm = [[1.0, 0.9], [0.9, 1.0]]
     cov = tf.constant(cm)
     _assert_eq(multivariate_normal.entropy(cov=cov),
                stats.multivariate_normal.entropy(cov=np.array(cm)))

--- a/tests/test_stats_multivariate_normal_entropy.py
+++ b/tests/test_stats_multivariate_normal_entropy.py
@@ -7,26 +7,26 @@ from scipy import stats
 
 sess = tf.Session()
 
-
 def _assert_eq(res_ed, res_true):
     with sess.as_default():
         assert np.allclose(res_ed.eval(), res_true)
 
-
 def test_entropy_empty():
     _assert_eq(multivariate_normal.entropy(),
                stats.multivariate_normal.entropy())
-
 
 def test_entropy_1d():
     diag = [1.0, 1.0]
     cov = tf.constant(diag)
     _assert_eq(multivariate_normal.entropy(cov=cov),
                stats.multivariate_normal.entropy(cov=np.diag(diag)))
-
+    _assert_eq(multivariate_normal.entropy(cov=np.diag(diag)),
+               stats.multivariate_normal.entropy(cov=np.diag(diag)))
 
 def test_entropy_2d():
     cm = [[1.0, 0.0], [0.0, 1.0]]
     cov = tf.constant(cm)
     _assert_eq(multivariate_normal.entropy(cov=cov),
+               stats.multivariate_normal.entropy(cov=np.array(cm)))
+    _assert_eq(multivariate_normal.entropy(cov=np.array(cm)),
                stats.multivariate_normal.entropy(cov=np.array(cm)))

--- a/tests/test_stats_multivariate_normal_logpdf.py
+++ b/tests/test_stats_multivariate_normal_logpdf.py
@@ -7,11 +7,9 @@ from scipy import stats
 
 sess = tf.Session()
 
-
 def _assert_eq(val_ed, val_true):
     with sess.as_default():
         assert np.allclose(val_ed.eval(), val_true)
-
 
 def _test_logpdf_standard_2d(val):
     x = tf.constant(val)
@@ -20,19 +18,19 @@ def _test_logpdf_standard_2d(val):
         np.zeros(2),
         np.diag(np.ones(2)))
     _assert_eq(multivariate_normal.logpdf(x), val_true)
+    _assert_eq(multivariate_normal.logpdf(x, np.zeros([2]), np.ones([2])),
+               val_true)
     _assert_eq(multivariate_normal.logpdf(x, tf.zeros([2]), tf.ones([2])),
                val_true)
-    _assert_eq(multivariate_normal.logpdf(
-        x, tf.zeros([2]), tf.diag(tf.ones([2]))), val_true)
-
+    _assert_eq(
+        multivariate_normal.logpdf(x, np.zeros([2]), np.diag(np.ones([2]))),
+        val_true)
 
 def test_logpdf_standard_float_2d():
     _test_logpdf_standard_2d([0.0, 0.0])
 
-
 def test_logpdf_standard_int_2d():
     _test_logpdf_standard_2d([0, 0])
-
 
 def test_logpdf_cov_float_2d():
     x = tf.constant([0.0, 0.0])

--- a/tests/test_stats_multivariate_normal_logpdf.py
+++ b/tests/test_stats_multivariate_normal_logpdf.py
@@ -11,19 +11,16 @@ def _assert_eq(val_ed, val_true):
     with sess.as_default():
         assert np.allclose(val_ed.eval(), val_true)
 
-def _test_logpdf_standard_2d(val):
-    x = tf.constant(val)
-    val_true = stats.multivariate_normal.logpdf(
-        np.zeros(2),
-        np.zeros(2),
-        np.diag(np.ones(2)))
-    _assert_eq(multivariate_normal.logpdf(x), val_true)
-    _assert_eq(multivariate_normal.logpdf(x, np.zeros([2]), np.ones([2])),
+def _test_logpdf_standard_2d(x):
+    xtf = tf.constant(x)
+    val_true = stats.multivariate_normal.logpdf(x, np.zeros(2), np.diag(np.ones(2)))
+    _assert_eq(multivariate_normal.logpdf(xtf), val_true)
+    _assert_eq(multivariate_normal.logpdf(xtf, np.zeros([2]), np.ones([2])),
                val_true)
-    _assert_eq(multivariate_normal.logpdf(x, tf.zeros([2]), tf.ones([2])),
+    _assert_eq(multivariate_normal.logpdf(xtf, tf.zeros([2]), tf.ones([2])),
                val_true)
     _assert_eq(
-        multivariate_normal.logpdf(x, np.zeros([2]), np.diag(np.ones([2]))),
+        multivariate_normal.logpdf(xtf, np.zeros([2]), np.diag(np.ones([2]))),
         val_true)
 
 def test_logpdf_standard_float_2d():
@@ -33,11 +30,10 @@ def test_logpdf_standard_int_2d():
     _test_logpdf_standard_2d([0, 0])
 
 def test_logpdf_cov_float_2d():
-    x = tf.constant([0.0, 0.0])
+    x = np.zeros(2)
+    xtf = tf.constant([0.0, 0.0])
     val_true = stats.multivariate_normal.logpdf(
-        np.zeros(2),
-        np.zeros(2),
-        np.array([[2.0, 0.5], [0.5, 1.0]]))
+        x, np.zeros(2), np.array([[2.0, 0.5], [0.5, 1.0]]))
     _assert_eq(multivariate_normal.logpdf(
-        x, tf.zeros([2]), tf.constant([[2.0, 0.5], [0.5, 1.0]])),
+        xtf, tf.zeros([2]), tf.constant([[2.0, 0.5], [0.5, 1.0]])),
         val_true)

--- a/tests/test_stats_norm_entropy.py
+++ b/tests/test_stats_norm_entropy.py
@@ -7,20 +7,16 @@ from scipy import stats
 
 sess = tf.Session()
 
-
 def _assert_eq(res_ed, res_true):
     with sess.as_default():
         assert np.allclose(res_ed.eval(), res_true)
 
-
 def test_entropy_empty():
     _assert_eq(norm.entropy(), stats.norm.entropy())
-
 
 def test_entropy_scalar():
     x = tf.constant(1.0)
     _assert_eq(norm.entropy(x), stats.norm.entropy(1.0))
-
 
 def test_entropy_1d():
     x = tf.ones([1.0])

--- a/tests/test_stats_norm_logpdf.py
+++ b/tests/test_stats_norm_logpdf.py
@@ -7,40 +7,37 @@ from scipy import stats
 
 sess = tf.Session()
 
-
 def _assert_eq(val_ed, val_true):
     with sess.as_default():
         assert np.allclose(val_ed.eval(), val_true)
 
-
-def _test_logpdf_scalar(scalar):
-    x = tf.constant(scalar)
-    val_true = stats.norm.logpdf(scalar)
-    _assert_eq(norm.logpdf(x), val_true)
-    _assert_eq(norm.logpdf(x, tf.zeros([1]), tf.constant(1.0)), val_true)
-    _assert_eq(norm.logpdf(x, tf.zeros([1]), tf.ones([1])), val_true)
-    _assert_eq(norm.logpdf(x, tf.zeros([1]), tf.diag(tf.ones([1]))), val_true)
-
+def _test_logpdf_scalar(x):
+    xtf = tf.constant(x)
+    val_true = stats.norm.logpdf(x)
+    _assert_eq(norm.logpdf(xtf), val_true)
+    _assert_eq(norm.logpdf(xtf, tf.zeros([1]), tf.constant(1.0)), val_true)
+    _assert_eq(norm.logpdf(xtf, tf.zeros([1]), tf.ones([1])), val_true)
+    _assert_eq(norm.logpdf(xtf, tf.zeros([1]), tf.diag(tf.ones([1]))), val_true)
 
 def test_logpdf_scalar():
     _test_logpdf_scalar(0.0)
     _test_logpdf_scalar(0.623)
 
-
 def test_logpdf_1d():
-    x = tf.constant([0.0])
-    val_true = stats.norm.logpdf([0.0])
-    _assert_eq(norm.logpdf(x), val_true)
-    _assert_eq(norm.logpdf(x, tf.constant(0.0), tf.constant(1.0)), val_true)
-    _assert_eq(norm.logpdf(x, tf.constant([0.0]), tf.constant(1.0)), val_true)
-    _assert_eq(norm.logpdf(x, tf.constant([0.0]), tf.constant([1.0])), val_true)
-
+    x = [0.0]
+    xtf = tf.constant([0.0])
+    val_true = stats.norm.logpdf(x)
+    _assert_eq(norm.logpdf(xtf), val_true)
+    _assert_eq(norm.logpdf(xtf, tf.constant(0.0), tf.constant(1.0)), val_true)
+    _assert_eq(norm.logpdf(xtf, tf.constant([0.0]), tf.constant(1.0)), val_true)
+    _assert_eq(norm.logpdf(xtf, tf.constant([0.0]), tf.constant([1.0])), val_true)
 
 def test_logpdf_1by1mat():
-    x = tf.constant([[0.0]])
-    val_true = stats.norm.logpdf([[0.0]])
-    _assert_eq(norm.logpdf(x), val_true)
-    _assert_eq(norm.logpdf(x, tf.constant(0.0), tf.constant(1.0)), val_true)
-    _assert_eq(norm.logpdf(x, tf.constant([0.0]), tf.constant(1.0)), val_true)
-    _assert_eq(norm.logpdf(x, tf.constant(0.0), tf.constant([1.0])), val_true)
-    _assert_eq(norm.logpdf(x, tf.constant([0.0]), tf.constant([1.0])), val_true)
+    x = [[0.0]]
+    xtf = tf.constant([[0.0]])
+    val_true = stats.norm.logpdf(x)
+    _assert_eq(norm.logpdf(xtf), val_true)
+    _assert_eq(norm.logpdf(xtf, tf.constant(0.0), tf.constant(1.0)), val_true)
+    _assert_eq(norm.logpdf(xtf, tf.constant([0.0]), tf.constant(1.0)), val_true)
+    _assert_eq(norm.logpdf(xtf, tf.constant(0.0), tf.constant([1.0])), val_true)
+    _assert_eq(norm.logpdf(xtf, tf.constant([0.0]), tf.constant([1.0])), val_true)


### PR DESCRIPTION
#### Summary:

Issues: makes progress for #8

I fixed and robustified the implementation for Dirichlet, Gamma, Inverse Gamma, and Multinomial distributions. I also let all distributions take np.array or tf.tensors as arguments; previously it was only tf.tensors as arguments with the occasional np argument, which was confusing.

#### Intended Effect:

The above distributions work.

#### How to Verify:

Run all examples and unit tests. See that nothing is broken. Tests are added for the fixed distributions.

#### Side Effects:

N/A

#### Documentation:

Doc is added for any distributions that use vectors as arguments (e.g. dirichlet, multinomial, multivariate normal). Distributions without doc use scalars as arguments by default.

#### Reviewer Suggestions: 

@akucukelbir since you have time? or @dawenl? Someone just has to run the unit tests to verify that it works on their computer too.