### PR TITLE
add vertical layers

### DIFF
--- a/examples/mixture_gaussian_mapping.py
+++ b/examples/mixture_gaussian_mapping.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+"""
+Mixture model using mean-field variational inference. As a proof of
+concept, we use a custom parameterization of the Dirichlet variational
+family to only have one parameter.
+
+Probability model
+    Mixture of Gaussians
+    pi ~ Dirichlet(alpha)
+    for k = 1, ..., K
+        mu_k ~ N(0, cI)
+        sigma_k ~ Inv-Gamma(a, b)
+    for n = 1, ..., N
+        c_n ~ Multinomial(pi)
+        x_n|c_n ~ N(mu_{c_n}, sigma_{c_n})
+Variational model
+    Likelihood:
+        q(pi) prod_{k=1}^K q(mu_k) q(sigma_k)
+        q(pi) = Dirichlet(alpha')
+        q(mu_k) = N(mu'_k, Sigma'_k)
+        q(sigma_k) = Inv-Gamma(a'_k, b'_k)
+    (We collapse the c_n latent variables in the probability model's
+    joint density.)
+
+Data: x = {x_1, ..., x_N}, where each x_i is in R^2
+"""
+import edward as ed
+import tensorflow as tf
+import numpy as np
+
+from edward.stats import dirichlet, invgamma, multivariate_normal, norm
+from edward.variationals import Variational, Dirichlet, Normal, InvGamma
+from edward.util import get_dims, Variable
+
+class MixtureGaussian:
+    """
+    Mixture of Gaussians
+
+    p(x, z) = [ prod_{n=1}^N N(x_n; mu_{c_n}, sigma_{c_n}) Multinomial(c_n; pi) ]
+              [ prod_{k=1}^K N(mu_k; 0, cI) Inv-Gamma(sigma_k; a, b) ]
+              Dirichlet(pi; alpha)
+
+    where z = {pi, mu, sigma} and for known hyperparameters a, b, c, alpha.
+
+    Parameters
+    ----------
+    K : int
+        Number of mixture components.
+    D : float, optional
+        Dimension of the Gaussians.
+    """
+    def __init__(self, K, D):
+        self.K = K
+        self.D = D
+        self.num_vars = (2*D + 1) * K
+
+        self.a = 1
+        self.b = 1
+        self.c = 10
+        self.alpha = tf.ones([K])
+
+    def unpack_params(self, z):
+        """Unpack parameters from a flattened vector."""
+        pi = z[0:self.K]
+        mus = z[self.K:(self.K+self.K*self.D)]
+        sigmas = z[(self.K+self.K*self.D):(self.K+2*self.K*self.D)]
+        return pi, mus, sigmas
+
+    def log_prob(self, xs, zs):
+        """Returns a vector [log p(xs, zs[1,:]), ..., log p(xs, zs[S,:])]."""
+        N = get_dims(xs)[0]
+        # Loop over each mini-batch zs[b,:]
+        log_prob = []
+        for z in tf.unpack(zs):
+            pi, mus, sigmas = self.unpack_params(z)
+            log_prior = dirichlet.logpdf(pi, self.alpha)
+            for k in xrange(self.K):
+                log_prior += norm.logpdf(mus[k*self.D], 0, np.sqrt(self.c))
+                log_prior += norm.logpdf(mus[k*self.D+1], 0, np.sqrt(self.c))
+                log_prior += invgamma.logpdf(sigmas[k*self.D], self.a, self.b)
+                log_prior += invgamma.logpdf(sigmas[k*self.D+1], self.a, self.b)
+
+            log_lik = tf.constant(0.0, dtype=tf.float32)
+            for x in tf.unpack(xs):
+                for k in xrange(self.K):
+                    log_lik += tf.log(pi[k])
+                    log_lik += multivariate_normal.logpdf(x,
+                        mus[(k*self.D):((k+1)*self.D)],
+                        sigmas[(k*self.D):((k+1)*self.D)])
+
+            log_prob += [log_prior + log_lik]
+
+        return tf.pack(log_prob)
+
+# Here we constrain parameters of the Dirichlet variational family to
+# be a scalar rather than K-dimensional.
+def mapping(x, output_dim):
+    alpha = Variable("dirichlet_alpha", [1, 1])
+    return [tf.concat(1, [tf.nn.softplus(alpha)]*output_dim)]
+
+ed.set_seed(42)
+x = np.loadtxt('data/mixture_data.txt', dtype='float32', delimiter=',')
+data = ed.Data(tf.constant(x, dtype=tf.float32))
+
+model = MixtureGaussian(K=2, D=2)
+variational = Variational()
+variational.add(Dirichlet(1, model.K))
+variational.add(Normal(model.K*model.D))
+variational.add(InvGamma(model.K*model.D))
+variational.layer()
+variational.add(mapping) # change parameterization of Dirichlet
+
+inference = ed.MFVI(model, variational, data)
+inference.run(n_iter=10000, n_minibatch=5, n_data=5)


