### PR TITLE
support gradients in TensorFlow for Python, PyMC3, and Stan models

### DIFF
--- a/edward/models/models.py
+++ b/edward/models/models.py
@@ -82,7 +82,17 @@ class PyMC3Model(object):
             # pass the tensors into tf.py_func.
             inp = [zs] + xs.values()
 
-        return tf.py_func(self._py_log_prob_args, inp, [tf.float32])[0]
+        # Register gradient here rather than as a property in the
+        # class method. User has option to modify _py_log_prob_grad()
+        # and therefore modify this method's gradient.
+        tf.RegisterGradient("PythonModel_PyFunc_Grad")(self._py_log_prob_grad)
+        g = tf.get_default_graph()
+        # TODO which one is it? what is the name of the pyfunc op to
+        # be used in the dictionary?
+        #with g.gradient_override_map({'PyFunc': name}):
+        with g.gradient_override_map({"PythonModel_PyFunc": "PythonModel_PyFunc_Grad"}):
+            return tf.py_func(self._py_log_prob_args, inp, [tf.float32],
+                              name="PythonModel_PyFunc")[0]
 
     def _py_log_prob_args(self, zs, *args):
         # Set `values` to NumPy arrays that were passed in via
@@ -103,6 +113,13 @@ class PyMC3Model(object):
             lp[s] = self.logp(zs[s, :])
 
         return lp
+
+    # TODO is this still registered appropriately when the method is
+    # overwritten in a derived class?
+    @tf.RegisterGradient("PythonModel_PyFunc_Grad")
+    def _py_log_prob_grad(op, grad):
+        # TODO use PyMC3's autodiff; wrap around it with a py_func
+        pass
 
 
 class PythonModel(object):
@@ -152,6 +169,7 @@ class PythonModel(object):
             # pass the tensors into tf.py_func.
             inp = [zs] + xs.values()
 
+        # TODO whatever is done in PyMC3Model
         return tf.py_func(self._py_log_prob_args, inp, [tf.float32])[0]
 
     def _py_log_prob_args(self, zs, *args):
@@ -168,6 +186,9 @@ class PythonModel(object):
     def _py_log_prob(self, xs, zs):
         raise NotImplementedError()
 
+    def _py_log_prob_grad(op, grad):
+        # TODO use autograd's autodiff; wrap around it with a py_func
+        pass
 
 class StanModel(object):
     """Model wrapper for models written in Stan.
@@ -215,6 +236,7 @@ class StanModel(object):
         if self.flag_init is False:
             self._initialize(xs)
 
+        # TODO whatever is done in PyMC3Model
         return tf.py_func(self._py_log_prob, [zs], [tf.float32])[0]
 
     def _initialize(self, xs):
@@ -262,6 +284,9 @@ class StanModel(object):
 
         return lp
 
+    def _py_log_prob_grad(op, grad):
+        # TODO use Stan's autodiff; wrap around it with a py_func
+        pass
 
 class Variational(object):
     """A container for collecting distribution objects."""

--- a/edward/util.py
+++ b/edward/util.py
@@ -251,7 +251,6 @@ def multivariate_rbf(x, y=0.0, sigma=1.0, l=1.0):
            tf.exp(-1.0/(2.0*tf.pow(l, 2.0)) * \
                   tf.reduce_sum(tf.pow(x - y , 2.0)))
 
-
 def rbf(x, y=0.0, sigma=1.0, l=1.0):
     """Squared-exponential kernel element-wise
 

--- a/edward/util.py
+++ b/edward/util.py
@@ -251,6 +251,7 @@ def multivariate_rbf(x, y=0.0, sigma=1.0, l=1.0):
            tf.exp(-1.0/(2.0*tf.pow(l, 2.0)) * \
                   tf.reduce_sum(tf.pow(x - y , 2.0)))
 
+
 def rbf(x, y=0.0, sigma=1.0, l=1.0):
     """Squared-exponential kernel element-wise
 

--- a/examples/normal_np.py
+++ b/examples/normal_np.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """
-The model is written in NumPy/SciPy.
+The model is written in native Python. Gradients are specified
+manually.
 
 Probability model
     Posterior: (1-dimensional) Normal

