### PR TITLE
Feature/issue 47 vectorize densities

### DIFF
--- a/edward/stats/distributions.py
+++ b/edward/stats/distributions.py
@@ -262,7 +262,7 @@ class Poisson:
         return stats.poisson.rvs(mu, size=size)
 
     def logpmf(self, x, mu):
-        x = tf.squeeze(x)
+        x = tf.cast(tf.squeeze(x), dtype=tf.float32)
         mu = tf.cast(tf.squeeze(mu), dtype=tf.float32)
         return x * tf.log(mu) - mu - log_gamma(x + 1.0)
 
@@ -307,7 +307,7 @@ invgamma = InvGamma()
 multinomial = Multinomial()
 multivariate_normal = Multivariate_Normal()
 norm = Norm()
-poisson = Poisson() # TODO unit test
+poisson = Poisson()
 t = T() # TODO unit test
 truncnorm = TruncNorm() # TODO unit test
 wishart = Wishart() # TODO unit test

--- a/edward/stats/distributions.py
+++ b/edward/stats/distributions.py
@@ -250,7 +250,7 @@ class Norm:
         loc = tf.cast(tf.squeeze(loc), dtype=tf.float32)
         scale = tf.cast(tf.squeeze(scale), dtype=tf.float32)
         z = (x - loc) / scale
-        return -0.5*tf.log(2*np.pi) - tf.log(scale) - 0.5*z*z
+        return -0.5*tf.log(2*np.pi) - tf.log(scale) - 0.5*tf.square(z)
 
     def entropy(self, loc=0, scale=1):
         """Note entropy does not depend on its mean."""

--- a/edward/stats/distributions.py
+++ b/edward/stats/distributions.py
@@ -25,12 +25,19 @@ class Distribution:
         Arguments
         ---------
         x: np.array or tf.Tensor
+            If univariate distribution, can be a scalar or vector.
+            If multivariate distribution, can be a vector or matrix.
+
         params: np.array or tf.Tensor
 
         Returns
         -------
         tf.Tensor
-            scalar
+            For univariate distributions, scalar if scalar input and
+            vector if vector input. For multivariate distributions,
+            scalar if vector input and vector if matrix input, where
+            the each element in the vector evaluates a row in the
+            matrix.
 
         Note
         ----

--- a/edward/stats/distributions.py
+++ b/edward/stats/distributions.py
@@ -290,13 +290,6 @@ class TruncNorm:
         cst = -np.log(scale) - np.log(cst)
         return cst + norm.logpdf(loc, scale)
 
-class Wishart:
-    def rvs(self, df, scale, size=1):
-        return stats.wishart.rvs(df, scale, size=size)
-
-    def logpdf(self, x, df, scale):
-        raise NotImplementedError()
-
 bernoulli = Bernoulli()
 beta = Beta()
 dirichlet = Dirichlet()
@@ -309,4 +302,3 @@ norm = Norm()
 poisson = Poisson()
 t = T()
 truncnorm = TruncNorm() # TODO unit test
-wishart = Wishart() # TODO unit test

--- a/edward/stats/distributions.py
+++ b/edward/stats/distributions.py
@@ -272,14 +272,13 @@ class T:
 
     def logpdf(self, x, df, loc=0, scale=1):
         x = tf.cast(tf.squeeze(x), dtype=tf.float32)
-        df = tf.squeeze(df)
+        df = tf.cast(tf.squeeze(df), dtype=tf.float32)
         loc = tf.cast(tf.squeeze(loc), dtype=tf.float32)
         scale = tf.cast(tf.squeeze(scale), dtype=tf.float32)
-        return 0.5 * log_gamma(df + 1.0) - \
-               log_gamma(0.5 * df) - \
-               0.5 * (np.log(np.pi) + tf.log(df)) +  tf.log(scale) - \
-               0.5 * (df + 1.0) * \
-                   tf.log(1.0 + (1.0/df) * tf.square((x-loc)/scale))
+        z = (x - loc) / scale
+        return log_gamma(0.5 * (df + 1.0)) - log_gamma(0.5 * df) - \
+               0.5 * (tf.log(np.pi) + tf.log(df)) - tf.log(scale) - \
+               0.5 * (df + 1.0) * tf.log(1.0 + (1.0/df) * tf.square(z))
 
 class TruncNorm:
     def rvs(self, a, b, loc=0, scale=1, size=1):
@@ -308,6 +307,6 @@ multinomial = Multinomial()
 multivariate_normal = Multivariate_Normal()
 norm = Norm()
 poisson = Poisson()
-t = T() # TODO unit test
+t = T()
 truncnorm = TruncNorm() # TODO unit test
 wishart = Wishart() # TODO unit test

--- a/edward/stats/distributions.py
+++ b/edward/stats/distributions.py
@@ -142,14 +142,13 @@ class Multinomial:
         x = tf.cast(tf.squeeze(x), dtype=tf.float32)
         n = tf.cast(tf.squeeze(n), dtype=tf.float32)
         p = tf.cast(tf.squeeze(p), dtype=tf.float32)
-        one = tf.constant(1.0, dtype=tf.float32)
         if len(get_dims(x)) == 1:
-            return log_gamma(n + one) - \
-                   tf.reduce_sum(log_gamma(x + one)) + \
+            return log_gamma(n + 1.0) - \
+                   tf.reduce_sum(log_gamma(x + 1.0)) + \
                    tf.reduce_sum(tf.mul(x, tf.log(p)))
         else:
-            return log_gamma(n + one) - \
-                   tf.reduce_sum(log_gamma(x + one), 1) + \
+            return log_gamma(n + 1.0) - \
+                   tf.reduce_sum(log_gamma(x + 1.0), 1) + \
                    tf.reduce_sum(tf.mul(x, tf.log(p)), 1)
 
 class Multivariate_Normal:
@@ -285,6 +284,7 @@ class TruncNorm:
         return stats.truncnorm.rvs(a, b, loc, scale, size=size)
 
     def logpdf(self, x, a, b, loc=0, scale=1):
+        # Note there is no error checking if x is outside domain.
         x = tf.cast(tf.squeeze(x), dtype=tf.float32)
         # This is slow, as we require use of stats.norm.cdf.
         sess = tf.Session()

