### PR TITLE
Forcing user to correctly seed code

### DIFF
--- a/edward/util.py
+++ b/edward/util.py
@@ -440,6 +440,10 @@ def set_seed(x):
     x : int, float
         seed
     """
+    if len(tf.get_default_graph()._nodes_by_id.keys()) > 0:
+        raise RuntimeError("Seeding is not supported after initializing part of the graph. "
+                           "Please move set_seed to the beginning of your code.")
+
     np.random.seed(x)
     tf.set_random_seed(x)
 


### PR DESCRIPTION
**Summary**

Due to holding single TF session code is not properly seeded. If you run example in a loop twice (with seeding) it will produce different results. What's maybe worse, if user places ``ed.set_seed()`` too late in a single run code (after creation of at least one random variable) it will also be stochastic.

There is no simple way of fixing that, simplest way I could think of was creating some auxiliary class for storing what initializers were used for Variables and recreating all Variables in the graph when running ``ed.set_seed()``.

Instead I propose to force user to place ``ed.set_seed()`` before creating any variables. Now code produces a RuntimeError if user does differently.

(This is continuation of https://github.com/blei-lab/edward/pull/119 and #74)

Reference on seeding in TF: https://www.tensorflow.org/versions/r0.8/api_docs/python/constant_op.html#set_random_seed

**How to verify**

This snippet now throws error instead of producing incosistent results despite seeding
```
class BetaBernoulli:
    """p(x, z) = Bernoulli(x | z) * Beta(z | 1, 1)"""
    def log_prob(self, xs, zs):
        log_prior = beta.logpdf(zs, a=1.0, b=1.0)
        log_lik = tf.pack([tf.reduce_sum(bernoulli.logpmf(xs['x'], z))
                           for z in tf.unpack(zs)])
        return log_lik + log_prior


model = BetaBernoulli()
variational = Variational()
variational.add(Beta())
data = {'x': np.array([0, 1, 0, 0, 0, 0, 0, 0, 0, 1])}

ed.set_seed(42)
inference = ed.MFVI(model, variational, data)
inference.run(n_iter=10)
```

**Reviewer Suggestions**
@dustinvtran 