### PR TITLE
removed second tf.sum in log_prob

### DIFF
--- a/examples/mixture_density_network.py
+++ b/examples/mixture_density_network.py
@@ -47,8 +47,7 @@ class MixtureDensityNetwork:
         result = tf.exp(norm.logpdf(y, self.mus, self.sigmas))
         result = tf.mul(result, self.pi)
         result = tf.reduce_sum(result, 1, keep_dims=True)
-        result = tf.log(result)
-        return tf.reduce_sum(result)
+        return tf.log(result)
 
 def build_toy_dataset(nsample=6000):
     y_data = np.float32(np.random.uniform(-10.5, 10.5, (1, nsample))).T


### PR DESCRIPTION
I removed the second ```tf.reduce_sum``` in ```log_prob``` method of ```class MixtureDensityNetwork```
I don't think it's supposed to be there. 