--- a/examples/normal_np.py
+++ b/examples/normal_np.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+"""
+The model is written in NumPy/SciPy.
+
+Probability model
+    Posterior: (1-dimensional) Normal
+Variational model
+    Likelihood: Mean-field Normal
+"""
+import edward as ed
+import numpy as np
+
+from edward.models import PythonModel, Variational, Normal
+from scipy.stats import norm
+
+class NormalPosterior(PythonModel):
+    """
+    p(x, z) = p(z) = p(z | x) = Gaussian(z; mu, Sigma)
+    """
+    def __init__(self, mu, std):
+        self.mu = mu
+        self.std = std
+
+    def _py_log_prob(self, xs, zs):
+        # This example is written for pedagogy. We recommend
+        # vectorizing operations in practice.
+        n_samples = zs.shape[0]
+        lp = np.zeros(n_samples, dtype=np.float32)
+        for b in range(n_samples):
+            lp[b] = norm.logpdf(zs[b, :], loc=self.mu, scale=self.std)
+
+        return lp
+
+    # TODO manually write gradient wrt mu and sigma
+    def _py_log_prob_grad(self, zs):
+        return np.array([0, 0], dtype=np.float32)
+
+ed.set_seed(42)
+mu = np.array(1.0)
+std = np.array(1.0)
+model = NormalPosterior(mu, std)
+variational = Variational()
+variational.add(Normal())
+
+inference = ed.MFVI(model, variational)
+inference.run(n_iter=10000)

