### PR TITLE
Feature/params

### DIFF
--- a/edward/inferences.py
+++ b/edward/inferences.py
@@ -128,7 +128,7 @@ class VariationalInference(Inference):
         if self.n_print is not None:
             if t % self.n_print == 0:
                 print("iter {:d} loss {:.2f}".format(t, loss))
-                self.variational.print_params()
+                print(self.variational)
 
     def finalize(self):
         """Run steps after all updates."""

--- a/edward/inferences.py
+++ b/edward/inferences.py
@@ -203,7 +203,7 @@ class MFVI(VariationalInference):
 
         q_log_prob = tf.zeros([self.n_minibatch], dtype=tf.float32)
         for i in range(self.variational.num_factors):
-            q_log_prob += self.variational.log_prob_zi(i, tf.stop_gradient(z))
+            q_log_prob += self.variational.log_prob_i(i, tf.stop_gradient(z))
 
         losses = self.model.log_prob(x, z) - q_log_prob
         self.loss = tf.reduce_mean(losses)
@@ -222,7 +222,7 @@ class MFVI(VariationalInference):
 
         q_log_prob = tf.zeros([self.n_minibatch], dtype=tf.float32)
         for i in range(self.variational.num_factors):
-            q_log_prob += self.variational.log_prob_zi(i, z)
+            q_log_prob += self.variational.log_prob_i(i, z)
 
         self.loss = tf.reduce_mean(self.model.log_prob(x, z) - q_log_prob)
         return -self.loss
@@ -242,7 +242,7 @@ class MFVI(VariationalInference):
 
         q_log_prob = tf.zeros([self.n_minibatch], dtype=tf.float32)
         for i in range(self.variational.num_factors):
-            q_log_prob += self.variational.log_prob_zi(i, tf.stop_gradient(z))
+            q_log_prob += self.variational.log_prob_i(i, tf.stop_gradient(z))
 
         p_log_lik = self.model.log_lik(x, z)
         mu = tf.pack([layer.m for layer in self.variational.layers])
@@ -264,7 +264,7 @@ class MFVI(VariationalInference):
 
         q_log_prob = tf.zeros([self.n_minibatch], dtype=tf.float32)
         for i in range(self.variational.num_factors):
-            q_log_prob += self.variational.log_prob_zi(i, tf.stop_gradient(z))
+            q_log_prob += self.variational.log_prob_i(i, tf.stop_gradient(z))
 
         p_log_prob = self.model.log_prob(x, z)
         q_entropy = self.variational.entropy()
@@ -342,7 +342,7 @@ class KLpq(VariationalInference):
 
         q_log_prob = tf.zeros([self.n_minibatch], dtype=tf.float32)
         for i in range(self.variational.num_factors):
-            q_log_prob += self.variational.log_prob_zi(i, z)
+            q_log_prob += self.variational.log_prob_i(i, z)
 
         # 1/B sum_{b=1}^B grad_log_q * w_norm
         # = 1/B sum_{b=1}^B grad_log_q * exp{ log(w_norm) }

--- a/edward/inferences.py
+++ b/edward/inferences.py
@@ -199,7 +199,7 @@ class MFVI(VariationalInference):
         ELBO = E_{q(z; lambda)} [ log p(x, z) - log q(z; lambda) ]
         """
         x = self.data.sample(self.n_data)
-        z, self.samples = self.variational.sample(x, self.n_minibatch)
+        z, self.samples = self.variational.sample(self.n_minibatch)
 
         q_log_prob = tf.zeros([self.n_minibatch], dtype=tf.float32)
         for i in range(self.variational.num_factors):
@@ -218,7 +218,7 @@ class MFVI(VariationalInference):
         ELBO = E_{q(z; lambda)} [ log p(x, z) - log q(z; lambda) ]
         """
         x = self.data.sample(self.n_data)
-        z, self.samples = self.variational.sample(x, self.n_minibatch)
+        z, self.samples = self.variational.sample(self.n_minibatch)
 
         q_log_prob = tf.zeros([self.n_minibatch], dtype=tf.float32)
         for i in range(self.variational.num_factors):