--- a/edward/stats/distributions.py
+++ b/edward/stats/distributions.py
@@ -273,7 +273,7 @@ class Wishart:
 bernoulli = Bernoulli()
 beta = Beta()
 dirichlet = Dirichlet()
-expon = Expon() # TODO unit test
+expon = Expon()
 gamma = Gamma()
 invgamma = InvGamma()
 multinomial = Multinomial()

--- a/edward/stats/distributions.py
+++ b/edward/stats/distributions.py
@@ -136,9 +136,14 @@ class Multinomial:
         n = tf.cast(tf.squeeze(n), dtype=tf.float32)
         p = tf.cast(tf.squeeze(p), dtype=tf.float32)
         one = tf.constant(1.0, dtype=tf.float32)
-        return log_gamma(n + one) - \
-               tf.reduce_sum(log_gamma(x + one)) + \
-               tf.reduce_sum(tf.mul(x, tf.log(p)))
+        if len(get_dims(x)) == 1:
+            return log_gamma(n + one) - \
+                   tf.reduce_sum(log_gamma(x + one)) + \
+                   tf.reduce_sum(tf.mul(x, tf.log(p)))
+        else:
+            return log_gamma(n + one) - \
+                   tf.reduce_sum(log_gamma(x + one), 1) + \
+                   tf.reduce_sum(tf.mul(x, tf.log(p)), 1)
 
 class Multivariate_Normal:
     def rvs(self, mean=None, cov=1, size=1):

--- a/edward/stats/distributions.py
+++ b/edward/stats/distributions.py
@@ -73,8 +73,12 @@ class Dirichlet:
         """
         x = tf.cast(tf.squeeze(x), dtype=tf.float32)
         alpha = tf.cast(tf.squeeze(tf.convert_to_tensor(alpha)), dtype=tf.float32)
-        return -multivariate_log_beta(alpha) + \
-               tf.reduce_sum(tf.mul(alpha-1, tf.log(x)))
+        if len(get_dims(x)) == 1:
+            return -multivariate_log_beta(alpha) + \
+                   tf.reduce_sum(tf.mul(alpha-1, tf.log(x)))
+        else:
+            return -multivariate_log_beta(alpha) + \
+                   tf.reduce_sum(tf.mul(alpha-1, tf.log(x)), 1)
 
 class Expon:
     def rvs(self, scale=1, size=1):

--- a/edward/variationals.py
+++ b/edward/variationals.py
@@ -264,8 +264,7 @@ class Bernoulli(Likelihood):
         if i >= self.num_factors:
             raise IndexError()
 
-        return tf.pack([bernoulli.logpmf(z[i], self.p[i])
-                        for z in tf.unpack(zs)])
+        return bernoulli.logpmf(zs[:, i], self.p[i])
 
 class Beta(Likelihood):
     """

--- a/edward/variationals.py
+++ b/edward/variationals.py
@@ -397,8 +397,7 @@ class InvGamma(Likelihood):
         if i >= self.num_factors:
             raise IndexError()
 
-        return tf.pack([invgamma.logpdf(z[i], self.a[i], self.b[i])
-                        for z in tf.unpack(zs)])
+        return invgamma.logpdf(zs[:, i], self.a[i], self.b[i])
 
 class Multinomial(Likelihood):
     """

--- a/edward/variationals.py
+++ b/edward/variationals.py
@@ -308,8 +308,7 @@ class Beta(Likelihood):
         if i >= self.num_factors:
             raise IndexError()
 
-        return tf.pack([beta.logpdf(z[i], self.a[i], self.b[i])
-                        for z in tf.unpack(zs)])
+        return beta.logpdf(zs[:, i], self.a[i], self.b[i])
 
 class Dirichlet(Likelihood):
     """

--- a/edward/variationals.py
+++ b/edward/variationals.py
@@ -455,9 +455,8 @@ class Multinomial(Likelihood):
         if i >= self.num_factors:
             raise IndexError()
 
-        return tf.pack([multinomial.logpmf(z[(i*self.K):((i+1)*self.K)],
-                                           1, self.pi[i, :])
-                        for z in tf.unpack(zs)])
+        return multinomial.logpmf(zs[:, (i*self.K):((i+1)*self.K)],
+                                  1, self.pi[i, :])
 
 class Normal(Likelihood):
     """

--- a/edward/variationals.py
+++ b/edward/variationals.py
@@ -352,9 +352,8 @@ class Dirichlet(Likelihood):
         if i >= self.num_factors:
             raise IndexError()
 
-        return tf.pack([dirichlet.logpdf(z[(i*self.K):((i+1)*self.K)],
-                                         self.alpha[i, :])
-                        for z in tf.unpack(zs)])
+        return dirichlet.logpdf(zs[:, (i*self.K):((i+1)*self.K)],
+                                self.alpha[i, :])
 
 class InvGamma(Likelihood):
     """

--- a/edward/variationals.py
+++ b/edward/variationals.py
@@ -510,8 +510,7 @@ class Normal(Likelihood):
 
         mi = self.m[i]
         si = self.s[i]
-        return tf.pack([norm.logpdf(z[i], mi, si)
-                        for z in tf.unpack(zs)])
+        return norm.logpdf(zs[:, i], mi, si)
 
     # TODO entropy is bugged
     #def entropy(self):

--- a/tests/test_stats_bernoulli_logpmf.py
+++ b/tests/test_stats_bernoulli_logpmf.py
@@ -26,9 +26,9 @@ def test_logpdf_float_scalar():
     _test_logpdf(1.0, 0.75)
 
 def test_logpdf_int_1d():
-    _test_logpdf([0], 0.5)
-    _test_logpdf([1], 0.75)
+    _test_logpdf([0, 1, 0], 0.5)
+    _test_logpdf([1, 0, 0], 0.75)
 
 def test_logpdf_float_1d():
-    _test_logpdf([0.0], 0.5)
-    _test_logpdf([1.0], 0.75)
+    _test_logpdf([0.0, 1.0, 0.0], 0.5)
+    _test_logpdf([1.0, 0.0, 0.0], 0.75)

--- a/tests/test_stats_bernoulli_logpmf.py
+++ b/tests/test_stats_bernoulli_logpmf.py
@@ -11,24 +11,24 @@ def _assert_eq(val_ed, val_true):
     with sess.as_default():
         assert np.allclose(val_ed.eval(), val_true)
 
