### PR TITLE
simplify plotting model examples

### DIFF
--- a/examples/bayesian_linear_regression_plot.py
+++ b/examples/bayesian_linear_regression_plot.py
@@ -11,6 +11,7 @@ Variational model
 """
 import edward as ed
 import tensorflow as tf
+import matplotlib.pyplot as plt
 import numpy as np
 
 from edward.models import Variational, Normal
@@ -74,5 +75,38 @@ variational = Variational()
 variational.add(Normal(model.num_vars))
 data = build_toy_dataset()
 
+# Set up figure
+fig = plt.figure(figsize=(8,8), facecolor='white')
+ax = fig.add_subplot(111, frameon=False)
+plt.ion()
+plt.show(block=False)
+
 inference = ed.MFVI(model, variational, data)
-inference.run(n_iter=250, n_minibatch=5, n_print=10)
+sess = inference.initialize(n_minibatch=5, n_print=5)
+for t in range(5000):
+    loss = inference.update(sess)
+    if t % inference.n_print == 0:
+        print("iter {:d} loss {:.2f}".format(t, np.mean(loss)))
+
+        # Sample functions from variational model
+        mean, std = sess.run([variational.layers[0].m,
+                              variational.layers[0].s])
+        rs = np.random.RandomState(0)
+        zs = rs.randn(10, variational.num_vars) * std + mean
+        zs = tf.constant(zs, dtype=tf.float32)
+        inputs = np.linspace(-8, 8, num=400, dtype=np.float32)
+        x = tf.expand_dims(tf.constant(inputs), 1)
+        W = tf.expand_dims(zs[:, 0], 0)
+        b = zs[:, 1]
+        mus = tf.matmul(x, W) + b
+        outputs = sess.run(mus)
+
+        # Get data
+        y, x = sess.run([data.data[:, 0], data.data[:, 1]])
+
+        # Plot data and functions
+        plt.cla()
+        ax.plot(x, y, 'bx')
+        ax.plot(inputs, outputs)
+        ax.set_ylim([-2, 3])
+        plt.draw()

--- a/examples/bayesian_linear_regression_plot.py
+++ b/examples/bayesian_linear_regression_plot.py
@@ -83,7 +83,7 @@ plt.show(block=False)
 
 inference = ed.MFVI(model, variational, data)
 sess = inference.initialize(n_minibatch=5, n_print=5)
-for t in range(5000):
+for t in range(250):
     loss = inference.update(sess)
     if t % inference.n_print == 0:
         print("iter {:d} loss {:.2f}".format(t, np.mean(loss)))

--- a/examples/bayesian_nn.py
+++ b/examples/bayesian_nn.py
@@ -126,23 +126,26 @@ ax = fig.add_subplot(111, frameon=False)
 plt.ion()
 plt.show(block=False)
 
-def print_progress(self, t, losses, sess):
-    if t % self.n_print == 0:
-        print("iter %d loss %.2f " % (t, np.mean(losses)))
+inference = ed.MFVI(model, variational, data)
+sess = inference.initialize(n_print=10)
+for t in range(1000):
+    loss = inference.update(sess)
+    if t % inference.n_print == 0:
+        print("iter {:d} loss {:.2f}".format(t, np.mean(loss)))
 
         # Sample functions from variational model
-        mean, std = sess.run([self.variational.layers[0].m,
-                              self.variational.layers[0].s])
+        mean, std = sess.run([variational.layers[0].m,
+                              variational.layers[0].s])
         rs = np.random.RandomState(0)
-        zs = rs.randn(10, self.variational.num_vars) * std + mean
+        zs = rs.randn(10, variational.num_vars) * std + mean
         zs = tf.constant(zs, dtype=tf.float32)
         inputs = np.linspace(-8, 8, num=400, dtype=np.float32)
         x = tf.expand_dims(tf.constant(inputs), 1)
-        mus = tf.pack([self.model.mapping(x, z) for z in tf.unpack(zs)])
+        mus = tf.pack([model.mapping(x, z) for z in tf.unpack(zs)])
         outputs = sess.run(mus)
 
         # Get data
-        y, x = sess.run([self.data.data[:, 0], self.data.data[:, 1]])
+        y, x = sess.run([data.data[:, 0], data.data[:, 1]])
 
         # Plot data and functions
         plt.cla()
@@ -151,7 +154,3 @@ def print_progress(self, t, losses, sess):
         ax.set_xlim([-8, 8])
         ax.set_ylim([-2, 3])
         plt.draw()
-
-ed.MFVI.print_progress = print_progress
-inference = ed.MFVI(model, variational, data)
-inference.run(n_iter=1000, n_print=10)

--- a/examples/hierarchical_logistic_regression.py
+++ b/examples/hierarchical_logistic_regression.py
@@ -98,24 +98,28 @@ ax = fig.add_subplot(111, frameon=False)
 plt.ion()
 plt.show(block=False)
 
-def print_progress(self, t, losses, sess):
-    if t % self.n_print == 0:
-        print("iter %d loss %.2f " % (t, np.mean(losses)))
-        self.variational.print_params(sess)
+inference = ed.MFVI(model, variational, data)
+sess = inference.initialize(n_print=5)
+# TODO it gets NaN's at iteration 608 and beyond
+for t in range(600):
+    loss = inference.update(sess)
+    if t % inference.n_print == 0:
+        print("iter {:d} loss {:.2f}".format(t, np.mean(loss)))
+        variational.print_params(sess)
 
         # Sample functions from variational model
-        mean, std = sess.run([self.variational.layers[0].m,
-                              self.variational.layers[0].s])
+        mean, std = sess.run([variational.layers[0].m,
+                              variational.layers[0].s])
         rs = np.random.RandomState(0)
-        zs = rs.randn(10, self.variational.num_vars) * std + mean
+        zs = rs.randn(10, variational.num_vars) * std + mean
         zs = tf.constant(zs, dtype=tf.float32)
         inputs = np.linspace(-3, 3, num=400, dtype=np.float32)
         x = tf.expand_dims(tf.constant(inputs), 1)
-        mus = tf.pack([self.model.mapping(x, z) for z in tf.unpack(zs)])
+        mus = tf.pack([model.mapping(x, z) for z in tf.unpack(zs)])
         outputs = sess.run(mus)
 
         # Get data
-        y, x = sess.run([self.data.data[:, 0], self.data.data[:, 1]])
+        y, x = sess.run([data.data[:, 0], data.data[:, 1]])
 
         # Plot data and functions
         plt.cla()
@@ -124,8 +128,3 @@ def print_progress(self, t, losses, sess):
         ax.set_xlim([-3, 3])
         ax.set_ylim([-0.5, 1.5])
         plt.draw()
-
-ed.MFVI.print_progress = print_progress
-inference = ed.MFVI(model, variational, data)
-# TODO it gets NaN's at iteration 608 and beyond
-inference.run(n_iter=600, n_print=5)


### PR DESCRIPTION
This is a simple clean-up of the model examples which plot things during inference. It is meant to be easier to read. Also, since `bayesian_linear_regression.py` is the first example shown on the front page, I removed plotting from it because plotting makes the first example needlessly complex. The example with plotting is still available at `bayesian_linear_regression_plot.py`. 

I would merge this but I'm having weird issues with matplotlib not working in virtualenv (and now suddenly not working on root either). Would be good if someone could double check that the plots all still work.