@@ -238,7 +238,7 @@ class MFVI(VariationalInference):
         It assumes the model prior is p(z) = N(z; 0, 1).
         """
         x = self.data.sample(self.n_data)
-        z, self.samples = self.variational.sample(x, self.n_minibatch)
+        z, self.samples = self.variational.sample(self.n_minibatch)
 
         q_log_prob = tf.zeros([self.n_minibatch], dtype=tf.float32)
         for i in range(self.variational.num_factors):
@@ -260,7 +260,7 @@ class MFVI(VariationalInference):
         where entropy is analytic
         """
         x = self.data.sample(self.n_data)
-        z, self.samples = self.variational.sample(x, self.n_minibatch)
+        z, self.samples = self.variational.sample(self.n_minibatch)
 
         q_log_prob = tf.zeros([self.n_minibatch], dtype=tf.float32)
         for i in range(self.variational.num_factors):
@@ -283,7 +283,7 @@ class MFVI(VariationalInference):
         It assumes the model prior is p(z) = N(z; 0, 1).
         """
         x = self.data.sample(self.n_data)
-        z, self.samples = self.variational.sample(x, self.n_minibatch)
+        z, self.samples = self.variational.sample(self.n_minibatch)
 
         mu = tf.pack([layer.loc for layer in self.variational.layers])
         sigma = tf.pack([layer.scale for layer in self.variational.layers])
@@ -300,7 +300,7 @@ class MFVI(VariationalInference):
         where entropy is analytic
         """
         x = self.data.sample(self.n_data)
-        z, self.samples = self.variational.sample(x, self.n_minibatch)
+        z, self.samples = self.variational.sample(self.n_minibatch)
         self.loss = tf.reduce_mean(self.model.log_prob(x, z)) + \
                     self.variational.entropy()
         return -self.loss
@@ -338,7 +338,7 @@ class KLpq(VariationalInference):
         # gradient = - E_{q(z; lambda)} [ w_norm(z; lambda) *
         #                                 grad_{lambda} log q(z; lambda) ]
         x = self.data.sample(self.n_data)
-        z, self.samples = self.variational.sample(x, self.n_minibatch)
+        z, self.samples = self.variational.sample(self.n_minibatch)
 
         q_log_prob = tf.zeros([self.n_minibatch], dtype=tf.float32)
         for i in range(self.variational.num_factors):
@@ -388,14 +388,14 @@ class Laplace(VariationalInference):
 
     def build_loss(self):
         x = self.data.sample(self.n_data)
-        z, _ = self.variational.sample(x)
+        z, _ = self.variational.sample()
         self.loss = tf.squeeze(self.model.log_prob(x, z))
         return -self.loss
 
     def finalize(self):
         get_session()
         x = self.data.sample(self.n_data) # uses mini-batch
-        z, _ = self.variational.sample(x)
+        z, _ = self.variational.sample()
         var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES,
                                      scope='variational')
         inv_cov = hessian(self.model.log_prob(x, z), var_list)

--- a/edward/inferences.py
+++ b/edward/inferences.py
@@ -359,19 +359,19 @@ class MAP(VariationalInference):
     """
     Maximum a posteriori
     """
-    def __init__(self, model, data=Data(), transform=tf.identity):
+    def __init__(self, model, data=Data(), params=None):
         if hasattr(model, 'num_vars'):
             variational = Variational()
-            variational.add(PointMass(model.num_vars, transform))
+            variational.add(PointMass(model.num_vars, params))
         else:
             variational = Variational()
-            variational.add(PointMass(0, transform))
+            variational.add(PointMass(0))
 
         VariationalInference.__init__(self, model, variational, data)
 
     def build_loss(self):
         x = self.data.sample(self.n_data)
-        z, _ = self.variational.sample(x)
+        z, _ = self.variational.sample()
         self.loss = tf.squeeze(self.model.log_prob(x, z))
         return -self.loss
 
@@ -379,10 +379,10 @@ class Laplace(VariationalInference):
     """
     Laplace approximation
     """
-    def __init__(self, model, data=Data(), transform=tf.identity):
+    def __init__(self, model, data=Data(), params=None):
         with tf.variable_scope("variational"):
             variational = Variational()