-def _test_logpdf(x, p):
+def _test_logpmf(x, p):
     xtf = tf.constant(x)
     val_true = stats.bernoulli.logpmf(x, p)
     _assert_eq(bernoulli.logpmf(xtf, tf.constant(p)), val_true)
     _assert_eq(bernoulli.logpmf(xtf, tf.constant([p])), val_true)
 
-def test_logpdf_int_scalar():
-    _test_logpdf(0, 0.5)
-    _test_logpdf(1, 0.75)
+def test_logpmf_int_scalar():
+    _test_logpmf(0, 0.5)
+    _test_logpmf(1, 0.75)
 
-def test_logpdf_float_scalar():
-    _test_logpdf(0.0, 0.5)
-    _test_logpdf(1.0, 0.75)
+def test_logpmf_float_scalar():
+    _test_logpmf(0.0, 0.5)
+    _test_logpmf(1.0, 0.75)
 
-def test_logpdf_int_1d():
-    _test_logpdf([0, 1, 0], 0.5)
-    _test_logpdf([1, 0, 0], 0.75)
+def test_logpmf_int_1d():
+    _test_logpmf([0, 1, 0], 0.5)
+    _test_logpmf([1, 0, 0], 0.75)
 
-def test_logpdf_float_1d():
-    _test_logpdf([0.0, 1.0, 0.0], 0.5)
-    _test_logpdf([1.0, 0.0, 0.0], 0.75)
+def test_logpmf_float_1d():
+    _test_logpmf([0.0, 1.0, 0.0], 0.5)
+    _test_logpmf([1.0, 0.0, 0.0], 0.75)

--- a/tests/test_stats_beta_logpdf.py
+++ b/tests/test_stats_beta_logpdf.py
@@ -13,7 +13,7 @@ def _assert_eq(val_ed, val_true):
         # only an approximation
         assert np.allclose(val_ed.eval(), val_true, atol=1e-4)
 
-def _test_logpdf_scalar(x, a=0.5, b=0.5):
+def _test_logpdf(x, a=0.5, b=0.5):
     xtf = tf.constant(x)
     val_true = stats.beta.logpdf(x, a, b)
     _assert_eq(beta.logpdf(xtf, tf.constant(a), tf.constant(b)), val_true)
@@ -22,23 +22,17 @@ def _test_logpdf_scalar(x, a=0.5, b=0.5):
     _assert_eq(beta.logpdf(xtf, tf.constant([a]), tf.constant([b])), val_true)
 
 def test_logpdf_scalar():
-    _test_logpdf_scalar(0.3)
-    _test_logpdf_scalar(0.7)
+    _test_logpdf(0.3)
+    _test_logpdf(0.7)
 
-    _test_logpdf_scalar(0.3, a=1.0, b=1.0)
-    _test_logpdf_scalar(0.7, a=1.0, b=1.0)
+    _test_logpdf(0.3, a=1.0, b=1.0)
+    _test_logpdf(0.7, a=1.0, b=1.0)
 
-    _test_logpdf_scalar(0.3, a=0.5, b=5.0)
-    _test_logpdf_scalar(0.7, a=0.5, b=5.0)
+    _test_logpdf(0.3, a=0.5, b=5.0)
+    _test_logpdf(0.7, a=0.5, b=5.0)
 
-    _test_logpdf_scalar(0.3, a=5.0, b=0.5)
-    _test_logpdf_scalar(0.7, a=5.0, b=0.5)
+    _test_logpdf(0.3, a=5.0, b=0.5)
+    _test_logpdf(0.7, a=5.0, b=0.5)
 
 def test_logpdf_1d():
-    x = [0.5, 0.3, 0.8, 0.1]
-    xtf = tf.constant(x)
-    val_true = stats.beta.logpdf(x, 0.5, 0.5)
-    _assert_eq(beta.logpdf(xtf, tf.constant(0.5), tf.constant(0.5)), val_true)
-    _assert_eq(beta.logpdf(xtf, tf.constant([0.5]), tf.constant(0.5)), val_true)
-    _assert_eq(beta.logpdf(xtf, tf.constant(0.5), tf.constant([0.5])), val_true)
-    _assert_eq(beta.logpdf(xtf, tf.constant([0.5]), tf.constant([0.5])), val_true)
+    _test_logpdf([0.5, 0.3, 0.8, 0.1], a=0.5, b=0.5)

--- a/tests/test_stats_beta_logpdf.py
+++ b/tests/test_stats_beta_logpdf.py
@@ -35,8 +35,8 @@ def test_logpdf_scalar():
     _test_logpdf_scalar(0.7, a=5.0, b=0.5)
 
 def test_logpdf_1d():
-    x = [0.5]
-    xtf = tf.constant([0.5])
+    x = [0.5, 0.3, 0.8, 0.1]
+    xtf = tf.constant(x)
     val_true = stats.beta.logpdf(x, 0.5, 0.5)
     _assert_eq(beta.logpdf(xtf, tf.constant(0.5), tf.constant(0.5)), val_true)
     _assert_eq(beta.logpdf(xtf, tf.constant([0.5]), tf.constant(0.5)), val_true)

--- a/tests/test_stats_dirichlet_logpdf.py
+++ b/tests/test_stats_dirichlet_logpdf.py
@@ -7,27 +7,49 @@ from scipy import stats
 
 sess = tf.Session()
 
+def dirichlet_logpdf_vec(x, alpha):
+    """Vectorized version of stats.dirichlet.logpdf."""
+    if len(x.shape) == 1:
+        return stats.dirichlet.logpdf(x, alpha)
+    else:
+        n_minibatch = x.shape[0]
+        return np.array([stats.dirichlet.logpdf(x[i, :], alpha)
+                         for i in xrange(n_minibatch)])
+
 def _assert_eq(val_ed, val_true):
     with sess.as_default():
         # NOTE: since Tensorflow has no special functions, the values here are
         # only an approximation
         assert np.allclose(val_ed.eval(), val_true, atol=1e-4)
 
-def _test_logpdf_1d(x, alpha=np.array([0.5, 0.5])):
+def _test_logpdf(x, alpha=np.array([0.5, 0.5])):
     xtf = tf.constant(x)