### PR DESCRIPTION
#### Summary:

+ issues: makes progress for #7; relevant to #27

`variational.add()` enables horizontal stacking. The variational model `q(z | lambda)` is a product of distributions, and the method adds another distribution as part of this product.

This feature request adds `variational.layer()`, which enables vertical stacking. Calling `variational.layer()` declares that a new layer has been added. We can place a prior `q(lambda)` on the previous layer `q(z | lambda)`. We can also place a mapping `phi(x) = lambda` to newly parameterize the previous layer `q(z | lambda)` with functions such as inference networks.

Here is the typical variational model used in variational auto-encoders. It is a mean-field normal parameterized by a neural network.
```{Python}
variational = Variational()
variational.add(Normal(model.num_vars))
variational.layer()
variational.add(mapping)
```
`mapping` is a user-defined function which takes data `x` as input and outputs the parameters of the mean-field normal. It can be simple such as constraining the set of variational parameters to be the same value, or tie all local parameters through parameters of a neural network.

This also makes progress for refactoring `VAE` into `MFVI`.

The above interface is designed so that it is amenable to the following extensions. We can think about how to best design them later.
+ __Hierarchical variational models.__
  For now, priors are not enabled and the vertical stacking only enables parameterizations.  As a proof of concept, here is a hierarchical variational model.
```{Python}
variational = Variational()
variational.add(Dirichlet(1, model.K))
variational.add(Normal(model.K*model.D))
variational.add(InvGamma(model.K*model.D))
variational.layer()
variational.add(InvGamma(model.K)) # prior on Dirichlet's alpha
variational.add(Normal(2*model.K*model.D)) # prior on Normal's mu and sigma
variational.add(InvGamma(model.K*model.D*2)) # prior on InvGamma's alpha and beta
```
  The likelihood is a typical mean-field distribution for inferring a mixture of Gaussians.  The variational prior is over the mean-field parameters.
+ __Leverage individual distribution structures.__
  This is amenable as it preserves the internal ordering of the list.
+ __More error checking.__
  Currently we want to verify that the ordering is specified
  correctly. With vertical layers we also want to verify that the node
  it is placed over matches dimensions and also that there are no
  empty layers (e.g., user can't stop after `Variational.layer()`).
+ __Invariant to the order of horizontal layers.__
  Ordering matters. We can make this invariant to the ordering with
  variable naming.
+ __Mappings and priors over combinations of variational families.__
  This is currently restricted to stacking the specific distribution
  in the list of variational families. In general we'd like to place
  parameterizations and priors over combinations of variational
  families. This is also possible with variable naming.
+ __Mappings and priors over a subset of parameters in a variational
  family and also for variational families with multiple sets of
  parameters.__
  This is currently possible although the interface is not intuitive,
  as it requires a wrapper class over multiple variational families or the use of identity functions.
  You can see that this is needed in the mixture of Gaussians example
  as we place a prior over the mean-field Gaussian's mean and standard
  deviation (they have different support).
+ __Beyond lego blocks.__
  This currently restricts hierarchical variational
  models to stacking directly on top. Similar to Keras we can generalize this to DAGs.
+ __A graphical modeling language.__
  We can use the same construction for building a graphical
  modeling language for specifying data models.

Remarks.
+ This is opposite to Keras' behavior, where `model.add()` adds vertical
  layers, and `Merge()` composes layers horizontally. Keras is
  interested in making simple horizontal layers and composing many
  vertical layers. We're interested in composing both many horizontal
  layers and many vertical layers. Thus `Merge()` is not a good
  solution.
+ This may be confusing if we put a prior on a mapping's parameters.
  The prior is a third layer but if we think in terms of hierarchical
  models, hierarchies are according to new distributions; that is,
  parameterizations are just parameterizations and priors are what
  create the next layer. Maybe this is okay though because when
  visualizing this as a graphical model we can have a deterministic
  node as the second layer and a random node as the third layer.

#### Intended Effect:

Variational models can now be globally parameterized in order to amortize inference.

#### How to Verify:

See the new example file `examples/mixture_gaussian_mapping.py`. There's no reason why I did what I did; it's just to show we can.

#### Side Effects:

N/A

#### Documentation:

Documentation is added to `Variational()` to show how this works internally.

#### Reviewer Suggestions:

@akucukelbir