-            variational.add(PointMass(model.num_vars, transform))
+            variational.add(PointMass(model.num_vars, params))
 
         VariationalInference.__init__(self, model, variational, data)
 

--- a/edward/inferences.py
+++ b/edward/inferences.py
@@ -245,8 +245,8 @@ class MFVI(VariationalInference):
             q_log_prob += self.variational.log_prob_i(i, tf.stop_gradient(z))
 
         p_log_lik = self.model.log_lik(x, z)
-        mu = tf.pack([layer.m for layer in self.variational.layers])
-        sigma = tf.pack([layer.s for layer in self.variational.layers])
+        mu = tf.pack([layer.loc for layer in self.variational.layers])
+        sigma = tf.pack([layer.scale for layer in self.variational.layers])
         kl = kl_multivariate_normal(mu, sigma)
         self.loss = tf.reduce_mean(p_log_lik) - kl
         return -(tf.reduce_mean(q_log_prob * tf.stop_gradient(p_log_lik)) - kl)
@@ -285,8 +285,8 @@ class MFVI(VariationalInference):
         x = self.data.sample(self.n_data)
         z, self.samples = self.variational.sample(x, self.n_minibatch)
 
-        mu = tf.pack([layer.m for layer in self.variational.layers])
-        sigma = tf.pack([layer.s for layer in self.variational.layers])
+        mu = tf.pack([layer.loc for layer in self.variational.layers])
+        sigma = tf.pack([layer.scale for layer in self.variational.layers])
         self.loss = tf.reduce_mean(self.model.log_lik(x, z)) - \
                     kl_multivariate_normal(mu, sigma)
         return -self.loss

--- a/edward/inferences.py
+++ b/edward/inferences.py
@@ -380,8 +380,10 @@ class Laplace(VariationalInference):
     Laplace approximation
     """
     def __init__(self, model, data=Data(), transform=tf.identity):
-        variational = Variational()
-        variational.add(PointMass(model.num_vars, transform))
+        with tf.variable_scope("variational"):
+            variational = Variational()
+            variational.add(PointMass(model.num_vars, transform))
+
         VariationalInference.__init__(self, model, variational, data)
 
     def build_loss(self):

--- a/edward/models/__init__.py
+++ b/edward/models/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import absolute_import
 from .models import *
-from .variationals import *
+from .distributions import *

--- a/edward/models/distributions.py
+++ b/edward/models/distributions.py
@@ -30,6 +30,17 @@ class Variational:
                                    for layer in self.layers])
             self.sample_tensor = [layer.sample_tensor for layer in self.layers]
 
+    def __str__(self):
+        string = ""
+        for i in range(len(self.layers)):
+            if i != 0:
+                string += "\n"
+
+            layer = self.layers[i]
+            string += layer.__str__()
+
+        return string
+
     def add(self, layer):
         """
         Adds a layer instance on top of the layer stack.
@@ -86,9 +97,6 @@ class Variational:
 
         return feed_dict
 
-    def print_params(self):
-        [layer.print_params() for layer in self.layers]
-
     def log_prob_i(self, i, xs):
         start = final = 0
         for layer in self.layers:
@@ -123,9 +131,6 @@ class Distribution:
         self.num_vars = None # number of random variables
         self.num_params = None # number of parameters
         self.sample_tensor = False