-    val_true = stats.dirichlet.logpdf(x, alpha)
+    val_true = dirichlet_logpdf_vec(x, alpha)
     _assert_eq(dirichlet.logpdf(xtf, alpha), val_true)
     _assert_eq(dirichlet.logpdf(xtf, tf.convert_to_tensor(alpha)), val_true)
 
 def test_logpdf_1d():
-    _test_logpdf_1d(np.array([0.3, 0.7]))
-    _test_logpdf_1d(np.array([0.2, 0.8]))
+    _test_logpdf(np.array([0.3, 0.7]))
+    _test_logpdf(np.array([0.2, 0.8]))
 
-    _test_logpdf_1d(np.array([0.3, 0.7]), alpha=np.array([1.0, 1.0]))
-    _test_logpdf_1d(np.array([0.2, 0.8]), alpha=np.array([1.0, 1.0]))
+    _test_logpdf(np.array([0.3, 0.7]), alpha=np.array([1.0, 1.0]))
+    _test_logpdf(np.array([0.2, 0.8]), alpha=np.array([1.0, 1.0]))
 
-    _test_logpdf_1d(np.array([0.3, 0.7]), alpha=np.array([0.5, 5.0]))
-    _test_logpdf_1d(np.array([0.2, 0.8]), alpha=np.array([0.5, 5.0]))
+    _test_logpdf(np.array([0.3, 0.7]), alpha=np.array([0.5, 5.0]))
+    _test_logpdf(np.array([0.2, 0.8]), alpha=np.array([0.5, 5.0]))
 
-    _test_logpdf_1d(np.array([0.3, 0.7]), alpha=np.array([5.0, 0.5]))
-    _test_logpdf_1d(np.array([0.2, 0.8]), alpha=np.array([5.0, 0.5]))
+    _test_logpdf(np.array([0.3, 0.7]), alpha=np.array([5.0, 0.5]))
+    _test_logpdf(np.array([0.2, 0.8]), alpha=np.array([5.0, 0.5]))
+
+def test_logpdf_2d():
+    _test_logpdf(np.array([[0.3, 0.7],[0.2, 0.8]]))
+    _test_logpdf(np.array([[0.2, 0.8],[0.3, 0.7]]))
+
+    _test_logpdf(np.array([[0.3, 0.7],[0.2, 0.8]]), alpha=np.array([1.0, 1.0]))
+    _test_logpdf(np.array([[0.2, 0.8],[0.3, 0.7]]), alpha=np.array([1.0, 1.0]))
+
+    _test_logpdf(np.array([[0.3, 0.7],[0.2, 0.8]]), alpha=np.array([0.5, 5.0]))
+    _test_logpdf(np.array([[0.2, 0.8],[0.3, 0.7]]), alpha=np.array([0.5, 5.0]))
+
+    _test_logpdf(np.array([[0.3, 0.7],[0.2, 0.8]]), alpha=np.array([5.0, 0.5]))
+    _test_logpdf(np.array([[0.2, 0.8],[0.3, 0.7]]), alpha=np.array([5.0, 0.5]))

--- a/tests/test_stats_expon_logpdf.py
+++ b/tests/test_stats_expon_logpdf.py
@@ -1,0 +1,34 @@
+from __future__ import print_function
+import numpy as np
+import tensorflow as tf
+
+from edward.stats import expon
+from scipy import stats
+
+sess = tf.Session()
+
+def _assert_eq(val_ed, val_true):
+    with sess.as_default():
+        assert np.allclose(val_ed.eval(), val_true)
+
+def _test_logpdf(x, scale=0.5):
+    xtf = tf.constant(x)
+    val_true = stats.expon.logpdf(x, scale=scale)
+    _assert_eq(expon.logpdf(xtf, scale=tf.constant(scale)), val_true)
+    _assert_eq(expon.logpdf(xtf, scale=tf.constant([scale])), val_true)
+
+def test_logpdf_scalar():
+    _test_logpdf(0.3)
+    _test_logpdf(0.7)
+
+    _test_logpdf(0.3, scale=1.0)
+    _test_logpdf(0.7, scale=1.0)
+
+    _test_logpdf(0.3, scale=0.5)
+    _test_logpdf(0.7, scale=0.5)
+
+    _test_logpdf(0.3, scale=5.0)
+    _test_logpdf(0.7, scale=5.0)
+
+def test_logpdf_1d():
+    _test_logpdf([0.5, 2.3, 5.8, 10.1], scale=5.0)

--- a/tests/test_stats_gamma_logpdf.py
+++ b/tests/test_stats_gamma_logpdf.py
@@ -13,7 +13,7 @@ def _assert_eq(val_ed, val_true):
         # only an approximation
         assert np.allclose(val_ed.eval(), val_true, atol=1e-4)
 
-def _test_logpdf_scalar(x, a=0.5, b=0.5):
+def _test_logpdf(x, a=0.5, b=0.5):
     xtf = tf.constant(x)
     val_true = stats.gamma.logpdf(x, a, scale=b)
     _assert_eq(gamma.logpdf(xtf, tf.constant(a), tf.constant(b)), val_true)
@@ -22,23 +22,17 @@ def _test_logpdf_scalar(x, a=0.5, b=0.5):
     _assert_eq(gamma.logpdf(xtf, tf.constant([a]), tf.constant([b])), val_true)
 
 def test_logpdf_scalar():
-    _test_logpdf_scalar(0.3)
-    _test_logpdf_scalar(0.7)
+    _test_logpdf(0.3)
+    _test_logpdf(0.7)
 
-    _test_logpdf_scalar(0.3, a=1.0, b=1.0)
-    _test_logpdf_scalar(0.7, a=1.0, b=1.0)
+    _test_logpdf(0.3, a=1.0, b=1.0)
+    _test_logpdf(0.7, a=1.0, b=1.0)
 
-    _test_logpdf_scalar(0.3, a=0.5, b=5.0)
-    _test_logpdf_scalar(0.7, a=0.5, b=5.0)
+    _test_logpdf(0.3, a=0.5, b=5.0)
+    _test_logpdf(0.7, a=0.5, b=5.0)
 