--- a/examples/normal_np_autograd.py
+++ b/examples/normal_np_autograd.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """
-The model is written in NumPy/SciPy.
+The model is written in native Python. Gradients are given by
+default via autograd.
 
 Probability model
     Posterior: (1-dimensional) Normal

--- a/examples/normal_np_autograd.py
+++ b/examples/normal_np_autograd.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+"""
+The model is written in NumPy/SciPy.
+
+Probability model
+    Posterior: (1-dimensional) Normal
+Variational model
+    Likelihood: Mean-field Normal
+"""
+import autograd.numpy as np
+import edward as ed
+
+from autograd.scipy.stats import norm
+from edward.models import PythonModel, Variational, Normal
+
+class NormalPosterior(PythonModel):
+    """
+    p(x, z) = p(z) = p(z | x) = Gaussian(z; mu, Sigma)
+    """
+    def __init__(self, mu, std):
+        self.mu = mu
+        self.std = std
+
+    def _py_log_prob(self, xs, zs):
+        # This example is written for pedagogy. We recommend
+        # vectorizing operations in practice.
+        n_samples = zs.shape[0]
+        lp = np.zeros(n_samples, dtype=np.float32)
+        for b in range(n_samples):
+            lp[b] = norm.logpdf(zs[b, :], loc=self.mu, scale=self.std)
+
+        return lp
+
+ed.set_seed(42)
+mu = np.array(1.0)
+std = np.array(1.0)
+model = NormalPosterior(mu, std)
+variational = Variational()
+variational.add(Normal())
+
+inference = ed.MFVI(model, variational)
+inference.run(n_iter=10000)

--- a/examples/normal_pymc3.py
+++ b/examples/normal_pymc3.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+"""
+The model is written in NumPy/SciPy.
+
+Probability model
+    Posterior: (1-dimensional) Normal
+Variational model
+    Likelihood: Mean-field Normal
+"""
+import edward as ed
+import numpy as np
+
+from edward.models import PythonModel, Variational, Normal
+from scipy.stats import norm
+
+# TODO define normal posterior PyMC3 model
+class NormalPosterior(PythonModel):
+    """
+    p(x, z) = p(z) = p(z | x) = Gaussian(z; mu, Sigma)
+    """
+    def __init__(self, mu, std):
+        self.mu = mu
+        self.std = std
+
+    def _py_log_prob(self, xs, zs):
+        # This example is written for pedagogy. We recommend
+        # vectorizing operations in practice.
+        n_samples = zs.shape[0]
+        lp = np.zeros(n_samples, dtype=np.float32)
+        for b in range(n_samples):
+            lp[b] = norm.logpdf(zs[b, :], loc=self.mu, scale=self.std)
+
+        return lp
+
+ed.set_seed(42)
+mu = np.array(1.0)
+std = np.array(1.0)
+model = NormalPosterior(mu, std)
+variational = Variational()
+variational.add(Normal())
+
+inference = ed.MFVI(model, variational)
+inference.run(n_iter=10000)

--- a/examples/normal_pymc3.py
+++ b/examples/normal_pymc3.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-The model is written in NumPy/SciPy.
+The model is written in PyMC3.
 
 Probability model
     Posterior: (1-dimensional) Normal

--- a/examples/normal_stan.py
+++ b/examples/normal_stan.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+"""
+The model is written in NumPy/SciPy.
+
+Probability model
+    Posterior: (1-dimensional) Normal
+Variational model
+    Likelihood: Mean-field Normal
+"""
+import edward as ed
+import numpy as np
+
+from edward.models import PythonModel, Variational, Normal
+from scipy.stats import norm
+
+# TODO define normal posterior stan program
+class NormalPosterior(PythonModel):
+    """
+    p(x, z) = p(z) = p(z | x) = Gaussian(z; mu, Sigma)
+    """
+    def __init__(self, mu, std):
+        self.mu = mu
+        self.std = std
+
+    def _py_log_prob(self, xs, zs):
+        # This example is written for pedagogy. We recommend
+        # vectorizing operations in practice.
+        n_samples = zs.shape[0]
+        lp = np.zeros(n_samples, dtype=np.float32)
+        for b in range(n_samples):
+            lp[b] = norm.logpdf(zs[b, :], loc=self.mu, scale=self.std)
+
+        return lp
+
+    def _py_log_prob_grad(self, zs):
+        return np.array([0, 0], dtype=np.float32)
+
+ed.set_seed(42)
+mu = np.array(1.0)
+std = np.array(1.0)
+model = NormalPosterior(mu, std)
+variational = Variational()
+variational.add(Normal())
+
+inference = ed.MFVI(model, variational)
+inference.run(n_iter=10000)

--- a/examples/normal_stan.py
+++ b/examples/normal_stan.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-The model is written in NumPy/SciPy.
+The model is written in Stan.
 
 Probability model
     Posterior: (1-dimensional) Normal


### PR DESCRIPTION
**This pull request is a work in progress. Comments are welcome from interested parties, and also feedback on the implementation.**
- fixes #163; related to discussion in #154 

Gradients of the log density are now supported for all model wrappers for use within a TensorFlow session.
- `PythonModel` uses autograd's automatic differentiation.
- `PyMC3Model` uses PyMC3's automatic differentiation.
- `StanModel` uses Stan's automatic differentiation. 

In all wrappers, the gradient can be overwritten by manually specifying it. The manual gradient is written in native Python. This is useful for speeding up computation: manual gradients are often faster than automatic gradients (especially reverse-mode autodiff). It is also useful for the `PythonModel` in cases where its gradient is not supported by autograd.

Examples showing proof of concept are added. Each example is a normal posterior; inference is done via variational inference with the reparameterization trick, which uses the model gradient. The model is written in 4 ways:
1. PythonModel (with autograd).
2. PythonModel with a manually specified gradient.
3. PyMC3Model.
4. StanModel.

**References.**
- [TensorFlow discussion](https://github.com/tensorflow/tensorflow/issues/1095) on how to define gradients of a `tf.py_func` op.
- [API for `tf.RegisterGradient`](https://www.tensorflow.org/versions/r0.9/api_docs/python/framework.html#RegisterGradient).
- [API for `tf.Graph.gradient_override_map`](https://github.com/tensorflow/tensorflow/blob/2a06837336bc29cb797c5be5605cb6188857768c/tensorflow/g3doc/api_docs/python/functions_and_classes/shard2/tf.Graph.md#tfgraphgradient_override_mapop_type_map-graphgradient_override_map).
- [GPU support for Python gradients, and in autograd](https://github.com/HIPS/autograd/issues/46).