-
-    def print_params(self):
-        raise NotImplementedError()
 
     def sample_noise(self, size=1):
         """
@@ -224,10 +229,9 @@ class Bernoulli(Distribution):
 
         self.p = p
 
-    def print_params(self):
+    def __str__(self):
         p = self.p.eval()
-        print("probability:")
-        print(p)
+        return "probability: \n" + p.__str__()
 
     def sample(self, size=1):
         """x ~ p(x | params)"""
@@ -270,13 +274,11 @@ class Beta(Distribution):
         self.alpha = alpha
         self.beta = beta
 
-    def print_params(self):
+    def __str__(self):
         sess = get_session()
         a, b = sess.run([self.alpha, self.beta])
-        print("shape:")
-        print(a)
-        print("scale:")
-        print(b)
+        return "shape: \n" + a.__str__() + "\n" + \
+               "scale: \n" + b.__str__()
 
     def sample(self, size=1):
         """x ~ p(x | params)"""
@@ -319,10 +321,9 @@ class Dirichlet(Distribution):
 
         self.alpha = alpha
 
-    def print_params(self):
+    def __str__(self):
         alpha = self.alpha.eval()
-        print("concentration vector:")
-        print(alpha)
+        return "concentration vector: \n" + alpha.__str__()
 
     def sample(self, size=1):
         """x ~ p(x | params)"""
@@ -369,13 +370,11 @@ class InvGamma(Distribution):
         self.alpha = alpha
         self.beta = beta
 
-    def print_params(self):
+    def __str__(self):
         sess = get_session()
         a, b = sess.run([self.alpha, self.beta])
-        print("shape:")
-        print(a)
-        print("scale:")
-        print(b)
+        return "shape: \n" + a.__str__() + "\n" + \
+               "scale: \n" + b.__str__()
 
     def sample(self, size=1):
         """x ~ p(x | params)"""
@@ -433,10 +432,9 @@ class Multinomial(Distribution):
 
         self.pi = pi
 
-    def print_params(self):
+    def __str__(self):
         pi = self.pi.eval()
-        print("probability vector:")
-        print(pi)
+        return "probability vector: \n" + pi.__str__()
 
     def sample(self, size=1):
         """x ~ p(x | params)"""
@@ -482,13 +480,11 @@ class Normal(Distribution):
         self.loc = loc
         self.scale = scale
 
-    def print_params(self):
+    def __str__(self):
         sess = get_session()
         m, s = sess.run([self.loc, self.scale])
-        print("mean:")
-        print(m)
-        print("std dev:")
-        print(s)
+        return "mean: \n" + m.__str__() + "\n" + \
+               "std dev: \n" + s.__str__()
 
     def sample_noise(self, size=1):
         """
@@ -536,13 +532,12 @@ class PointMass(Distribution):
 
         self.params = params
 
-    def print_params(self):
+    def __str__(self):
         if self.params.get_shape()[0] == 0:
-            return
+            return "parameter values: \n" + "None"
 
         params = self.params.eval()
-        print("parameter values:")
-        print(params)
+        return "parameter values: \n" + params.__str__()
 
     def sample(self, size=1):
         # Return a matrix where each row is the same set of

--- a/edward/models/distributions.py
+++ b/edward/models/distributions.py
@@ -305,7 +305,8 @@ class Dirichlet(Distribution):
     the ith factor x[(i-1)*K:i*K], and params = alpha.
     """
     def __init__(self, shape, alpha=None):
-        num_factors, K = shape
+        num_factors = shape[0]
+        K = shape[-1]
         Distribution.__init__(self, num_factors)
         self.num_vars = K*num_factors
         self.num_params = K*num_factors
@@ -408,7 +409,8 @@ class Multinomial(Distribution):
     trial (n=1) when sampling and calculating the density.
     """
     def __init__(self, shape, pi=None):
-        num_factors, K = shape
+        num_factors = shape[0]
+        K = shape[-1]
         if K == 1:
             raise ValueError("Multinomial is not supported for K=1. Use Bernoulli.")
 

--- a/edward/models/distributions.py
+++ b/edward/models/distributions.py
@@ -523,18 +523,14 @@ class PointMass(Distribution):
     Dirac(x; p) is the Dirac delta distribution with density equal to
     1 if x == p and 0 otherwise.
     """
-    def __init__(self, num_vars=1, transform=tf.identity):
+    def __init__(self, num_vars=1, params=None):
         Distribution.__init__(self, 1)
         self.num_vars = num_vars
         self.num_params = num_vars
         self.sample_tensor = True
 
-        # TODO
-        params = None
         if params is None:
             params = Variable("params", [self.num_vars])
-            # TODO temporary
-            params = transform(params)
 
         self.params = params
 

--- a/edward/models/distributions.py
+++ b/edward/models/distributions.py
@@ -47,7 +47,7 @@ class Variational:
         self.is_normal = self.is_normal and isinstance(layer, Normal)
         self.sample_tensor += [layer.sample_tensor]
 
-    def sample(self, x, size=1):
+    def sample(self, size=1):
         """
         Draws a mix of tensors and placeholders, corresponding to
         TensorFlow-based samplers and SciPy-based samplers depending
