### PR TITLE
fix pymc3model bug

### DIFF
--- a/edward/models/models.py
+++ b/edward/models/models.py
@@ -16,7 +16,6 @@ except ImportError:
     pass
 
 try:
-    #import pymc3 as pm
     from theano import theano, scalar, tensor as tt
     from theano.gof.graph import inputs
     def makeiter(a):
@@ -117,11 +116,9 @@ class PyMC3Model(object):
         """
         self.model = model
 
-        #vars = pm.inputvars(model.cont_vars)
         vars = [v for v in inputs(makeiter(model.cont_vars)) if isinstance(v, tt.TensorVariable)]
         self.n_vars = len(vars)
 
-        #bij = pm.DictToArrayBijection(pm.ArrayOrdering(vars), model.test_point)
         bij = DictToArrayBijection(ArrayOrdering(vars), model.test_point)
         self.logp = bij.mapf(model.fastlogp)
         self.dlogp = bij.mapf(model.fastdlogp(vars))

--- a/edward/models/models.py
+++ b/edward/models/models.py
@@ -16,7 +16,89 @@ except ImportError:
     pass
 
 try:
-    import pymc3 as pm
+    #import pymc3 as pm
+    from theano import theano, scalar, tensor as tt
+    from theano.gof.graph import inputs
+    def makeiter(a):
+        if isinstance(a, (tuple, list)):
+            return a
+        else:
+            return [a]
+
+    import collections
+    VarMap = collections.namedtuple('VarMap', 'var, slc, shp, dtyp')
+
+    class ArrayOrdering(object):
+        """
+        An ordering for an array space
+        """
+        def __init__(self, vars):
+            self.vmap = []
+            dim = 0
+
+            for var in vars:
+                slc = slice(dim, dim + var.dsize)
+                self.vmap.append(VarMap(str(var), slc, var.dshape, var.dtype))
+                dim += var.dsize
+
+            self.dimensions = dim
+
+    class DictToArrayBijection(object):
+        """
+        A mapping between a dict space and an array space
+        """
+        def __init__(self, ordering, dpoint):
+            self.ordering = ordering
+            self.dpt = dpoint
+
+        def map(self, dpt):
+            """
+            Maps value from dict space to array space
+            Parameters
+            ----------
+            dpt : dict
+            """
+            apt = np.empty(self.ordering.dimensions)
+            for var, slc, _, _ in self.ordering.vmap:
+                apt[slc] = dpt[var].ravel()
+            return apt
+
+        def rmap(self, apt):
+            """
+            Maps value from array space to dict space
+            Parameters
+            ----------
+            apt : array
+            """
+            dpt = self.dpt.copy()
+
+            for var, slc, shp, dtyp in self.ordering.vmap:
+                dpt[var] = np.atleast_1d(apt)[slc].reshape(shp).astype(dtyp)
+
+            return dpt
+
+        def mapf(self, f):
+            """
+             function f : DictSpace -> T to ArraySpace -> T
+            Parameters
+            ----------
+            f : dict -> T
+            Returns
+            -------
+            f : array -> T
+            """
+            return Compose(f, self.rmap)
+
+    class Compose(object):
+        """
+        Compose two functions in a pickleable way
+        """
+        def __init__(self, fa, fb):
+            self.fa = fa
+            self.fb = fb
+
+        def __call__(self, x):
+            return self.fa(self.fb(x))
 except ImportError:
     pass
 
@@ -35,10 +117,12 @@ class PyMC3Model(object):
         """
         self.model = model
 
-        vars = pm.inputvars(model.cont_vars)
+        #vars = pm.inputvars(model.cont_vars)
+        vars = [v for v in inputs(makeiter(model.cont_vars)) if isinstance(v, tt.TensorVariable)]
         self.n_vars = len(vars)
 
-        bij = pm.DictToArrayBijection(pm.ArrayOrdering(vars), model.test_point)
+        #bij = pm.DictToArrayBijection(pm.ArrayOrdering(vars), model.test_point)
+        bij = DictToArrayBijection(ArrayOrdering(vars), model.test_point)
         self.logp = bij.mapf(model.fastlogp)
         self.dlogp = bij.mapf(model.fastdlogp(vars))
 


### PR DESCRIPTION
Recent installations of PyMC3 will not work with our `PyMC3Model` wrapper. It errors with `inputvars` not found in the PyMC3 module.

This pull request (https://github.com/pymc-devs/pymc3/pull/1257) removed `core.py`. It used to import to `__init__.py` the method `inputvars`  via `theanof.py`, and the method `DictToArrayBijection` and `ArrayOrdering` via `blocking.py`.

In this pull request, I manually added all the required methods via copy-pastes. `PyMC3Model` now works. But I don't suggest we do this. This pull request will be useful to discuss what our next steps should be. Perhaps we should contact the PyMC3 devs on their API plan.