### PR TITLE
Fixes integer truncation for BetaBern example.

### DIFF
--- a/examples/beta_bernoulli_ppc.py
+++ b/examples/beta_bernoulli_ppc.py
@@ -50,5 +50,5 @@ data = {'x': np.array([0, 1, 0, 0, 0, 0, 0, 0, 0, 1])}
 inference = ed.MFVI(model, variational, data)
 inference.run(n_iter=200)
 
-T = lambda x, z=None: tf.reduce_mean(x['x'])
+T = lambda x, z=None: tf.reduce_mean(tf.cast(x['x'], tf.float32))
 print(ed.ppc(model, variational, data, T))


### PR DESCRIPTION
It appears that because of integer dataset in the Beta Bernoulli example
that `ed.ppc` will return the mean of the dataset, but truncated to an
integer.  As such, I'm getting 1s in the event each sample was a 1 and
0s otherwise.

I'd be happy to update the docs (such as the delving in) to reflect this change,
but I wasn't sure if making the change to the docs would be worth the added
mental challenge of thinking about integer math.