-    _test_logpdf_scalar(0.3, a=5.0, b=0.5)
-    _test_logpdf_scalar(0.7, a=5.0, b=0.5)
+    _test_logpdf(0.3, a=5.0, b=0.5)
+    _test_logpdf(0.7, a=5.0, b=0.5)
 
 def test_logpdf_1d():
-    x = [0.5]
-    xtf = tf.constant([0.5])
-    val_true = stats.gamma.logpdf(x, 0.5, scale=0.5)
-    _assert_eq(gamma.logpdf(xtf, tf.constant(0.5), tf.constant(0.5)), val_true)
-    _assert_eq(gamma.logpdf(xtf, tf.constant([0.5]), tf.constant(0.5)), val_true)
-    _assert_eq(gamma.logpdf(xtf, tf.constant(0.5), tf.constant([0.5])), val_true)
-    _assert_eq(gamma.logpdf(xtf, tf.constant([0.5]), tf.constant([0.5])), val_true)
+    _test_logpdf([0.5, 1.2, 5.3, 8.7], a=0.5, b=0.5)

--- a/tests/test_stats_invgamma_logpdf.py
+++ b/tests/test_stats_invgamma_logpdf.py
@@ -13,32 +13,26 @@ def _assert_eq(val_ed, val_true):
         # only an approximation
         assert np.allclose(val_ed.eval(), val_true, atol=1e-4)
 
-def _test_logpdf_scalar(x, a=0.5, b=0.5):
+def _test_logpdf(x, a=0.5, scale=0.5):
     xtf = tf.constant(x)
-    val_true = stats.invgamma.logpdf(x, a, scale=b)
-    _assert_eq(invgamma.logpdf(xtf, tf.constant(a), tf.constant(b)), val_true)
-    _assert_eq(invgamma.logpdf(xtf, tf.constant([a]), tf.constant(b)), val_true)
-    _assert_eq(invgamma.logpdf(xtf, tf.constant(a), tf.constant([b])), val_true)
-    _assert_eq(invgamma.logpdf(xtf, tf.constant([a]), tf.constant([b])), val_true)
+    val_true = stats.invgamma.logpdf(x, a, scale=scale)
+    _assert_eq(invgamma.logpdf(xtf, tf.constant(a), tf.constant(scale)), val_true)
+    _assert_eq(invgamma.logpdf(xtf, tf.constant([a]), tf.constant(scale)), val_true)
+    _assert_eq(invgamma.logpdf(xtf, tf.constant(a), tf.constant([scale])), val_true)
+    _assert_eq(invgamma.logpdf(xtf, tf.constant([a]), tf.constant([scale])), val_true)
 
 def test_logpdf_scalar():
-    _test_logpdf_scalar(0.3)
-    _test_logpdf_scalar(0.7)
+    _test_logpdf(0.3)
+    _test_logpdf(0.7)
 
-    _test_logpdf_scalar(0.3, a=1.0, b=1.0)
-    _test_logpdf_scalar(0.7, a=1.0, b=1.0)
+    _test_logpdf(0.3, a=1.0, scale=1.0)
+    _test_logpdf(0.7, a=1.0, scale=1.0)
 
-    _test_logpdf_scalar(0.3, a=0.5, b=5.0)
-    _test_logpdf_scalar(0.7, a=0.5, b=5.0)
+    _test_logpdf(0.3, a=0.5, scale=5.0)
+    _test_logpdf(0.7, a=0.5, scale=5.0)
 
-    _test_logpdf_scalar(0.3, a=5.0, b=0.5)
-    _test_logpdf_scalar(0.7, a=5.0, b=0.5)
+    _test_logpdf(0.3, a=5.0, scale=0.5)
+    _test_logpdf(0.7, a=5.0, scale=0.5)
 
 def test_logpdf_1d():
-    x = [0.5]
-    xtf = tf.constant([0.5])
-    val_true = stats.invgamma.logpdf(x, 0.5, scale=0.5)
-    _assert_eq(invgamma.logpdf(xtf, tf.constant(0.5), tf.constant(0.5)), val_true)
-    _assert_eq(invgamma.logpdf(xtf, tf.constant([0.5]), tf.constant(0.5)), val_true)
-    _assert_eq(invgamma.logpdf(xtf, tf.constant(0.5), tf.constant([0.5])), val_true)
-    _assert_eq(invgamma.logpdf(xtf, tf.constant([0.5]), tf.constant([0.5])), val_true)
+    _test_logpdf([0.5, 1.2, 5.3, 8.7], a=0.5, scale=0.5)

--- a/tests/test_stats_multinomial_logpmf.py
+++ b/tests/test_stats_multinomial_logpmf.py
@@ -23,6 +23,14 @@ def multinomial_logpmf(x, n, p):
            np.sum(gammaln(x + 1.0)) + \
            np.sum(x * np.log(p))
 
+def multinomial_logpmf_vec(x, n, p):
+    if len(x.shape) == 1:
+        return multinomial_logpmf(x, n, p)
+    else:
+        n_minibatch = x.shape[0]
+        return np.array([multinomial_logpmf(x[i, :], n, p)
+                         for i in xrange(n_minibatch)])
+
 def _assert_eq(val_ed, val_true):
     with sess.as_default():
         # NOTE: since Tensorflow has no special functions, the values here are
@@ -31,7 +39,7 @@ def _assert_eq(val_ed, val_true):
 
 def _test_logpdf(x, n, p):
     xtf = tf.constant(x)
