### PR TITLE
add predict() function for mixture_gaussian.py example

### DIFF
--- a/examples/mixture_gaussian.py
+++ b/examples/mixture_gaussian.py
@@ -98,24 +98,38 @@ class MixtureGaussian:
 
         return log_prior + tf.pack(log_lik)
 
+    def predict(self, xs, zs):
+        """Return matrix with log-likelihoods for each data point under each cluster, 
+        averaging over each set of latent variables z in zs."""
+        x = xs['x']
+        pi, mus, sigmas = zs
+        pi = tf.reduce_mean(pi, 0)
+        mus = tf.reduce_mean(mus, 0)
+        sigmas = tf.reduce_mean(sigmas, 0)
+
+        matrix = []
+        for k in range(self.K):
+            matrix += [multivariate_normal.logpdf(x,
+                               mus[(k*self.D):((k+1)*self.D)],
+                               sigmas[(k*self.D):((k+1)*self.D)])]
+
+        return tf.pack(matrix)
 
 def build_toy_dataset(N):
     pi = np.array([0.4, 0.6])
     mus = [[1, 1], [-1, -1]]
     stds = [[0.1, 0.1], [0.1, 0.1]]
     x = np.zeros((N, 2), dtype=np.float32)
-    colors = cm.rainbow(np.linspace(0, 1, 2))
     for n in range(N):
         k = np.argmax(np.random.multinomial(1, pi))
         x[n, :] = np.random.multivariate_normal(mus[k], np.diag(stds[k]))
-        plt.scatter(x[n, 0], x[n, 1], color=colors[k])
-
-    plt.show()
     return {'x': x}
 
 
 ed.set_seed(42)
 data = build_toy_dataset(500)
+plt.scatter(data['x'][:, 0], data['x'][:, 1])
+plt.show()
 
 model = MixtureGaussian(K=2, D=2)
 variational = Variational()
@@ -125,3 +139,7 @@ variational.add(InvGamma(model.K*model.D))
 
 inference = ed.MFVI(model, variational, data)
 inference.run(n_iter=4000, n_samples=50, n_minibatch=10)
+
+clusters = np.argmax(ed.evaluate('log_likelihood', model, variational, data), axis=0)
+plt.scatter(data['x'][:, 0], data['x'][:, 1], c=clusters, cmap=cm.bwr)
+plt.show()

--- a/examples/mixture_gaussian.py
+++ b/examples/mixture_gaussian.py
@@ -115,6 +115,7 @@ class MixtureGaussian:
 
         return tf.pack(matrix)
 
+
 def build_toy_dataset(N):
     pi = np.array([0.4, 0.6])
     mus = [[1, 1], [-1, -1]]
@@ -129,6 +130,7 @@ def build_toy_dataset(N):
 ed.set_seed(42)
 data = build_toy_dataset(500)
 plt.scatter(data['x'][:, 0], data['x'][:, 1])
+plt.title("Artificial dataset")
 plt.show()
 
 model = MixtureGaussian(K=2, D=2)
@@ -142,4 +144,5 @@ inference.run(n_iter=4000, n_samples=50, n_minibatch=10)
 
 clusters = np.argmax(ed.evaluate('log_likelihood', model, variational, data), axis=0)
 plt.scatter(data['x'][:, 0], data['x'][:, 1], c=clusters, cmap=cm.bwr)
+plt.title("Estimated cluster assignments")
 plt.show()


### PR DESCRIPTION
This improves the mixture_gaussian.py example by adding a predict() function, in order to estimate the most likely cluster assignments based on the (log)likelihood of the data point under the different gaussians. A visualization of the estimated cluster assignments for the artificial dataset of the example shows that it recovers the correct assignments. 