@@ -55,7 +55,6 @@ class Variational:
 
         Parameters
         ----------
-        x : Data
         size : int, optional
 
         Returns

--- a/edward/models/distributions.py
+++ b/edward/models/distributions.py
@@ -259,8 +259,8 @@ class Bernoulli(Distribution):
 
 class Beta(Distribution):
     """
-    q(z | lambda) = prod_{i=1}^d Beta(z[i] | a[i], b[i])
-    where lambda = {a, b}.
+    q(z | lambda) = prod_{i=1}^d Beta(z[i] | alpha[i], beta[i])
+    where lambda = {alpha, beta}.
     """
     def __init__(self, num_factors=1, alpha=None, beta=None):
         Distribution.__init__(self, num_factors)
@@ -276,12 +276,12 @@ class Beta(Distribution):
             beta_unconst = Variable("beta", [self.num_vars])
             beta = tf.nn.softplus(beta_unconst)
 
-        self.a = alpha
-        self.b = beta
+        self.alpha = alpha
+        self.beta = beta
 
     def print_params(self):
         sess = get_session()
-        a, b = sess.run([self.a, self.b])
+        a, b = sess.run([self.alpha, self.beta])
         print("shape:")
         print(a)
         print("scale:")
@@ -290,7 +290,7 @@ class Beta(Distribution):
     def sample(self, size=1):
         """z ~ q(z | lambda)"""
         sess = get_session()
-        a, b = sess.run([self.a, self.b])
+        a, b = sess.run([self.alpha, self.beta])
         z = np.zeros((size, self.num_vars))
         for d in range(self.num_vars):
             z[:, d] = beta.rvs(a[d], b[d], size=size)
@@ -302,10 +302,10 @@ class Beta(Distribution):
         if i >= self.num_factors:
             raise IndexError()
 
-        return beta.logpdf(zs[:, i], self.a[i], self.b[i])
+        return beta.logpdf(zs[:, i], self.alpha[i], self.beta[i])
 
     def entropy(self):
-        return tf.reduce_sum(beta.entropy(self.a, self.b))
+        return tf.reduce_sum(beta.entropy(self.alpha, self.beta))
 
 class Dirichlet(Distribution):
     """
@@ -357,8 +357,8 @@ class Dirichlet(Distribution):
 
 class InvGamma(Distribution):
     """
-    q(z | lambda) = prod_{i=1}^d Inv_Gamma(z[i] | a[i], b[i])
-    where lambda = {a, b}.
+    q(z | lambda) = prod_{i=1}^d Inv_Gamma(z[i] | alpha[i], beta[i])
+    where lambda = {alpha, beta}.
     """
     def __init__(self, num_factors=1, alpha=None, beta=None):
         Distribution.__init__(self, num_factors)
@@ -374,12 +374,12 @@ class InvGamma(Distribution):
             beta_unconst = Variable("beta", [self.num_vars])
             beta = tf.nn.softplus(beta_unconst) + 1e-2
 
-        self.a = alpha
-        self.b = beta
+        self.alpha = alpha
+        self.beta = beta
 
     def print_params(self):
         sess = get_session()
-        a, b = sess.run([self.a, self.b])
+        a, b = sess.run([self.alpha, self.beta])
         print("shape:")
         print(a)
         print("scale:")
@@ -388,7 +388,7 @@ class InvGamma(Distribution):
     def sample(self, size=1):
         """z ~ q(z | lambda)"""
         sess = get_session()
-        a, b = sess.run([self.a, self.b])
+        a, b = sess.run([self.alpha, self.beta])
         z = np.zeros((size, self.num_vars))
         for d in range(self.num_vars):
             z[:, d] = invgamma.rvs(a[d], b[d], size=size)
@@ -400,10 +400,10 @@ class InvGamma(Distribution):
         if i >= self.num_factors:
             raise IndexError()
 
-        return invgamma.logpdf(zs[:, i], self.a[i], self.b[i])
+        return invgamma.logpdf(zs[:, i], self.alpha[i], self.beta[i])
 
     def entropy(self):
-        return tf.reduce_sum(invgamma.entropy(self.a, self.b))
+        return tf.reduce_sum(invgamma.entropy(self.alpha, self.beta))
 
 class Multinomial(Distribution):
     """