-    val_true = multinomial_logpmf(x, n, p)
+    val_true = multinomial_logpmf_vec(x, n, p)
     _assert_eq(multinomial.logpmf(xtf, n, p),
                val_true)
     _assert_eq(multinomial.logpmf(xtf, n, tf.constant(p, dtype=tf.float32)),
@@ -48,3 +56,11 @@ def test_logpdf_int_1d():
 def test_logpdf_float_1d():
     _test_logpdf(np.array([0.0, 1.0]), 1, np.array([0.5, 0.5]))
     _test_logpdf(np.array([1.0, 0.0]), 1, np.array([0.75, 0.25]))
+
+def test_logpdf_int_2d():
+    _test_logpdf(np.array([[0, 1],[1, 0]]), 1, np.array([0.5, 0.5]))
+    _test_logpdf(np.array([[1, 0],[0, 1]]), 1, np.array([0.75, 0.25]))
+
+def test_logpdf_float_2d():
+    _test_logpdf(np.array([[0.0, 1.0],[1.0, 0.0]]), 1, np.array([0.5, 0.5]))
+    _test_logpdf(np.array([[1.0, 0.0],[0.0, 1.0]]), 1, np.array([0.75, 0.25]))

--- a/tests/test_stats_multinomial_logpmf.py
+++ b/tests/test_stats_multinomial_logpmf.py
@@ -37,7 +37,7 @@ def _assert_eq(val_ed, val_true):
         # only an approximation
         assert np.allclose(val_ed.eval(), val_true, atol=1e-4)
 
-def _test_logpdf(x, n, p):
+def _test_logpmf(x, n, p):
     xtf = tf.constant(x)
     val_true = multinomial_logpmf_vec(x, n, p)
     _assert_eq(multinomial.logpmf(xtf, n, p),
@@ -49,18 +49,18 @@ def _test_logpdf(x, n, p):
     _assert_eq(multinomial.logpmf(xtf, n, tf.constant(p, dtype=tf.float32)),
                val_true)
 
-def test_logpdf_int_1d():
-    _test_logpdf(np.array([0, 1]), 1, np.array([0.5, 0.5]))
-    _test_logpdf(np.array([1, 0]), 1, np.array([0.75, 0.25]))
+def test_logpmf_int_1d():
+    _test_logpmf(np.array([0, 1]), 1, np.array([0.5, 0.5]))
+    _test_logpmf(np.array([1, 0]), 1, np.array([0.75, 0.25]))
 
-def test_logpdf_float_1d():
-    _test_logpdf(np.array([0.0, 1.0]), 1, np.array([0.5, 0.5]))
-    _test_logpdf(np.array([1.0, 0.0]), 1, np.array([0.75, 0.25]))
+def test_logpmf_float_1d():
+    _test_logpmf(np.array([0.0, 1.0]), 1, np.array([0.5, 0.5]))
+    _test_logpmf(np.array([1.0, 0.0]), 1, np.array([0.75, 0.25]))
 
-def test_logpdf_int_2d():
-    _test_logpdf(np.array([[0, 1],[1, 0]]), 1, np.array([0.5, 0.5]))
-    _test_logpdf(np.array([[1, 0],[0, 1]]), 1, np.array([0.75, 0.25]))
+def test_logpmf_int_2d():
+    _test_logpmf(np.array([[0, 1],[1, 0]]), 1, np.array([0.5, 0.5]))
+    _test_logpmf(np.array([[1, 0],[0, 1]]), 1, np.array([0.75, 0.25]))
 
-def test_logpdf_float_2d():
-    _test_logpdf(np.array([[0.0, 1.0],[1.0, 0.0]]), 1, np.array([0.5, 0.5]))
-    _test_logpdf(np.array([[1.0, 0.0],[0.0, 1.0]]), 1, np.array([0.75, 0.25]))
+def test_logpmf_float_2d():
+    _test_logpmf(np.array([[0.0, 1.0],[1.0, 0.0]]), 1, np.array([0.5, 0.5]))
+    _test_logpmf(np.array([[1.0, 0.0],[0.0, 1.0]]), 1, np.array([0.75, 0.25]))

--- a/tests/test_stats_multivariate_normal_logpdf.py
+++ b/tests/test_stats_multivariate_normal_logpdf.py
@@ -11,29 +11,42 @@ def _assert_eq(val_ed, val_true):
     with sess.as_default():
         assert np.allclose(val_ed.eval(), val_true)
 
-def _test_logpdf_standard_2d(x):
+def _test_logpdf(x, mean, cov):
+    xtf = tf.constant(x)
+    mean_tf = tf.convert_to_tensor(mean)
+    cov_tf = tf.convert_to_tensor(cov)
+    val_true = stats.multivariate_normal.logpdf(x, mean, cov)
+    _assert_eq(multivariate_normal.logpdf(xtf, mean, cov), val_true)
+    _assert_eq(multivariate_normal.logpdf(xtf, mean_tf, cov), val_true)
+    _assert_eq(multivariate_normal.logpdf(xtf, mean, cov_tf), val_true)
+    _assert_eq(multivariate_normal.logpdf(xtf, mean_tf, cov_tf), val_true)
+
+def test_logpdf_int_1d():
+    x = [0, 0]
+    _test_logpdf(x, np.zeros([2]), np.ones([2]))
+    _test_logpdf(x, np.zeros(2), np.diag(np.ones(2)))
     xtf = tf.constant(x)
     val_true = stats.multivariate_normal.logpdf(x, np.zeros(2), np.diag(np.ones(2)))
     _assert_eq(multivariate_normal.logpdf(xtf), val_true)
-    _assert_eq(multivariate_normal.logpdf(xtf, np.zeros([2]), np.ones([2])),
-               val_true)
-    _assert_eq(multivariate_normal.logpdf(xtf, tf.zeros([2]), tf.ones([2])),
-               val_true)
-    _assert_eq(
-        multivariate_normal.logpdf(xtf, np.zeros([2]), np.diag(np.ones([2]))),
-        val_true)
 
-def test_logpdf_standard_float_2d():
-    _test_logpdf_standard_2d([0.0, 0.0])
+    _test_logpdf(x, np.zeros(2), np.array([[2.0, 0.5], [0.5, 1.0]]))
 
-def test_logpdf_standard_int_2d():
-    _test_logpdf_standard_2d([0, 0])
+def test_logpdf_float_1d():
+    x = [0.0, 0.0]
+    _test_logpdf(x, np.zeros([2]), np.ones([2]))
+    _test_logpdf(x, np.zeros(2), np.diag(np.ones(2)))
+    xtf = tf.constant(x)
+    val_true = stats.multivariate_normal.logpdf(x, np.zeros(2), np.diag(np.ones(2)))
+    _assert_eq(multivariate_normal.logpdf(xtf), val_true)
 
-def test_logpdf_cov_float_2d():
-    x = np.zeros(2)
-    xtf = tf.constant([0.0, 0.0])
-    val_true = stats.multivariate_normal.logpdf(
-        x, np.zeros(2), np.array([[2.0, 0.5], [0.5, 1.0]]))
-    _assert_eq(multivariate_normal.logpdf(
-        xtf, tf.zeros([2]), tf.constant([[2.0, 0.5], [0.5, 1.0]])),
-        val_true)
+    _test_logpdf(x, np.zeros(2), np.array([[2.0, 0.5], [0.5, 1.0]]))
+
+def test_logpdf_float_2d():
+    x = np.array([[0.3, 0.7],[0.2, 0.8]])
+    _test_logpdf(x, np.zeros([2]), np.ones([2]))
+    _test_logpdf(x, np.zeros(2), np.diag(np.ones(2)))
+    xtf = tf.constant(x)
+    val_true = stats.multivariate_normal.logpdf(x, np.zeros(2), np.diag(np.ones(2)))
+    _assert_eq(multivariate_normal.logpdf(xtf), val_true)
+
+    _test_logpdf(x, np.zeros(2), np.array([[2.0, 0.5], [0.5, 1.0]]))

--- a/tests/test_stats_norm_logpdf.py
+++ b/tests/test_stats_norm_logpdf.py
@@ -9,8 +9,6 @@ sess = tf.Session()
 
 def _assert_eq(val_ed, val_true):
     with sess.as_default():
-        print(val_ed.eval())
-        print(val_true)
         assert np.allclose(val_ed.eval(), val_true)
 
 def _test_logpdf(x, loc=0, scale=1):

--- a/tests/test_stats_norm_logpdf.py
+++ b/tests/test_stats_norm_logpdf.py
@@ -9,35 +9,22 @@ sess = tf.Session()
 
 def _assert_eq(val_ed, val_true):
     with sess.as_default():
+        print(val_ed.eval())
+        print(val_true)
         assert np.allclose(val_ed.eval(), val_true)
 
-def _test_logpdf_scalar(x):
+def _test_logpdf(x, loc=0, scale=1):
     xtf = tf.constant(x)
-    val_true = stats.norm.logpdf(x)
-    _assert_eq(norm.logpdf(xtf), val_true)
-    _assert_eq(norm.logpdf(xtf, tf.zeros([1]), tf.constant(1.0)), val_true)
-    _assert_eq(norm.logpdf(xtf, tf.zeros([1]), tf.ones([1])), val_true)
-    _assert_eq(norm.logpdf(xtf, tf.zeros([1]), tf.diag(tf.ones([1]))), val_true)
+    val_true = stats.norm.logpdf(x, loc, scale)
+    _assert_eq(norm.logpdf(xtf, loc, scale), val_true)
+    _assert_eq(norm.logpdf(xtf, tf.constant(loc), tf.constant(scale)), val_true)
+    _assert_eq(norm.logpdf(xtf, tf.constant([loc]), tf.constant(scale)), val_true)
+    _assert_eq(norm.logpdf(xtf, tf.constant(loc), tf.constant([scale])), val_true)
+    _assert_eq(norm.logpdf(xtf, tf.constant([loc]), tf.constant([scale])), val_true)
 
 def test_logpdf_scalar():
-    _test_logpdf_scalar(0.0)
-    _test_logpdf_scalar(0.623)
+    _test_logpdf(0.0)
+    _test_logpdf(0.623)
 
 def test_logpdf_1d():
-    x = [0.0]
-    xtf = tf.constant([0.0])
-    val_true = stats.norm.logpdf(x)
-    _assert_eq(norm.logpdf(xtf), val_true)
-    _assert_eq(norm.logpdf(xtf, tf.constant(0.0), tf.constant(1.0)), val_true)
-    _assert_eq(norm.logpdf(xtf, tf.constant([0.0]), tf.constant(1.0)), val_true)
-    _assert_eq(norm.logpdf(xtf, tf.constant([0.0]), tf.constant([1.0])), val_true)
-
-def test_logpdf_1by1mat():
-    x = [[0.0]]
-    xtf = tf.constant([[0.0]])
-    val_true = stats.norm.logpdf(x)
-    _assert_eq(norm.logpdf(xtf), val_true)
-    _assert_eq(norm.logpdf(xtf, tf.constant(0.0), tf.constant(1.0)), val_true)
-    _assert_eq(norm.logpdf(xtf, tf.constant([0.0]), tf.constant(1.0)), val_true)
-    _assert_eq(norm.logpdf(xtf, tf.constant(0.0), tf.constant([1.0])), val_true)
-    _assert_eq(norm.logpdf(xtf, tf.constant([0.0]), tf.constant([1.0])), val_true)
+    _test_logpdf([0.0, 1.0, 0.58, 2.3])

--- a/tests/test_stats_poisson_logpmf.py
+++ b/tests/test_stats_poisson_logpmf.py
@@ -13,25 +13,25 @@ def _assert_eq(val_ed, val_true):
         # only an approximation
         assert np.allclose(val_ed.eval(), val_true, atol=1e-4)
 
-def _test_logpdf(x, mu):
+def _test_logpmf(x, mu):
     xtf = tf.constant(x)
     val_true = stats.poisson.logpmf(x, mu)
     _assert_eq(poisson.logpmf(xtf, mu), val_true)
     _assert_eq(poisson.logpmf(xtf, tf.constant(mu)), val_true)
     _assert_eq(poisson.logpmf(xtf, tf.constant([mu])), val_true)
 
-def test_logpdf_int_scalar():
-    _test_logpdf(0, 0.5)
-    _test_logpdf(1, 0.75)
+def test_logpmf_int_scalar():
+    _test_logpmf(0, 0.5)
+    _test_logpmf(1, 0.75)
 
-def test_logpdf_float_scalar():
-    _test_logpdf(0.0, 0.5)
-    _test_logpdf(1.0, 0.75)
+def test_logpmf_float_scalar():
+    _test_logpmf(0.0, 0.5)
+    _test_logpmf(1.0, 0.75)
 
-def test_logpdf_int_1d():
-    _test_logpdf([0, 1, 3], 0.5)
-    _test_logpdf([1, 8, 2], 0.75)
+def test_logpmf_int_1d():
+    _test_logpmf([0, 1, 3], 0.5)
+    _test_logpmf([1, 8, 2], 0.75)
 
-def test_logpdf_float_1d():
-    _test_logpdf([0.0, 1.0, 3.0], 0.5)
-    _test_logpdf([1.0, 8.0, 2.0], 0.75)
+def test_logpmf_float_1d():
+    _test_logpmf([0.0, 1.0, 3.0], 0.5)
+    _test_logpmf([1.0, 8.0, 2.0], 0.75)

--- a/tests/test_stats_poisson_logpmf.py
+++ b/tests/test_stats_poisson_logpmf.py
@@ -1,0 +1,37 @@
+from __future__ import print_function
+import numpy as np
+import tensorflow as tf
+
+from edward.stats import poisson
+from scipy import stats
+
+sess = tf.Session()
+
+def _assert_eq(val_ed, val_true):
+    with sess.as_default():
+        # NOTE: since Tensorflow has no special functions, the values here are
+        # only an approximation
+        assert np.allclose(val_ed.eval(), val_true, atol=1e-4)
+
+def _test_logpdf(x, mu):
+    xtf = tf.constant(x)
+    val_true = stats.poisson.logpmf(x, mu)
+    _assert_eq(poisson.logpmf(xtf, mu), val_true)
+    _assert_eq(poisson.logpmf(xtf, tf.constant(mu)), val_true)
+    _assert_eq(poisson.logpmf(xtf, tf.constant([mu])), val_true)
+
+def test_logpdf_int_scalar():
+    _test_logpdf(0, 0.5)
+    _test_logpdf(1, 0.75)
+
+def test_logpdf_float_scalar():
+    _test_logpdf(0.0, 0.5)
+    _test_logpdf(1.0, 0.75)
+
+def test_logpdf_int_1d():
+    _test_logpdf([0, 1, 3], 0.5)
+    _test_logpdf([1, 8, 2], 0.75)
+
+def test_logpdf_float_1d():
+    _test_logpdf([0.0, 1.0, 3.0], 0.5)
+    _test_logpdf([1.0, 8.0, 2.0], 0.75)

--- a/tests/test_stats_t_logpdf.py
+++ b/tests/test_stats_t_logpdf.py
@@ -1,0 +1,30 @@
+from __future__ import print_function
+import numpy as np
+import tensorflow as tf
+
+from edward.stats import t
+from scipy import stats
+
+sess = tf.Session()
+
+def _assert_eq(val_ed, val_true):
+    with sess.as_default():
+        # NOTE: since Tensorflow has no special functions, the values here are
+        # only an approximation
+        assert np.allclose(val_ed.eval(), val_true, atol=1e-4)
+
+def _test_logpdf(x, df, loc=0, scale=1):
+    xtf = tf.constant(x)
+    val_true = stats.t.logpdf(x, df, loc, scale)
+    _assert_eq(t.logpdf(xtf, df, loc, scale), val_true)
+    _assert_eq(t.logpdf(xtf, df, tf.constant(loc), tf.constant(scale)), val_true)
+    _assert_eq(t.logpdf(xtf, df, tf.constant([loc]), tf.constant(scale)), val_true)
+    _assert_eq(t.logpdf(xtf, df, tf.constant(loc), tf.constant([scale])), val_true)
+    _assert_eq(t.logpdf(xtf, df, tf.constant([loc]), tf.constant([scale])), val_true)
+
+def test_logpdf_scalar():
+    _test_logpdf(0.0, df=3)
+    _test_logpdf(0.623, df=3)
+
+def test_logpdf_1d():
+    _test_logpdf([0.0, 1.0, 0.58, 2.3], df=3)

--- a/tests/test_stats_truncnorm_logpdf.py
+++ b/tests/test_stats_truncnorm_logpdf.py
@@ -1,0 +1,28 @@
+from __future__ import print_function
+import numpy as np
+import tensorflow as tf
+
+from edward.stats import truncnorm
+from scipy import stats
+
+sess = tf.Session()
+
+def _assert_eq(val_ed, val_true):
+    with sess.as_default():
+        assert np.allclose(val_ed.eval(), val_true)
+
+def _test_logpdf(x, a, b, loc=0, scale=1):
+    xtf = tf.constant(x)
+    val_true = stats.truncnorm.logpdf(x, a, b, loc, scale)
+    _assert_eq(truncnorm.logpdf(xtf, a, b, loc, scale), val_true)
+    _assert_eq(truncnorm.logpdf(xtf, a, b, tf.constant(loc), tf.constant(scale)), val_true)
+    _assert_eq(truncnorm.logpdf(xtf, a, b, tf.constant([loc]), tf.constant(scale)), val_true)
+    _assert_eq(truncnorm.logpdf(xtf, a, b, tf.constant(loc), tf.constant([scale])), val_true)
+    _assert_eq(truncnorm.logpdf(xtf, a, b, tf.constant([loc]), tf.constant([scale])), val_true)
+
+def test_logpdf_scalar():
+    _test_logpdf(0.0, a=-1.0, b=3.0)
+    _test_logpdf(0.623, a=-1.0, b=3.0)
+
+def test_logpdf_1d():
+    _test_logpdf([0.0, 1.0, 0.58, 2.3], a=-1.0, b=3.0)

--- a/tests/test_variationals_multinomial.py
+++ b/tests/test_variationals_multinomial.py
@@ -27,8 +27,8 @@ def multinomial_logpmf(x, n, p):
 
 def multinomial_logpmf_vec(x, n, p):
     n_minibatch = x.shape[0]
-    out = np.zeros(n_minibatch)
-    return np.array([multinomial_logpmf(x[i,:], n, p) for i in xrange(n_minibatch)])
+    return np.array([multinomial_logpmf(x[i, :], n, p)
+                     for i in xrange(n_minibatch)])
 
 def _test_log_prob_zi(n_minibatch, num_factors, K):
     multinomial = Multinomial(num_factors, K)


### PR DESCRIPTION
#### Summary:

Issues: solves #47; makes progress for #46, #73

This vectorizes all currently implemented distributions. It also speeds up calls to `variational.log_prob_zi`, as all currently implemented variational distributions now use a vector (or matrix) of inputs instead of unpacking, looping over calls to individual inputs, and re-packing. This will also let us speed up current model examples.

#### Intended Effect:

Log densities can now be called with vectorized inputs (matrix inputs if the density is multivariate).

#### How to Verify:

See unit tests.

#### Side Effects:

N/A

#### Documentation:

See doc in the `Distributions` class.

#### Reviewer Suggestions: 

N/A