### PR TITLE
remove multiple set_seed statements

### DIFF
--- a/examples/bayesian_linear_regression.py
+++ b/examples/bayesian_linear_regression.py
@@ -60,7 +60,6 @@ class LinearModel:
 
 
 def build_toy_dataset(N=40, noise_std=0.1):
-  ed.set_seed(0)
   x = np.concatenate([np.linspace(0, 2, num=N / 2),
                       np.linspace(6, 8, num=N / 2)])
   y = 0.075 * x + norm.rvs(0, noise_std, size=N)

--- a/examples/bayesian_linear_regression_plot.py
+++ b/examples/bayesian_linear_regression_plot.py
@@ -61,7 +61,6 @@ class LinearModel:
 
 
 def build_toy_dataset(N=40, noise_std=0.1):
-  ed.set_seed(0)
   x = np.concatenate([np.linspace(0, 2, num=N / 2),
                       np.linspace(6, 8, num=N / 2)])
   y = 0.075 * x + norm.rvs(0, noise_std, size=N)

--- a/examples/bayesian_nn.py
+++ b/examples/bayesian_nn.py
@@ -96,7 +96,6 @@ class BayesianNN:
 
 
 def build_toy_dataset(N=40, noise_std=0.1):
-  ed.set_seed(0)
   D = 1
   x = np.concatenate([np.linspace(0, 2, num=N / 2),
                       np.linspace(6, 8, num=N / 2)])

--- a/examples/bayesian_nn_analytic_kl.py
+++ b/examples/bayesian_nn_analytic_kl.py
@@ -90,7 +90,6 @@ class BayesianNN:
 
 
 def build_toy_dataset(N=40, noise_std=0.1):
-  ed.set_seed(0)
   D = 1
   x = np.concatenate([np.linspace(0, 2, num=N / 2),
                       np.linspace(6, 8, num=N / 2)])

--- a/examples/hierarchical_logistic_regression.py
+++ b/examples/hierarchical_logistic_regression.py
@@ -68,7 +68,6 @@ class HierarchicalLogistic:
 
 
 def build_toy_dataset(N=40, noise_std=0.1):
-  ed.set_seed(0)
   D = 1
   x = np.linspace(-3, 3, num=N)
   y = np.tanh(x) + norm.rvs(0, noise_std, size=N)


### PR DESCRIPTION
#### Summary:

+ fixes some examples under `/examples` to only call `set_seed` once.

#### Intended Effect:

See above.

#### How to Verify:

Look at code. Run tests.

#### Side Effects:

None.

#### Documentation:

None.

#### Reviewer Suggestions:

@dustinvtran 