@@ -470,8 +470,8 @@ class Multinomial(Distribution):
 
 class Normal(Distribution):
     """
-    q(z | lambda ) = prod_{i=1}^d Normal(z[i] | m[i], s[i])
-    where lambda = {m, s}.
+    q(z | lambda ) = prod_{i=1}^d Normal(z[i] | loc[i], scale[i])
+    where lambda = {loc, scale}.
     """
     def __init__(self, num_factors=1, loc=None, scale=None):
         Distribution.__init__(self, num_factors)
@@ -486,12 +486,12 @@ class Normal(Distribution):
             scale_unconst = Variable("sigma", [self.num_vars])
             scale = tf.nn.softplus(scale_unconst)
 
-        self.m = loc
-        self.s = scale
+        self.loc = loc
+        self.scale = scale
 
     def print_params(self):
         sess = get_session()
-        m, s = sess.run([self.m, self.s])
+        m, s = sess.run([self.loc, self.scale])
         print("mean:")
         print(m)
         print("std dev:")
@@ -509,19 +509,19 @@ class Normal(Distribution):
         eps = sample_noise() ~ s(eps)
         s.t. z = reparam(eps; lambda) ~ q(z | lambda)
         """
-        return self.m + eps * self.s
+        return self.loc + eps * self.scale
 
     def log_prob_zi(self, i, zs):
         """log q(z_i | lambda)"""
         if i >= self.num_factors:
             raise IndexError()
 
-        mi = self.m[i]
-        si = self.s[i]
-        return norm.logpdf(zs[:, i], mi, si)
+        loci = self.loc[i]
+        scalei = self.scale[i]
+        return norm.logpdf(zs[:, i], loci, scalei)
 
     def entropy(self):
-        return tf.reduce_sum(norm.entropy(scale=self.s))
+        return tf.reduce_sum(norm.entropy(scale=self.scale))
 
 class PointMass(Distribution):
     """

--- a/examples/bayesian_linear_regression_plot.py
+++ b/examples/bayesian_linear_regression_plot.py
@@ -90,8 +90,8 @@ for t in range(250):
         print("iter {:d} loss {:.2f}".format(t, loss))
 
         # Sample functions from variational model
-        mean, std = sess.run([variational.layers[0].m,
-                              variational.layers[0].s])
+        mean, std = sess.run([variational.layers[0].loc,
+                              variational.layers[0].scale])
         rs = np.random.RandomState(0)
         zs = rs.randn(10, variational.num_vars) * std + mean
         zs = tf.constant(zs, dtype=tf.float32)

--- a/examples/bayesian_nn.py
+++ b/examples/bayesian_nn.py
@@ -135,8 +135,8 @@ for t in range(1000):
         print("iter {:d} loss {:.2f}".format(t, loss))
 
         # Sample functions from variational model
-        mean, std = sess.run([variational.layers[0].m,
-                              variational.layers[0].s])
+        mean, std = sess.run([variational.layers[0].loc,
+                              variational.layers[0].scale])
         rs = np.random.RandomState(0)
         zs = rs.randn(10, variational.num_vars) * std + mean
         zs = tf.constant(zs, dtype=tf.float32)

--- a/examples/bayesian_nn_analytic_kl.py
+++ b/examples/bayesian_nn_analytic_kl.py
@@ -133,8 +133,8 @@ for t in range(1000):
         print("iter {:d} loss {:.2f}".format(t, np.mean(loss)))
 
         # Sample functions from variational model
-        mean, std = sess.run([variational.layers[0].m,
-                              variational.layers[0].s])
+        mean, std = sess.run([variational.layers[0].loc,
+                              variational.layers[0].scale])
         rs = np.random.RandomState(0)
         zs = rs.randn(10, variational.num_vars) * std + mean
         zs = tf.constant(zs, dtype=tf.float32)

