### PR TITLE
remove need for sample_noise() and reparam() methods

### DIFF
--- a/edward/inferences.py
+++ b/edward/inferences.py
@@ -228,7 +228,7 @@ class MFVI(VariationalInference):
             gradient estimator. Otherwise default is to use the
             reparameterization gradient if available.
         """
-        if score is None and self.variational.is_reparam:
+        if score is None and self.variational.is_reparameterized:
             self.score = False
         else:
             self.score = True

--- a/edward/models/models.py
+++ b/edward/models/models.py
@@ -219,7 +219,7 @@ class Variational(object):
             self.shape = []
             self.num_vars = 0
             self.num_params = 0
-            self.is_reparam = True
+            self.is_reparameterized = True
             self.is_normal = True
             self.is_entropy = True
             self.is_multivariate = []
@@ -228,8 +228,8 @@ class Variational(object):
             self.shape = [layer.shape for layer in self.layers]
             self.num_vars = sum([layer.num_vars for layer in self.layers])
             self.num_params = sum([layer.num_params for layer in self.layers])
-            self.is_reparam = all(['reparam' in layer.__class__.__dict__
-                                   for layer in self.layers])
+            self.is_reparameterized = all([layer.is_reparameterized
+                                           for layer in self.layers])
             self.is_normal = all([isinstance(layer, Normal)
                                   for layer in self.layers])
             self.is_entropy = all(['entropy' in layer.__class__.__dict__
@@ -258,7 +258,7 @@ class Variational(object):
         self.shape += [layer.shape]
         self.num_vars += layer.num_vars
         self.num_params += layer.num_params
-        self.is_reparam = self.is_reparam and 'reparam' in layer.__class__.__dict__
+        self.is_reparameterized = self.is_reparameterized and layer.is_reparameterized
         self.is_entropy = self.is_entropy and 'entropy' in layer.__class__.__dict__
         self.is_normal = self.is_normal and isinstance(layer, Normal)
         self.is_multivariate += [layer.is_multivariate]


### PR DESCRIPTION
+ fix #145 (by no longer needing it!)

This pull request comes at the advice of the Bayesflow folks. (also see https://github.com/tensorflow/tensorflow/issues/2423)

Rather than explicitly defining a `sample_noise()` method and `reparam()` method in distribution objects, any reparameterizable distributions simply do the noise generation and reparameterization in `sample()`. This simplifies the internal code and is more closely aligned with how `tf.contrib.distributions` works; see, e.g., [`tf.contrib.distributions.Normal`](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/distributions/python/ops/normal.py#L304-L334).

### Reviewer Suggestions:

Anyone feel free to review and merge this.