### PR TITLE
moved set_seeds within testing functions

### DIFF
--- a/tests/test-models/test_bernoulli_log_prob_idx.py
+++ b/tests/test-models/test_bernoulli_log_prob_idx.py
@@ -9,8 +9,6 @@ import tensorflow as tf
 from edward.models import Bernoulli
 from scipy import stats
 
-ed.set_seed(98765)
-
 
 def _test(shape, n):
   rv = Bernoulli(shape, p=tf.zeros(shape) + 0.5)
@@ -26,6 +24,7 @@ def _test(shape, n):
 class test_bernoulli_log_prob_idx_class(tf.test.TestCase):
 
   def test_1d(self):
+    ed.set_seed(98765)
     with self.test_session():
       _test((1, ), 1)
       _test((1, ), 5)

--- a/tests/test-models/test_beta_log_prob_idx.py
+++ b/tests/test-models/test_beta_log_prob_idx.py
@@ -9,8 +9,6 @@ import tensorflow as tf
 from edward.models import Beta
 from scipy import stats
 
-ed.set_seed(98765)
-
 
 def _test(shape, n):
   rv = Beta(shape, alpha=tf.zeros(shape) + 0.5, beta=tf.zeros(shape) + 0.5)
@@ -27,6 +25,7 @@ def _test(shape, n):
 class test_beta_log_prob_idx_class(tf.test.TestCase):
 
   def test_1d(self):
+    ed.set_seed(98765)
     with self.test_session():
       _test((1, ), 1)
       _test((1, ), 5)

--- a/tests/test-models/test_dirichlet_log_prob_idx.py
+++ b/tests/test-models/test_dirichlet_log_prob_idx.py
@@ -9,8 +9,6 @@ import tensorflow as tf
 from edward.models import Dirichlet
 from scipy import stats
 
-ed.set_seed(98765)
-
 
 def dirichlet_logpdf_vec(x, alpha):
   """Vectorized version of stats.dirichlet.logpdf."""
@@ -43,6 +41,7 @@ def _test(shape, n):
 class test_dirichlet_log_prob_idx_class(tf.test.TestCase):
 
   def test_1d(self):
+    ed.set_seed(98765)
     with self.test_session():
       _test((2, ), 1)
       _test((2, ), 2)

--- a/tests/test-models/test_distribution_log_prob.py
+++ b/tests/test-models/test_distribution_log_prob.py
@@ -9,8 +9,6 @@ import tensorflow as tf
 from edward.models import Bernoulli
 from scipy import stats
 
-ed.set_seed(98765)
-
 
 def _test(shape, n):
   # using Bernoulli's internally implemented log_prob_idx() to check
@@ -32,6 +30,7 @@ def _test(shape, n):
 class test_distribution_log_prob_class(tf.test.TestCase):
 
   def test_1d(self):
+    ed.set_seed(98765)
     with self.test_session():
       _test((1, ), 1)
       _test((1, ), 5)

--- a/tests/test-models/test_invgamma_log_prob_idx.py
+++ b/tests/test-models/test_invgamma_log_prob_idx.py
@@ -9,8 +9,6 @@ import tensorflow as tf
 from edward.models import InvGamma
 from scipy import stats
 
-ed.set_seed(98765)
-
 
 def _test(shape, n):
   rv = InvGamma(shape, alpha=tf.zeros(shape) + 0.5, beta=tf.zeros(shape) + 0.5)
@@ -28,6 +26,7 @@ def _test(shape, n):
 class test_invgamma_log_prob_idx_class(tf.test.TestCase):
 
   def test_1d(self):
+    ed.set_seed(98765)
     with self.test_session():
       _test((1, ), 1)
       _test((1, ), 5)

--- a/tests/test-models/test_multinomial_log_prob_idx.py
+++ b/tests/test-models/test_multinomial_log_prob_idx.py
@@ -9,8 +9,6 @@ import tensorflow as tf
 from edward.models import Multinomial
 from scipy.special import gammaln
 
-ed.set_seed(98765)
-
 
 def multinomial_logpmf(x, n, p):
   """
@@ -56,6 +54,7 @@ def _test(shape, n):
 class test_multinomial_log_prob_idx_class(tf.test.TestCase):
 
   def test_1d(self):
+    ed.set_seed(98765)
     with self.test_session():
       _test((2, ), 1)
       _test((2, ), 2)

--- a/tests/test-models/test_normal_log_prob_idx.py
+++ b/tests/test-models/test_normal_log_prob_idx.py
@@ -9,8 +9,6 @@ import tensorflow as tf
 from edward.models import Normal
 from scipy import stats
 
-ed.set_seed(98765)
-
 
 def _test(shape, n):
   rv = Normal(shape, loc=tf.zeros(shape), scale=tf.ones(shape))
@@ -27,6 +25,7 @@ def _test(shape, n):
 class test_normal_log_prob_idx_class(tf.test.TestCase):
 
   def test_1d(self):
+    ed.set_seed(98765)
     with self.test_session():
       _test((1, ), 1)
       _test((1, ), 5)

--- a/tests/test-models/test_pointmass_log_prob_idx.py
+++ b/tests/test-models/test_pointmass_log_prob_idx.py
@@ -9,8 +9,6 @@ import tensorflow as tf
 from edward.models import PointMass
 from scipy import stats
 
-ed.set_seed(98765)
-
 
 def pointmass_logpmf_vec(x, params):
   """Vectorized log-density for point mass distribution."""
@@ -31,6 +29,7 @@ def _test(shape, n):
 class test_pointmass_log_prob_idx_class(tf.test.TestCase):
 
   def test_1d(self):
+    ed.set_seed(98765)
     with self.test_session():
       _test((1, ), 1)
       _test((1, ), 5)

--- a/tests/test_inference_data.py
+++ b/tests/test_inference_data.py
@@ -10,8 +10,6 @@ import six
 from edward.models import Variational, Normal
 from edward.stats import norm
 
-ed.set_seed(1512351)
-
 
 class NormalModel:
   """
@@ -112,4 +110,5 @@ class test_inference_data_class(tf.test.TestCase):
       self._test(sess, data, None, is_file=True)
 
 if __name__ == '__main__':
+  ed.set_seed(1512351)
   tf.test.main()


### PR DESCRIPTION
#### Summary:

+ fixed `set_seed` in a few test functions to pass `py.test` PEP8 collection

#### Intended Effect:

See above.

#### How to Verify:

Look at code. Run tests.

#### Side Effects:

None.

#### Documentation:

None.

#### Reviewer Suggestions:

@dustinvtran 