--- a/examples/beta_bernoulli_map.py
+++ b/examples/beta_bernoulli_map.py
@@ -30,5 +30,6 @@ ed.set_seed(42)
 model = BetaBernoulli()
 data = ed.Data(tf.constant((0, 1, 0, 0, 0, 0, 0, 0, 0, 1), dtype=tf.float32))
 
-inference = ed.MAP(model, data, transform=tf.sigmoid)
+params = tf.sigmoid(tf.Variable(tf.random_normal([1])))
+inference = ed.MAP(model, data, params=params)
 inference.run(n_iter=100, n_print=10)

--- a/examples/hierarchical_logistic_regression.py
+++ b/examples/hierarchical_logistic_regression.py
@@ -108,8 +108,8 @@ for t in range(600):
         variational.print_params()
 
         # Sample functions from variational model
-        mean, std = sess.run([variational.layers[0].m,
-                              variational.layers[0].s])
+        mean, std = sess.run([variational.layers[0].loc,
+                              variational.layers[0].scale])
         rs = np.random.RandomState(0)
         zs = rs.randn(10, variational.num_vars) * std + mean
         zs = tf.constant(zs, dtype=tf.float32)

--- a/examples/mixture_gaussian.py
+++ b/examples/mixture_gaussian.py
@@ -92,7 +92,7 @@ data = ed.Data(tf.constant(x, dtype=tf.float32))
 
 model = MixtureGaussian(K=2, D=2)
 variational = Variational()
-variational.add(Dirichlet(1, model.K))
+variational.add(Dirichlet([1, model.K]))
 variational.add(Normal(model.K*model.D))
 variational.add(InvGamma(model.K*model.D))
 

--- a/tests/test-models/test_models_multinomial.py
+++ b/tests/test-models/test_models_multinomial.py
@@ -30,7 +30,7 @@ def multinomial_logpmf_vec(x, n, p):
     return np.array([multinomial_logpmf(x[i, :], n, p)
                      for i in range(n_minibatch)])
 
-def _test_log_prob_zi(n_minibatch, num_factors, K):
+def _test_log_prob_i(n_minibatch, num_factors, K):
     multinomial = Multinomial(num_factors, K)
     multinomial.pi = tf.constant(1.0/K, shape=[num_factors, K])
 
@@ -45,21 +45,21 @@ def _test_log_prob_zi(n_minibatch, num_factors, K):
             # NOTE: since Tensorflow has no special functions, the values here are
             # only an approximation
             assert np.allclose(
-                multinomial.log_prob_zi(i, z_tf).eval(),
+                multinomial.log_prob_i(i, z_tf).eval(),
                 multinomial_logpmf_vec(z[:, (i*K):((i+1)*K)], 1, pi[i, :]),
                 atol=1e-4)
 
-def test_log_prob_zi_1d_1v_2k():
-    _test_log_prob_zi(1, 1, 2)
+def test_log_prob_i_1d_1v_2k():
+    _test_log_prob_i(1, 1, 2)
 
-def test_log_prob_zi_1d_1v_3k():
-    _test_log_prob_zi(1, 1, 3)
+def test_log_prob_i_1d_1v_3k():
+    _test_log_prob_i(1, 1, 3)
 
-def test_log_prob_zi_2d_1v_2k():
-    _test_log_prob_zi(2, 1, 2)
+def test_log_prob_i_2d_1v_2k():
+    _test_log_prob_i(2, 1, 2)
 
-def test_log_prob_zi_1d_2v_2k():
-    _test_log_prob_zi(1, 2, 2)
+def test_log_prob_i_1d_2v_2k():
+    _test_log_prob_i(1, 2, 2)
 
-def test_log_prob_zi_2d_2v_2k():
-    _test_log_prob_zi(2, 2, 2)
+def test_log_prob_i_2d_2v_2k():
+    _test_log_prob_i(2, 2, 2)

--- a/tests/test-models/test_models_multinomial.py
+++ b/tests/test-models/test_models_multinomial.py
@@ -31,9 +31,8 @@ def multinomial_logpmf_vec(x, n, p):
                      for i in range(n_minibatch)])
 
 def _test_log_prob_i(n_minibatch, num_factors, K):
-    multinomial = Multinomial(num_factors, K)
-    multinomial.pi = tf.constant(1.0/K, shape=[num_factors, K])
-
+    multinomial = Multinomial([num_factors, K],
+                               pi=tf.constant(1.0/K, shape=[num_factors, K]))
     with sess.as_default():
         pi = multinomial.pi.eval()
         z = np.zeros((n_minibatch, K*num_factors))

--- a/tests/test-models/test_models_normal.py
+++ b/tests/test-models/test_models_normal.py
@@ -14,8 +14,8 @@ def _test_log_prob_i(n_minibatch, num_factors):
                     loc=tf.constant([0.0] * num_factors),
                     scale=tf.constant([1.0] * num_factors))
     with sess.as_default():
-        m = normal.m.eval()
-        s = normal.s.eval()
+        m = normal.loc.eval()
+        s = normal.scale.eval()
         z = np.random.randn(n_minibatch, num_factors)
         for i in range(num_factors):
             assert np.allclose(

--- a/tests/test-models/test_models_normal.py
+++ b/tests/test-models/test_models_normal.py
@@ -9,7 +9,7 @@ from scipy import stats
 sess = tf.Session()
 ed.set_seed(98765)
 
-def _test_log_prob_zi(n_minibatch, num_factors):
+def _test_log_prob_i(n_minibatch, num_factors):
     normal = Normal(num_factors)
     normal.m = tf.constant([0.0] * num_factors)
     normal.s = tf.constant([1.0] * num_factors)
@@ -20,17 +20,17 @@ def _test_log_prob_zi(n_minibatch, num_factors):
         z = np.random.randn(n_minibatch, num_factors)
         for i in range(num_factors):
             assert np.allclose(
-                normal.log_prob_zi(i, tf.constant(z, dtype=tf.float32)).eval(),
+                normal.log_prob_i(i, tf.constant(z, dtype=tf.float32)).eval(),
                 stats.norm.logpdf(z[:, i], m[i], s[i]))
 
-def test_log_prob_zi_1d_1v():
-    _test_log_prob_zi(1, 1)
+def test_log_prob_i_1d_1v():
+    _test_log_prob_i(1, 1)
 
-def test_log_prob_zi_2d_1v():
-    _test_log_prob_zi(2, 1)
+def test_log_prob_i_2d_1v():
+    _test_log_prob_i(2, 1)
 
-def test_log_prob_zi_1d_2v():
-    _test_log_prob_zi(1, 2)
+def test_log_prob_i_1d_2v():
+    _test_log_prob_i(1, 2)
 
-def test_log_prob_zi_2d_2v():
-    _test_log_prob_zi(2, 2)
+def test_log_prob_i_2d_2v():
+    _test_log_prob_i(2, 2)

--- a/tests/test-models/test_models_normal.py
+++ b/tests/test-models/test_models_normal.py
@@ -10,10 +10,9 @@ sess = tf.Session()
 ed.set_seed(98765)
 
 def _test_log_prob_i(n_minibatch, num_factors):
-    normal = Normal(num_factors)
-    normal.m = tf.constant([0.0] * num_factors)
-    normal.s = tf.constant([1.0] * num_factors)
-
+    normal = Normal(num_factors,
+                    loc=tf.constant([0.0] * num_factors),
+                    scale=tf.constant([1.0] * num_factors))
     with sess.as_default():
         m = normal.m.eval()
         s = normal.s.eval()


### PR DESCRIPTION
#### Summary:

+ issues: makes progress for #7; makes progress for #27

Variational distribution objects are now just distribution objects. They take as input the number of distributions (or shape in the case of multivariate distributions) and their parameters.

The refactor is simple and in fact simplifies the internal code. The benefits are enormous. For example, it lets us use the same classes for constructing distributions in general, making progress for an internal modeling language. It also lets us define parameters outside the class and thus make complex parameterizations as in inference networks, without the need to fix possible inputs to the inference network, and perform transformations outside the class so that `MAP` and `Laplace` aren't restricted to only one transformation for all parameters.

#### Intended Effect:

See above.

#### How to Verify:

Run all examples and tests. They still work.

#### Side Effects:

None.

#### Documentation:

N/A

#### Reviewer Suggestions:

N/A