### PR TITLE
Feature/edward stats

### DIFF
--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -15,8 +15,8 @@ We detail specifics for each modeling language below.
   class BetaBernoulli:
     def log_prob(self, xs, zs):
       log_prior = beta.logpdf(zs['p'], a=1.0, b=1.0)
-      log_lik = tf.pack([tf.reduce_sum(bernoulli.logpmf(xs['x'], z))
-                         for z in tf.unpack(zs['p'])])
+      log_lik = tf.pack([tf.reduce_sum(bernoulli.logpmf(xs['x'], p=p))
+                         for p in tf.unpack(zs['p'])])
       return log_lik + log_prior
 
   model = BetaBernoulli()

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -28,11 +28,11 @@ evaluation for each set of latent variables. Here is an example:
   from edward.stats import bernoulli, beta
 
   class BetaBernoulli:
-    """p(x, z) = Bernoulli(x | z) * Beta(z | 1, 1)"""
+    """p(x, p) = Bernoulli(x | p) * Beta(p | 1, 1)"""
     def log_prob(self, xs, zs):
       log_prior = beta.logpdf(zs['p'], a=1.0, b=1.0)
-      log_lik = tf.pack([tf.reduce_sum(bernoulli.logpmf(xs['x'], z))
-                         for z in tf.unpack(zs['p'])])
+      log_lik = tf.pack([tf.reduce_sum(bernoulli.logpmf(xs['x'], p=p))
+                         for p in tf.unpack(zs['p'])])
       return log_lik + log_prior
 
   model = BetaBernoulli()
@@ -65,7 +65,7 @@ Here is an example:
   from scipy.stats import bernoulli, beta
 
   class BetaBernoulli(PythonModel):
-    """p(x, z) = Bernoulli(x | z) * Beta(z | 1, 1)"""
+    """p(x, p) = Bernoulli(x | p) * Beta(p | 1, 1)"""
     def _py_log_prob(self, xs, zs):
       # This example is written for pedagogy. We recommend
       # vectorizing operations in practice.

--- a/docs/tex/getting-started.tex
+++ b/docs/tex/getting-started.tex
@@ -49,7 +49,7 @@ class BayesianNN:
         # Specify the likelihood. Its mean is the output of a neural
         # network taking `x` as input with weights `zs`.
         mus = self.neural_network(x, zs)
-        log_lik = tf.reduce_sum(norm.logpdf(y, loc=mus, scale=1), 1)
+        log_lik = tf.reduce_sum(norm.logpdf(y, mu=mus, sigma=1.0), 1)
         return log_prior + log_lik
 \end{lstlisting}
 

--- a/docs/tex/tut_gp_classification.tex
+++ b/docs/tex/tut_gp_classification.tex
@@ -65,7 +65,7 @@ class GaussianProcess:
   Gaussian process classification
 
   p((x,y), z) = Bernoulli(y | logit^{-1}(x*z)) *
-          Normal(z | 0, K),
+                Normal(z | 0, K),
 
   where z are weights drawn from a GP with covariance given by k(x,
   x') for each pair of inputs (x, x'), and with squared-exponential
@@ -109,7 +109,7 @@ class GaussianProcess:
     x, y = xs['x'], xs['y']
     log_prior = multivariate_normal.logpdf(zs['z'], cov=self.kernel(x))
     log_lik = tf.pack([tf.reduce_sum(
-                       bernoulli.logpmf(y, self.inverse_link(tf.mul(y, z))))
+                       bernoulli.logpmf(y, p=self.inverse_link(tf.mul(y, z))))
                        for z in tf.unpack(zs['z'])])
     return log_prior + log_lik
 

--- a/docs/tex/tut_latent_space_models.tex
+++ b/docs/tex/tut_latent_space_models.tex
@@ -104,7 +104,7 @@ class LatentSpaceModel:
       xp = tf.matmul(z, z, transpose_b=True)
 
     if self.like == 'Gaussian':
-      log_lik = tf.reduce_sum(norm.logpdf(xs['x'], xp))
+      log_lik = tf.reduce_sum(norm.logpdf(xs['x'], xp, 1.0))
     elif self.like == 'Poisson':
       if not (self.dist == 'euclidean' or self.prior == "Lognormal"):
         raise NotImplementedError("Rate of Poisson has to be nonnegatve.")

--- a/docs/tex/tut_mixture_gaussian.tex
+++ b/docs/tex/tut_mixture_gaussian.tex
@@ -108,9 +108,9 @@ class MixtureGaussian:
     self.D = D
     self.n_vars = (2 * D + 1) * K
 
-    self.a = 1
-    self.b = 1
-    self.c = 10
+    self.a = 1.0
+    self.b = 1.0
+    self.c = 3.0
     self.alpha = tf.ones([K])
 
   def log_prob(self, xs, zs):
@@ -118,7 +118,7 @@ class MixtureGaussian:
     x = xs['x']
     pi, mus, sigmas = zs['pi'], zs['mu'], zs['sigma']
     log_prior = dirichlet.logpdf(pi, self.alpha)
-    log_prior += tf.reduce_sum(norm.logpdf(mus, 0, np.sqrt(self.c)), 1)
+    log_prior += tf.reduce_sum(norm.logpdf(mus, 0.0, self.c), 1)
     log_prior += tf.reduce_sum(invgamma.logpdf(sigmas, self.a, self.b), 1)
 
     # Loop over each sample zs[s, :].

--- a/docs/tex/tut_supervised_classification.tex
+++ b/docs/tex/tut_supervised_classification.tex
@@ -39,7 +39,7 @@ class GaussianProcess:
   Gaussian process classification
 
   p((x,y), z) = Bernoulli(y | logit^{-1}(x*z)) *
-          Normal(z | 0, K),
+                Normal(z | 0, K),
 
   where z are weights drawn from a GP with covariance given by k(x,
   x') for each pair of inputs (x, x'), and with squared-exponential
@@ -83,7 +83,7 @@ class GaussianProcess:
     x, y = xs['x'], xs['y']
     log_prior = multivariate_normal.logpdf(zs['z'], cov=self.kernel(x))
     log_lik = tf.pack([tf.reduce_sum(
-                       bernoulli.logpmf(y, self.inverse_link(tf.mul(y, z))))
+                       bernoulli.logpmf(y, p=self.inverse_link(tf.mul(y, z))))
                        for z in tf.unpack(zs['z'])])
     return log_prior + log_lik
 

--- a/docs/tex/tut_unsupervised.tex
+++ b/docs/tex/tut_unsupervised.tex
@@ -72,9 +72,9 @@ class MixtureGaussian:
     self.D = D
     self.n_vars = (2 * D + 1) * K
 
-    self.a = 1
-    self.b = 1
-    self.c = 10
+    self.a = 1.0
+    self.b = 1.0
+    self.c = 3.0
     self.alpha = tf.ones([K])
 
   def log_prob(self, xs, zs):
@@ -82,7 +82,7 @@ class MixtureGaussian:
     x = xs['x']
     pi, mus, sigmas = zs['pi'], zs['mu'], zs['sigma']
     log_prior = dirichlet.logpdf(pi, self.alpha)
-    log_prior += tf.reduce_sum(norm.logpdf(mus, 0, np.sqrt(self.c)), 1)
+    log_prior += tf.reduce_sum(norm.logpdf(mus, 0.0, self.c), 1)
     log_prior += tf.reduce_sum(invgamma.logpdf(sigmas, self.a, self.b), 1)
 
     # Loop over each sample zs[s, :].

--- a/edward/inferences.py
+++ b/edward/inferences.py
@@ -103,7 +103,7 @@ class Inference(object):
           # If ``data`` has tensors that are the output of
           # data readers, then batch training operates
           # according to the reader.
-          self.data[key] = value
+          self.data[key] = tf.cast(value, tf.float32)
         elif isinstance(value, np.ndarray):
           # If ``data`` has NumPy arrays, store the data
           # in the computational graph.

--- a/edward/stats/distributions.py
+++ b/edward/stats/distributions.py
@@ -5,14 +5,124 @@ from __future__ import print_function
 import numpy as np
 import tensorflow as tf
 
-from edward.util import dot, get_dims
+from edward.util import get_dims
 from itertools import product
 from scipy import stats
 
+distributions = tf.contrib.distributions
 
-class Bernoulli(object):
+
+class Distribution(object):
+  """A light wrapper to directly call methods from
+  `tf.contrib.distributions` in SciPy style.
+
+  Examples
+  --------
+  >>> norm.logpdf(tf.constant(0.0))
+  >>> bernoulli.logpmf(tf.constant([0.0, 1.0]), p=tf.constant([0.5, 0.4]))
+  """
+  def __init__(self, dist):
+    self._dist = dist
+
+  def batch_shape(self, *args, **kwargs):
+    rv = self._dist(*args, **kwargs)
+    return rv.batch_shape()
+
+  def get_batch_shape(self, *args, **kwargs):
+    rv = self._dist(*args, **kwargs)
+    return rv.get_batch_shape()
+
+  def event_shape(self, *args, **kwargs):
+    rv = self._dist(*args, **kwargs)
+    return rv.event_shape()
+
+  def get_event_shape(self, *args, **kwargs):
+    rv = self._dist(*args, **kwargs)
+    return rv.get_event_shape()
+
+  def sample(self, sample_shape=(), seed=None, *args, **kwargs):
+    rv = self._dist(*args, **kwargs)
+    return rv.sample(sample_shape, seed)
+
+  def sample_n(self, n, seed=None, *args, **kwargs):
+    rv = self._dist(*args, **kwargs)
+    return rv.sample_n(n, seed)
+
+  def log_prob(self, value, *args, **kwargs):
+    rv = self._dist(*args, **kwargs)
+    return rv.log_prob(value)
+
+  def prob(self, value, *args, **kwargs):
+    rv = self._dist(*args, **kwargs)
+    return rv.prob(value)
+
+  def log_cdf(self, value, *args, **kwargs):
+    rv = self._dist(*args, **kwargs)
+    return rv.log_cdf(value)
+
+  def cdf(self, value, *args, **kwargs):
+    rv = self._dist(*args, **kwargs)
+    return rv.cdf(value)
+
+  def entropy(self, *args, **kwargs):
+    rv = self._dist(*args, **kwargs)
+    return rv.entropy()
+
+  def mean(self, *args, **kwargs):
+    rv = self._dist(*args, **kwargs)
+    return rv.mean()
+
+  def variance(self, *args, **kwargs):
+    rv = self._dist(*args, **kwargs)
+    return rv.variance()
+
+  def std(self, *args, **kwargs):
+    rv = self._dist(*args, **kwargs)
+    return rv.std()
+
+  def mode(self, *args, **kwargs):
+    rv = self._dist(*args, **kwargs)
+    return rv.mode()
+
+  def log_pdf(self, value, *args, **kwargs):
+    rv = self._dist(*args, **kwargs)
+    return rv.log_pdf(value)
+
+  def pdf(self, value, *args, **kwargs):
+    rv = self._dist(*args, **kwargs)
+    return rv.pdf(value)
+
+  def log_pmf(self, value, *args, **kwargs):
+    rv = self._dist(*args, **kwargs)
+    return rv.log_pmf(value)
+
+  def pmf(self, value, *args, **kwargs):
+    rv = self._dist(*args, **kwargs)
+    return rv.pmf(value)
+
+  def rvs(self, *args, **kwargs):
+    """Returns samples as a NumPy array. Unlike the other methods,
+    this method follows the arguments of SciPy.
+    """
+    raise NotImplementedError()
+
+  def logpdf(self, value, *args, **kwargs):
+    """Backwards compatibility with SciPy."""
+    rv = self._dist(*args, **kwargs)
+    return rv.log_pdf(value)
+
+  def logpmf(self, value, *args, **kwargs):
+    """Backwards compatibility with SciPy."""
+    rv = self._dist(*args, **kwargs)
+    return rv.log_pmf(value)
+
+
+class Bernoulli(Distribution):
   """Bernoulli distribution.
   """
+  def __init__(self):
+    super(Bernoulli, self).__init__(distributions.Bernoulli)
+
   def rvs(self, p, size=1):
     """Random variates.
 
@@ -53,47 +163,13 @@ class Bernoulli(object):
     x = np.asarray(x).transpose()
     return x
 
-  def logpmf(self, x, p):
-    """Log of the probability mass function.
 
-    Parameters
-    ----------
-    x : tf.Tensor
-      A n-D tensor.
-    p : tf.Tensor
-      A tensor of same shape as ``x``, and with all elements
-      constrained to :math:`p\in(0,1)`.
-
-    Returns
-    -------
-    tf.Tensor
-      A tensor of same shape as input.
-    """
-    x = tf.cast(x, dtype=tf.float32)
-    p = tf.cast(p, dtype=tf.float32)
-    return x * tf.log(p) + (1.0 - x) * tf.log(1.0 - p)
-
-  def entropy(self, p):
-    """Entropy of probability distribution.
-
-    Parameters
-    ----------
-    p : tf.Tensor
-      A n-D tensor with all elements constrained to
-      :math:`p\in(0,1)`.
-
-    Returns
-    -------
-    tf.Tensor
-      A tensor of same shape as input.
-    """
-    p = tf.cast(p, dtype=tf.float32)
-    return -p * tf.log(p) - (1.0 - p) * tf.log(1.0 - p)
-
-
-class Beta(object):
+class Beta(Distribution):
   """Beta distribution.
   """
+  def __init__(self):
+    super(Beta, self).__init__(distributions.Beta)
+
   def rvs(self, a, b, size=1):
     """Random variates.
 
@@ -128,66 +204,13 @@ class Beta(object):
     x = np.asarray(x).transpose()
     return x
 
-  def logpdf(self, x, a, b):
-    """Log of the probability density function.
 
-    Parameters
-    ----------
-    x : tf.Tensor
-      A n-D tensor.
-    a : tf.Tensor
-      A tensor of same shape as ``x``, and with all elements
-      constrained to :math:`a > 0`.
-    b : tf.Tensor
-      A tensor of same shape as ``x``, and with all elements
-      constrained to :math:`b > 0`.
-
-    Returns
-    -------
-    tf.Tensor
-      A tensor of same shape as input.
-    """
-    x = tf.cast(x, dtype=tf.float32)
-    a = tf.cast(tf.squeeze(a), dtype=tf.float32)
-    b = tf.cast(tf.squeeze(b), dtype=tf.float32)
-    return (a - 1.0) * tf.log(x) + (b - 1.0) * tf.log(1.0 - x) - \
-        tf.lbeta(tf.pack([a, b]))
-
-  def entropy(self, a, b):
-    """Entropy of probability distribution.
-
-    Parameters
-    ----------
-    a : tf.Tensor
-      A n-D tensor with all elements constrained to :math:`a >
-      0`.
-    b : tf.Tensor
-      A n-D tensor with all elements constrained to :math:`b >
-      0`.
-
-    Returns
-    -------
-    tf.Tensor
-      A tensor of same shape as input.
-    """
-    a = tf.cast(tf.squeeze(a), dtype=tf.float32)
-    b = tf.cast(tf.squeeze(b), dtype=tf.float32)
-    if len(a.get_shape()) == 0:
-      return tf.lbeta(tf.pack([a, b])) - \
-          (a - 1.0) * tf.digamma(a) - \
-          (b - 1.0) * tf.digamma(b) + \
-          (a + b - 2.0) * tf.digamma(a + b)
-    else:
-      return tf.lbeta(tf.concat(1, [tf.expand_dims(a, 1),
-                                    tf.expand_dims(b, 1)])) - \
-          (a - 1.0) * tf.digamma(a) - \
-          (b - 1.0) * tf.digamma(b) + \
-          (a + b - 2.0) * tf.digamma(a + b)
-
-
-class Binom(object):
+class Binom(Distribution):
   """Binomial distribution.
   """
+  def __init__(self):
+    super(Binom, self).__init__(None)
+
   def rvs(self, n, p, size=1):
     """Random variates.
 
@@ -224,7 +247,6 @@ class Binom(object):
 
   def logpmf(self, x, n, p):
     """Log of the probability density function.
-
     Parameters
     ----------
     x : tf.Tensor
@@ -235,7 +257,6 @@ class Binom(object):
     p : tf.Tensor
       A tensor of same shape as ``x``, and with all elements
       constrained to :math:`p\in(0,1)`.
-
     Returns
     -------
     tf.Tensor
@@ -247,18 +268,20 @@ class Binom(object):
     return tf.lgamma(n + 1.0) - tf.lgamma(x + 1.0) - tf.lgamma(n - x + 1.0) + \
         x * tf.log(p) + (n - x) * tf.log(1.0 - p)
 
-  def entropy(self, n, p):
-    """
-    Raises
-    ------
-    NotImplementedError
-    """
-    raise NotImplementedError()
+
+class Categorical(Distribution):
+  """Categorical distribution.
+  """
+  def __init__(self):
+    super(Categorical, self).__init__(distributions.Categorical)
 
 
-class Chi2(object):
+class Chi2(Distribution):
   """:math:`\chi^2` distribution.
   """
+  def __init__(self):
+    super(Chi2, self).__init__(None)
+
   def rvs(self, df, size=1):
     """Random variates.
 
@@ -290,7 +313,6 @@ class Chi2(object):
 
   def logpdf(self, x, df):
     """Log of the probability density function.
-
     Parameters
     ----------
     x : tf.Tensor
@@ -298,7 +320,6 @@ class Chi2(object):
     df : tf.Tensor
       A tensor of same shape as ``x``, and with all elements
       constrained to :math:`df > 0`.
-
     Returns
     -------
     tf.Tensor
@@ -309,18 +330,13 @@ class Chi2(object):
     return (0.5 * df - 1) * tf.log(x) - 0.5 * x - \
         0.5 * df * tf.log(2.0) - tf.lgamma(0.5 * df)
 
-  def entropy(self, df):
-    """
-    Raises
-    ------
-    NotImplementedError
-    """
-    raise NotImplementedError()
 
-
-class Dirichlet(object):
+class Dirichlet(Distribution):
   """Dirichlet distribution.
   """
+  def __init__(self):
+    super(Dirichlet, self).__init__(distributions.Dirichlet)
+
   def rvs(self, alpha, size=1):
     """Random variates.
 
@@ -350,64 +366,21 @@ class Dirichlet(object):
     x = np.rollaxis(np.asarray(x), 1)
     return x
 
-  def logpdf(self, x, alpha):
-    """Log of the probability density function.
 
-    Parameters
-    ----------
-    x : tf.Tensor
-      A n-D tensor for n > 1, where the inner (right-most)
-      dimension represents the multivariate dimension.
-    alpha : tf.Tensor
-      A tensor of same shape as ``x``, and with each
-      :math:`\\alpha` constrained to :math:`\\alpha_i > 0`.
-
-    Returns
-    -------
-    tf.Tensor
-      A tensor of one dimension less than the input.
-    """
-    x = tf.cast(x, dtype=tf.float32)
-    alpha = tf.cast(alpha, dtype=tf.float32)
-    multivariate_idx = len(get_dims(x)) - 1
-    if multivariate_idx == 0:
-      return -tf.lbeta(alpha) + tf.reduce_sum((alpha - 1.0) * tf.log(x))
-    else:
-      return -tf.lbeta(alpha) + \
-          tf.reduce_sum((alpha - 1.0) * tf.log(x), multivariate_idx)
-
-  def entropy(self, alpha):
-    """Entropy of probability distribution.
-
-    Parameters
-    ----------
-    alpha : tf.Tensor
-      A n-D tensor with each :math:`\\alpha` constrained to
-      :math:`\\alpha_i > 0`.
-
-    Returns
-    -------
-    tf.Tensor
-      A tensor of one dimension less than the input.
-    """
-    alpha = tf.cast(alpha, dtype=tf.float32)
-    multivariate_idx = len(get_dims(alpha)) - 1
-    K = get_dims(alpha)[multivariate_idx]
-    if multivariate_idx == 0:
-      a = tf.reduce_sum(alpha)
-      return tf.lbeta(alpha) + \
-          (a - K) * tf.digamma(a) - \
-          tf.reduce_sum((alpha - 1.0) * tf.digamma(alpha))
-    else:
-      a = tf.reduce_sum(alpha, multivariate_idx)
-      return tf.lbeta(alpha) + \
-          (a - K) * tf.digamma(a) - \
-          tf.reduce_sum((alpha - 1.0) * tf.digamma(alpha), multivariate_idx)
+class DirichletMultinomial(Distribution):
+  """Dirichlet-Multinomial distribution.
+  """
+  def __init__(self):
+    super(DirichletMultinomial, self).__init__(
+        distributions.DirichletMultinomial)
 
 
-class Expon(object):
+class Exponential(Distribution):
   """Exponential distribution.
   """
+  def __init__(self):
+    super(Exponential, self).__init__(distributions.Exponential)
+
   def rvs(self, scale=1, size=1):
     """Random variates.
 
@@ -437,40 +410,15 @@ class Expon(object):
     x = np.asarray(x).transpose()
     return x
 
-  def logpdf(self, x, scale=1):
-    """Log of the probability density function.
 
-    Parameters
-    ----------
-    x : tf.Tensor
-      A n-D tensor.
-    scale : tf.Tensor
-      A tensor of same shape as ``x``, and with all elements
-      constrained to :math:`scale > 0`.
-
-    Returns
-    -------
-    tf.Tensor
-      A tensor of same shape as input.
-    """
-    x = tf.cast(x, dtype=tf.float32)
-    scale = tf.cast(scale, dtype=tf.float32)
-    return - x / scale - tf.log(scale)
-
-  def entropy(self, scale=1):
-    """
-    Raises
-    ------
-    NotImplementedError
-    """
-    raise NotImplementedError()
-
-
-class Gamma(object):
+class Gamma(Distribution):
   """Gamma distribution.
 
   Shape/scale parameterization (typically denoted: :math:`(k, \\theta)`)
   """
+  def __init__(self):
+    super(Gamma, self).__init__(distributions.Gamma)
+
   def rvs(self, a, scale=1, size=1):
     """Random variates.
 
@@ -505,55 +453,13 @@ class Gamma(object):
     x = np.asarray(x).transpose()
     return x
 
-  def logpdf(self, x, a, scale=1):
-    """Log of the probability density function.
 
-    Parameters
-    ----------
-    x : tf.Tensor
-      A n-D tensor.
-    a : tf.Tensor
-      **Shape** parameter. A tensor of same shape as ``x``, and with
-      all elements constrained to :math:`a > 0`.
-    scale : tf.Tensor
-      **Scale** parameter. A tensor of same shape as ``x``, and with
-      all elements constrained to :math:`scale > 0`.
-
-    Returns
-    -------
-    tf.Tensor
-      A tensor of same shape as input.
-    """
-    x = tf.cast(x, dtype=tf.float32)
-    a = tf.cast(a, dtype=tf.float32)
-    scale = tf.cast(scale, dtype=tf.float32)
-    return (a - 1.0) * tf.log(x) - x / scale - a * tf.log(scale) - tf.lgamma(a)
-
-  def entropy(self, a, scale=1):
-    """Entropy of probability distribution.
-
-    Parameters
-    ----------
-    a : tf.Tensor
-      **Shape** parameter. A n-D tensor with all elements
-      constrained to :math:`a > 0`.
-    scale : tf.Tensor
-      **Scale** parameter. A n-D tensor with all elements
-      constrained to :math:`scale > 0`.
-
-    Returns
-    -------
-    tf.Tensor
-      A tensor of same shape as input.
-    """
-    a = tf.cast(a, dtype=tf.float32)
-    scale = tf.cast(scale, dtype=tf.float32)
-    return a + tf.log(scale) + tf.lgamma(a) + (1.0 - a) * tf.digamma(a)
-
-
-class Geom(object):
+class Geom(Distribution):
   """Geometric distribution.
   """
+  def __init__(self):
+    super(Geom, self).__init__(None)
+
   def rvs(self, p, size=1):
     """Random variates.
 
@@ -585,7 +491,6 @@ class Geom(object):
 
   def logpmf(self, x, p):
     """Log of the probability mass function.
-
     Parameters
     ----------
     x : tf.Tensor
@@ -593,7 +498,6 @@ class Geom(object):
     p : tf.Tensor
       A tensor of same shape as ``x``, and with all elements
       constrained to :math:`p\in(0,1)`.
-
     Returns
     -------
     tf.Tensor
@@ -603,20 +507,15 @@ class Geom(object):
     p = tf.cast(p, dtype=tf.float32)
     return (x - 1) * tf.log(1.0 - p) + tf.log(p)
 
-  def entropy(self, p):
-    """
-    Raises
-    ------
-    NotImplementedError
-    """
-    raise NotImplementedError()
 
-
-class InvGamma(object):
+class InverseGamma(Distribution):
   """Inverse Gamma distribution.
 
   Shape/scale parameterization (typically denoted: :math:`(k, \\theta)`)
   """
+  def __init__(self):
+    super(InverseGamma, self).__init__(distributions.InverseGamma)
+
   def rvs(self, a, scale=1, size=1):
     """Random variates.
 
@@ -656,57 +555,20 @@ class InvGamma(object):
     x[np.logical_not(np.isfinite(x))] = 1.0
     return x
 
-  def logpdf(self, x, a, scale=1):
-    """Log of the probability density function.
 
-    Parameters
-    ----------
-    x : tf.Tensor
-      A n-D tensor.
-    a : tf.Tensor
-      **Shape** parameter. A tensor of same shape as ``x``, and with
-      all elements constrained to :math:`a > 0`.
-    scale : tf.Tensor
-      **Scale** parameter. A tensor of same shape as ``x``, and with
-      all elements constrained to :math:`scale > 0`.
-
-    Returns
-    -------
-    tf.Tensor
-      A tensor of same shape as input.
-    """
-    x = tf.cast(x, dtype=tf.float32)
-    a = tf.cast(a, dtype=tf.float32)
-    scale = tf.cast(scale, dtype=tf.float32)
-    return a * tf.log(scale) - tf.lgamma(a) + \
-        (-a - 1.0) * tf.log(x) - scale / x
-
-  def entropy(self, a, scale=1):
-    """Entropy of probability distribution.
-
-    Parameters
-    ----------
-    a : tf.Tensor
-      **Shape** parameter. A n-D tensor with all elements
-      constrained to :math:`a > 0`.
-    scale : tf.Tensor
-      **Scale** parameter. A n-D tensor with all elements
-      constrained to :math:`scale > 0`.
-
-    Returns
-    -------
-    tf.Tensor
-      A tensor of same shape as input.
-    """
-    a = tf.cast(a, dtype=tf.float32)
-    scale = tf.cast(scale, dtype=tf.float32)
-    return a + tf.log(scale * tf.exp(tf.lgamma(a))) - \
-        (1.0 + a) * tf.digamma(a)
+class Laplace(Distribution):
+  """Laplace distribution.
+  """
+  def __init__(self):
+    super(Laplace, self).__init__(distributions.Laplace)
 
 
-class LogNorm(object):
+class LogNorm(Distribution):
   """LogNormal distribution.
   """
+  def __init__(self):
+    super(LogNorm, self).__init__(None)
+
   def rvs(self, s, size=1):
     """Random variates.
 
@@ -738,7 +600,6 @@ class LogNorm(object):
 
   def logpdf(self, x, s):
     """Log of the probability density function.
-
     Parameters
     ----------
     x : tf.Tensor
@@ -746,7 +607,6 @@ class LogNorm(object):
     s : tf.Tensor
       A tensor of same shape as ``x``, and with all elements
       constrained to :math:`s > 0`.
-
     Returns
     -------
     tf.Tensor
@@ -757,20 +617,15 @@ class LogNorm(object):
     return -0.5 * tf.log(2 * np.pi) - tf.log(s) - tf.log(x) - \
         0.5 * tf.square(tf.log(x) / s)
 
-  def entropy(self, s):
-    """
-    Raises
-    ------
-    NotImplementedError
-    """
-    raise NotImplementedError()
 
-
-class Multinomial(object):
+class Multinomial(Distribution):
   """Multinomial distribution.
 
   Note: there is no equivalent version implemented in SciPy.
   """
+  def __init__(self):
+    super(Multinomial, self).__init__(None)
+
   def rvs(self, n, p, size=1):
     """Random variates.
 
@@ -808,7 +663,6 @@ class Multinomial(object):
 
   def logpmf(self, x, n, p):
     """Log of the probability mass function.
-
     Parameters
     ----------
     x : tf.Tensor
@@ -823,7 +677,6 @@ class Multinomial(object):
     p : tf.Tensor
       A tensor of one less dimension than ``x``, representing
       probabilities which sum to 1.
-
     Returns
     -------
     tf.Tensor
@@ -874,9 +727,29 @@ class Multinomial(object):
       return tf.pack(out)
 
 
-class Multivariate_Normal(object):
-  """Multivariate Normal distribution.
+class MultivariateNormalDiag(Distribution):
+  """Multivariate Normal (with diagonal covariance) distribution.
   """
+  def __init__(self):
+    super(MultivariateNormalDiag, self).__init__(
+        distributions.MultivariateNormalDiag)
+
+
+class MultivariateNormalCholesky(Distribution):
+  """Multivariate Normal (with Cholesky factorized covariance)  distribution.
+  """
+  def __init__(self):
+    super(MultivariateNormalCholesky, self).__init__(
+        distributions.MultivariateNormalCholesky)
+
+
+class MultivariateNormalFull(Distribution):
+  """Multivariate Normal (with full rank covariance) distribution.
+  """
+  def __init__(self):
+    super(MultivariateNormalFull, self).__init__(
+        distributions.MultivariateNormalFull)
+
   def rvs(self, mean=None, cov=1, size=1):
     """Random variates.
 
@@ -1007,9 +880,12 @@ class Multivariate_Normal(object):
     return 0.5 * (d + d * tf.log(2 * np.pi) + tf.log(det_cov))
 
 
-class NBinom(object):
+class NBinom(Distribution):
   """Negative binomial distribution.
   """
+  def __init__(self):
+    super(NBinom, self).__init__(None)
+
   def rvs(self, n, p, size=1):
     """Random variates.
 
@@ -1069,18 +945,13 @@ class NBinom(object):
     return tf.lgamma(x + n) - tf.lgamma(x + 1.0) - tf.lgamma(n) + \
         n * tf.log(p) + x * tf.log(1.0 - p)
 
-  def entropy(self, n, p):
-    """
-    Raises
-    ------
-    NotImplementedError
-    """
-    raise NotImplementedError()
 
-
-class Norm(object):
+class Normal(Distribution):
   """Normal (Gaussian) distribution.
   """
+  def __init__(self):
+    super(Normal, self).__init__(distributions.Normal)
+
   def rvs(self, loc=0, scale=1, size=1):
     """Random variates.
 
@@ -1114,53 +985,13 @@ class Norm(object):
     x = np.asarray(x).transpose()
     return x
 
-  def logpdf(self, x, loc=0, scale=1):
-    """Log of the probability density function.
 
-    Parameters
-    ----------
-    x : tf.Tensor
-      A n-D tensor.
-    loc : tf.Tensor
-      A tensor of same shape as ``x``.
-    scale : tf.Tensor
-      A tensor of same shape as ``x``, and with all elements
-      constrained to :math:`scale > 0`.
-
-    Returns
-    -------
-    tf.Tensor
-      A tensor of same shape as input.
-    """
-    x = tf.cast(x, dtype=tf.float32)
-    loc = tf.cast(loc, dtype=tf.float32)
-    scale = tf.cast(scale, dtype=tf.float32)
-    z = (x - loc) / scale
-    return -0.5 * tf.log(2 * np.pi) - tf.log(scale) - 0.5 * tf.square(z)
-
-  def entropy(self, loc=0, scale=1):
-    """Entropy of probability distribution.
-
-    Parameters
-    ----------
-    loc : tf.Tensor
-      A n-D tensor.
-    scale : tf.Tensor
-      A n-D tensor with all elements constrained to :math:`scale
-      > 0`.
-
-    Returns
-    -------
-    tf.Tensor
-      A tensor of same shape as input.
-    """
-    scale = tf.cast(scale, dtype=tf.float32)
-    return 0.5 * (1 + tf.log(2 * np.pi)) + tf.log(scale)
-
-
-class Poisson(object):
+class Poisson(Distribution):
   """Poisson distribution.
   """
+  def __init__(self):
+    super(Poisson, self).__init__(None)
+
   def rvs(self, mu, size=1):
     """Random variates.
 
@@ -1192,7 +1023,6 @@ class Poisson(object):
 
   def logpmf(self, x, mu):
     """Log of the probability mass function.
-
     Parameters
     ----------
     x : tf.Tensor
@@ -1200,7 +1030,6 @@ class Poisson(object):
     mu : tf.Tensor
       A tensor of same shape as ``x``, and with all elements
       constrained to :math:`mu > 0`.
-
     Returns
     -------
     tf.Tensor
@@ -1210,18 +1039,13 @@ class Poisson(object):
     mu = tf.cast(mu, dtype=tf.float32)
     return x * tf.log(mu) - mu - tf.lgamma(x + 1.0)
 
-  def entropy(self, mu):
-    """
-    Raises
-    ------
-    NotImplementedError
-    """
-    raise NotImplementedError()
 
-
-class T(object):
+class StudentT(Distribution):
   """Student-t distribution.
   """
+  def __init__(self):
+    super(StudentT, self).__init__(distributions.StudentT)
+
   def rvs(self, df, loc=0, scale=1, size=1):
     """Random variates.
 
@@ -1262,48 +1086,13 @@ class T(object):
     x = np.asarray(x).transpose()
     return x
 
-  def logpdf(self, x, df, loc=0, scale=1):
-    """Log of the probability density function.
 
-    Parameters
-    ----------
-    x : tf.Tensor
-      A n-D tensor.
-    df : tf.Tensor
-      A tensor of same shape as ``x``, and with all elements
-      constrained to :math:`df > 0`.
-    loc : tf.Tensor
-      A tensor of same shape as ``x``.
-    scale : tf.Tensor
-      A tensor of same shape as ``x``, and with all elements
-      constrained to :math:`scale > 0`.
-
-    Returns
-    -------
-    tf.Tensor
-      A tensor of same shape as input.
-    """
-    x = tf.cast(x, dtype=tf.float32)
-    df = tf.cast(df, dtype=tf.float32)
-    loc = tf.cast(loc, dtype=tf.float32)
-    scale = tf.cast(scale, dtype=tf.float32)
-    z = (x - loc) / scale
-    return tf.lgamma(0.5 * (df + 1.0)) - tf.lgamma(0.5 * df) - \
-        0.5 * (tf.log(np.pi) + tf.log(df)) - tf.log(scale) - \
-        0.5 * (df + 1.0) * tf.log(1.0 + (1.0 / df) * tf.square(z))
-
-  def entropy(self, df, loc=0, scale=1):
-    """
-    Raises
-    ------
-    NotImplementedError
-    """
-    raise NotImplementedError()
-
-
-class TruncNorm(object):
+class TruncNorm(Distribution):
   """Truncated Normal (Gaussian) distribution.
   """
+  def __init__(self):
+    super(TruncNorm, self).__init__(None)
+
   def rvs(self, a, b, loc=0, scale=1, size=1):
     """Random variates.
 
@@ -1388,20 +1177,15 @@ class TruncNorm(object):
         tf.log(tf.cast(stats.norm.cdf((b - loc) / scale) -
                stats.norm.cdf((a - loc) / scale), dtype=tf.float32))
 
-  def entropy(self, a, b, loc=0, scale=1):
-    """
-    Raises
-    ------
-    NotImplementedError
-    """
-    raise NotImplementedError()
 
-
-class Uniform(object):
+class Uniform(Distribution):
   """Uniform distribution (continous)
 
-  This distribution is constant between ``loc`` and ``loc + scale``
+  This distribution is constant between [`a`, `b`], and 0 elsewhere.
   """
+  def __init__(self):
+    super(Uniform, self).__init__(distributions.Uniform)
+
   def rvs(self, loc=0, scale=1, size=1):
     """Random variates.
 
@@ -1435,63 +1219,34 @@ class Uniform(object):
     x = np.asarray(x).transpose()
     return x
 
-  def logpdf(self, x, loc=0, scale=1):
-    """Log of the probability density function.
-
-    Parameters
-    ----------
-    x : tf.Tensor
-      A n-D tensor.
-    loc : tf.Tensor
-      Left boundary. A tensor of same shape as ``x``.
-    scale : tf.Tensor
-      Width of distribution. A tensor of same shape as ``x``,
-      and with all elements constrained to :math:`scale > 0`.
-
-    Returns
-    -------
-    tf.Tensor
-      A tensor of same shape as input.
-    """
-    # Note there is no error checking if x is outside domain.
-    scale = tf.cast(scale, dtype=tf.float32)
-    return tf.ones(list(x.get_shape())) * -tf.log(scale)
-
-  def entropy(self, loc=0, scale=1):
-    """Entropy of probability distribution.
-
-    Parameters
-    ----------
-    loc : tf.Tensor
-      Left boundary. A n-D tensor.
-    scale : tf.Tensor
-      Width of distribution. A n-D tensor, with all elements
-      constrained to :math:`scale > 0`.
-
-    Returns
-    -------
-    tf.Tensor
-      A tensor of same shape as input.
-    """
-    scale = tf.cast(scale, dtype=tf.float32)
-    return tf.log(scale)
-
 
 bernoulli = Bernoulli()
 beta = Beta()
 binom = Binom()
+categorical = Categorical()
+dirichlet_multinomial = DirichletMultinomial()
 chi2 = Chi2()
 dirichlet = Dirichlet()
-expon = Expon()
+exponential = Exponential()
 gamma = Gamma()
 geom = Geom()
-invgamma = InvGamma()
+inverse_gamma = InverseGamma()
+laplace = Laplace()
 lognorm = LogNorm()
 multinomial = Multinomial()
-multivariate_normal = Multivariate_Normal()
+multivariate_normal_diag = MultivariateNormalDiag()
+multivariate_normal_cholesky = MultivariateNormalCholesky()
+multivariate_normal_full = MultivariateNormalFull()
 nbinom = NBinom()
-norm = Norm()
+normal = Normal()
 poisson = Poisson()
-t = T()
+studentt = StudentT()
 truncnorm = TruncNorm()
 uniform = Uniform()
+
+# for backwards naming compatibility with scipy.stats
+expon = exponential
+norm = normal
+invgamma = inverse_gamma
+t = studentt
+multivariate_normal = multivariate_normal_full

--- a/examples/bernoulli.py
+++ b/examples/bernoulli.py
@@ -19,7 +19,7 @@ from edward.stats import bernoulli
 class BernoulliPosterior:
   """p(x, z) = p(z) = p(z | x) = Bernoulli(z; p)"""
   def log_prob(self, xs, zs):
-    return bernoulli.logpmf(zs['p'], 0.6)
+    return bernoulli.logpmf(zs['p'], p=0.6)
 
 
 ed.set_seed(42)

--- a/examples/beta_bernoulli_map.py
+++ b/examples/beta_bernoulli_map.py
@@ -27,7 +27,7 @@ class BetaBernoulli:
 
   def log_prob(self, xs, zs):
     log_prior = beta.logpdf(zs['p'], a=1.0, b=1.0)
-    log_lik = tf.pack([tf.reduce_sum(bernoulli.logpmf(xs['x'], p))
+    log_lik = tf.pack([tf.reduce_sum(bernoulli.logpmf(xs['x'], p=p))
                        for p in tf.unpack(zs['p'])])
     return log_lik + log_prior
 

--- a/examples/beta_bernoulli_np.py
+++ b/examples/beta_bernoulli_np.py
@@ -15,6 +15,7 @@ from __future__ import print_function
 
 import edward as ed
 import numpy as np
+import tensorflow as tf
 
 from edward.models import PythonModel, Beta
 from scipy.stats import beta, bernoulli

--- a/examples/beta_bernoulli_ppc.py
+++ b/examples/beta_bernoulli_ppc.py
@@ -25,7 +25,7 @@ class BetaBernoulli:
   """p(x, p) = Bernoulli(x | p) * Beta(p | 1, 1)"""
   def log_prob(self, xs, zs):
     log_prior = beta.logpdf(zs['p'], a=1.0, b=1.0)
-    log_lik = tf.pack([tf.reduce_sum(bernoulli.logpmf(xs['x'], p))
+    log_lik = tf.pack([tf.reduce_sum(bernoulli.logpmf(xs['x'], p=p))
                        for p in tf.unpack(zs['p'])])
     return log_lik + log_prior
 

--- a/examples/beta_bernoulli_pymc3.py
+++ b/examples/beta_bernoulli_pymc3.py
@@ -17,6 +17,7 @@ import edward as ed
 import numpy as np
 import pymc3 as pm
 import theano
+import tensorflow as tf
 
 from edward.models import PyMC3Model, Beta
 

--- a/examples/beta_bernoulli_stan.py
+++ b/examples/beta_bernoulli_stan.py
@@ -14,6 +14,7 @@ from __future__ import division
 from __future__ import print_function
 
 import edward as ed
+import tensorflow as tf
 
 from edward.models import Beta
 

--- a/examples/beta_bernoulli_tf.py
+++ b/examples/beta_bernoulli_tf.py
@@ -25,7 +25,7 @@ class BetaBernoulli:
   """p(x, p) = Bernoulli(x | p) * Beta(p | 1, 1)"""
   def log_prob(self, xs, zs):
     log_prior = beta.logpdf(zs['p'], a=1.0, b=1.0)
-    log_lik = tf.pack([tf.reduce_sum(bernoulli.logpmf(xs['x'], p))
+    log_lik = tf.pack([tf.reduce_sum(bernoulli.logpmf(xs['x'], p=p))
                        for p in tf.unpack(zs['p'])])
     return log_lik + log_prior
 

--- a/examples/getting_started_example.py
+++ b/examples/getting_started_example.py
@@ -85,7 +85,7 @@ class BayesianNN:
     """Return a vector [log p(xs | zs[1,:]), ..., log p(xs | zs[S,:])]."""
     x, y = xs['x'], xs['y']
     mus = self.neural_network(x, zs['z'])
-    log_lik = tf.reduce_sum(norm.logpdf(y, loc=mus, scale=self.lik_variance), 1)
+    log_lik = tf.reduce_sum(norm.logpdf(y, mus, self.lik_variance), 1)
     return log_lik
 
 

--- a/examples/gp_classification.py
+++ b/examples/gp_classification.py
@@ -27,7 +27,7 @@ class GaussianProcess:
   Gaussian process classification
 
   p((x,y), z) = Bernoulli(y | logit^{-1}(x*z)) *
-          Normal(z | 0, K),
+                Normal(z | 0, K),
 
   where z are weights drawn from a GP with covariance given by k(x,
   x') for each pair of inputs (x, x'), and with squared-exponential
@@ -71,7 +71,7 @@ class GaussianProcess:
     x, y = xs['x'], xs['y']
     log_prior = multivariate_normal.logpdf(zs['z'], cov=self.kernel(x))
     log_lik = tf.pack([tf.reduce_sum(
-                       bernoulli.logpmf(y, self.inverse_link(tf.mul(y, z))))
+                       bernoulli.logpmf(y, p=self.inverse_link(tf.mul(y, z))))
                        for z in tf.unpack(zs['z'])])
     return log_prior + log_lik
 

--- a/examples/hierarchical_logistic_regression.py
+++ b/examples/hierarchical_logistic_regression.py
@@ -60,7 +60,7 @@ class HierarchicalLogistic:
       # broadcasting to do (x*W) + b (e.g. 40x10 + 1x10)
       p = self.inv_link(tf.matmul(x, W) + b)
       p = tf.squeeze(p)  # n_minibatch x 1 to n_minibatch
-      log_lik += [bernoulli.logpmf(y, p)]
+      log_lik += [bernoulli.logpmf(y, p=p)]
 
     log_lik = tf.pack(log_lik)
     log_prior = -tf.reduce_sum(zs['z'] * zs['z'], 1) / self.prior_variance

--- a/examples/latent_space_model.py
+++ b/examples/latent_space_model.py
@@ -53,7 +53,7 @@ class LatentSpaceModel:
       xp = tf.matmul(z, z, transpose_b=True)
 
     if self.like == 'Gaussian':
-      log_lik = tf.reduce_sum(norm.logpdf(xs['x'], xp))
+      log_lik = tf.reduce_sum(norm.logpdf(xs['x'], xp, 1.0))
     elif self.like == 'Poisson':
       if not (self.dist == 'euclidean' or self.prior == "Lognormal"):
         raise NotImplementedError("Rate of Poisson has to be nonnegatve.")

--- a/examples/matrix_factorization.py
+++ b/examples/matrix_factorization.py
@@ -10,7 +10,7 @@ import edward as ed
 import tensorflow as tf
 import numpy as np
 
-from edward.models import Variational, Normal
+from edward.models import Normal
 from edward.stats import norm, poisson
 
 
@@ -56,7 +56,7 @@ class MatrixFactorization:
       raise NotImplementedError("interaction type unknown.")
 
     if self.like == 'Gaussian':
-      log_lik = tf.reduce_sum(norm.logpdf(xs['x'], xp))
+      log_lik = tf.reduce_sum(norm.logpdf(xs['x'], xp, 1.0))
     elif self.like == 'Poisson':
       if not (self.interaction == "additive" or self.prior == "Lognormal"):
         raise NotImplementedError("Rate of Poisson has to be nonnegatve.")

--- a/examples/mixture_gaussian.py
+++ b/examples/mixture_gaussian.py
@@ -61,9 +61,9 @@ class MixtureGaussian:
     self.D = D
     self.n_vars = (2 * D + 1) * K
 
-    self.a = 1
-    self.b = 1
-    self.c = 10
+    self.a = 1.0
+    self.b = 1.0
+    self.c = 3.0
     self.alpha = tf.ones([K])
 
   def log_prob(self, xs, zs):
@@ -71,7 +71,7 @@ class MixtureGaussian:
     x = xs['x']
     pi, mus, sigmas = zs['pi'], zs['mu'], zs['sigma']
     log_prior = dirichlet.logpdf(pi, self.alpha)
-    log_prior += tf.reduce_sum(norm.logpdf(mus, 0, np.sqrt(self.c)), 1)
+    log_prior += tf.reduce_sum(norm.logpdf(mus, 0.0, self.c), 1)
     log_prior += tf.reduce_sum(invgamma.logpdf(sigmas, self.a, self.b), 1)
 
     # Loop over each sample zs[s, :].

--- a/examples/mixture_gaussian_laplace.py
+++ b/examples/mixture_gaussian_laplace.py
@@ -50,9 +50,9 @@ class MixtureGaussian:
     self.D = D
     self.n_vars = (2 * D + 1) * K
 
-    self.a = 1
-    self.b = 1
-    self.c = 10
+    self.a = 1.0
+    self.b = 1.0
+    self.c = 3.0
     self.alpha = tf.ones([K])
 
   def log_prob(self, xs, zs):
@@ -60,7 +60,7 @@ class MixtureGaussian:
     x = xs['x']
     pi, mus, sigmas = zs['pi'], zs['mu'], zs['sigma']
     log_prior = dirichlet.logpdf(pi, self.alpha)
-    log_prior += tf.reduce_sum(norm.logpdf(mus, 0, np.sqrt(self.c)))
+    log_prior += tf.reduce_sum(norm.logpdf(mus, 0.0, self.c))
     log_prior += tf.reduce_sum(invgamma.logpdf(sigmas, self.a, self.b))
 
     # Loop over each sample zs[s, :].

--- a/examples/mixture_gaussian_map.py
+++ b/examples/mixture_gaussian_map.py
@@ -50,9 +50,9 @@ class MixtureGaussian:
     self.D = D
     self.n_vars = (2 * D + 1) * K
 
-    self.a = 1
-    self.b = 1
-    self.c = 10
+    self.a = 1.0
+    self.b = 1.0
+    self.c = 3.0
     self.alpha = tf.ones([K])
 
   def log_prob(self, xs, zs):
@@ -60,7 +60,7 @@ class MixtureGaussian:
     x = xs['x']
     pi, mus, sigmas = zs['pi'], zs['mu'], zs['sigma']
     log_prior = dirichlet.logpdf(pi, self.alpha)
-    log_prior += tf.reduce_sum(norm.logpdf(mus, 0, np.sqrt(self.c)))
+    log_prior += tf.reduce_sum(norm.logpdf(mus, 0.0, self.c))
     log_prior += tf.reduce_sum(invgamma.logpdf(sigmas, self.a, self.b))
 
     # Loop over each sample zs[s, :].

--- a/examples/normal.py
+++ b/examples/normal.py
@@ -17,19 +17,19 @@ from edward.stats import norm
 
 
 class NormalPosterior:
-  """p(x, z) = p(z) = p(z | x) = Normal(z; mu, std)"""
-  def __init__(self, mu, std):
+  """p(x, z) = p(z) = p(z | x) = Normal(z; mu, sigma)"""
+  def __init__(self, mu, sigma):
     self.mu = mu
-    self.std = std
+    self.sigma = sigma
 
   def log_prob(self, xs, zs):
-    return norm.logpdf(zs['z'], self.mu, self.std)
+    return norm.logpdf(zs['z'], self.mu, self.sigma)
 
 
 ed.set_seed(42)
 mu = tf.constant(1.0)
-std = tf.constant(1.0)
-model = NormalPosterior(mu, std)
+sigma = tf.constant(1.0)
+model = NormalPosterior(mu, sigma)
 
 qz_mu = tf.Variable(tf.random_normal([1]))
 qz_sigma = tf.nn.softplus(tf.Variable(tf.random_normal([1])))

--- a/examples/normal_idiomatic_tf.py
+++ b/examples/normal_idiomatic_tf.py
@@ -21,19 +21,19 @@ from edward.stats import norm
 
 
 class NormalPosterior:
-  """p(x, z) = p(z) = p(z | x) = Normal(z; mu, std)"""
-  def __init__(self, mu, std):
+  """p(x, z) = p(z) = p(z | x) = Normal(z; mu, sigma)"""
+  def __init__(self, mu, sigma):
     self.mu = mu
-    self.std = std
+    self.sigma = sigma
 
   def log_prob(self, xs, zs):
-    return norm.logpdf(zs['z'], self.mu, self.std)
+    return norm.logpdf(zs['z'], self.mu, self.sigma)
 
 
 ed.set_seed(42)
 mu = tf.constant(1.0)
-std = tf.constant(1.0)
-model = NormalPosterior(mu, std)
+sigma = tf.constant(1.0)
+model = NormalPosterior(mu, sigma)
 
 qz_mu = tf.Variable(tf.random_normal([1]))
 qz_sigma = tf.nn.softplus(tf.Variable(tf.random_normal([1])))

--- a/examples/normal_map.py
+++ b/examples/normal_map.py
@@ -16,15 +16,15 @@ from edward.stats import norm
 
 
 class NormalModel:
-  """p(x, z) = Normal(x; z, std) Normal(z; mu, std)"""
-  def __init__(self, mu, std):
+  """p(x, z) = Normal(x; z, sigma) Normal(z; mu, sigma)"""
+  def __init__(self, mu, sigma):
     self.mu = mu
-    self.std = std
+    self.sigma = sigma
     self.n_vars = 1
 
   def log_prob(self, xs, zs):
-    log_prior = norm.logpdf(zs['z'], self.mu, self.std)
-    log_lik = tf.pack([tf.reduce_sum(norm.logpdf(xs['x'], z, self.std))
+    log_prior = norm.logpdf(zs['z'], self.mu, self.sigma)
+    log_lik = tf.pack([tf.reduce_sum(norm.logpdf(xs['x'], z, self.sigma))
                        for z in tf.unpack(zs['z'])])
     return log_lik + log_prior
 
@@ -34,8 +34,8 @@ data = {'x': np.array([3] * 20 + [0, 1, 0, 0, 0, 0, 0, 0, 0, 1],
         dtype=np.float32)}
 
 mu = tf.constant(3.0)
-std = tf.constant(0.1)
-model = NormalModel(mu, std)
+sigma = tf.constant(0.1)
+model = NormalModel(mu, sigma)
 
 inference = ed.MAP(['z'], data, model)
 inference.run(n_iter=200, n_print=50)

--- a/tests/test-models/test_pythonmodel_log_prob.py
+++ b/tests/test-models/test_pythonmodel_log_prob.py
@@ -12,7 +12,7 @@ from scipy.stats import beta, bernoulli
 
 
 class BetaBernoulli(PythonModel):
-  """p(x, z) = Bernoulli(x | z) * Beta(z | 1, 1)"""
+  """p(x, p) = Bernoulli(x | p) * Beta(p | 1, 1)"""
   def _py_log_prob(self, xs, zs):
     # This example is written for pedagogy. We recommend
     # vectorizing operations in practice.

--- a/tests/test-stats/test_bernoulli_entropy.py
+++ b/tests/test-stats/test_bernoulli_entropy.py
@@ -12,9 +12,9 @@ from scipy import stats
 class test_bernoulli_entropy_class(tf.test.TestCase):
 
   def _test(self, p):
-    val_true = stats.bernoulli.entropy(p)
-    self.assertAllClose(bernoulli.entropy(p).eval(), val_true)
-    self.assertAllClose(bernoulli.entropy(tf.constant(p)).eval(), val_true)
+    val_true = stats.bernoulli.entropy(p=p)
+    self.assertAllClose(bernoulli.entropy(p=p).eval(), val_true)
+    self.assertAllClose(bernoulli.entropy(p=tf.constant(p)).eval(), val_true)
 
   def test_0d(self):
     with self.test_session():

--- a/tests/test-stats/test_bernoulli_logpmf.py
+++ b/tests/test-stats/test_bernoulli_logpmf.py
@@ -13,10 +13,10 @@ class test_bernoulli_logpmf_class(tf.test.TestCase):
 
   def _test(self, x, p):
     xtf = tf.constant(x)
-    val_true = stats.bernoulli.logpmf(x, p)
+    val_true = stats.bernoulli.logpmf(x, p=p)
     with self.test_session():
-      self.assertAllClose(bernoulli.logpmf(xtf, p).eval(), val_true)
-      self.assertAllClose(bernoulli.logpmf(xtf, tf.constant(p)).eval(),
+      self.assertAllClose(bernoulli.logpmf(xtf, p=p).eval(), val_true)
+      self.assertAllClose(bernoulli.logpmf(xtf, p=tf.constant(p)).eval(),
                           val_true)
 
   def test_int_0d(self):

--- a/tests/test-stats/test_beta_entropy.py
+++ b/tests/test-stats/test_beta_entropy.py
@@ -16,12 +16,6 @@ class test_beta_entropy_class(tf.test.TestCase):
     self.assertAllClose(beta.entropy(a, b).eval(), val_true, atol=1e-4)
     self.assertAllClose(beta.entropy(tf.constant(a), tf.constant(b)).eval(),
                         val_true, atol=1e-4)
-    self.assertAllClose(beta.entropy(tf.constant([a]), tf.constant(b)).eval(),
-                        val_true, atol=1e-4)
-    self.assertAllClose(beta.entropy(tf.constant(a), tf.constant([b])).eval(),
-                        val_true, atol=1e-4)
-    self.assertAllClose(beta.entropy(tf.constant([a]), tf.constant([b])).eval(),
-                        val_true, atol=1e-4)
 
   def test_0d(self):
     with self.test_session():

--- a/tests/test-stats/test_beta_logpdf.py
+++ b/tests/test-stats/test_beta_logpdf.py
@@ -18,12 +18,6 @@ class test_beta_logpdf_class(tf.test.TestCase):
       self.assertAllClose(beta.logpdf(xtf, a, b).eval(), val_true)
       self.assertAllClose(beta.logpdf(xtf, tf.constant(a),
                                       tf.constant(b)).eval(), val_true)
-      self.assertAllClose(beta.logpdf(xtf, tf.constant([a]),
-                                      tf.constant(b)).eval(), val_true)
-      self.assertAllClose(beta.logpdf(xtf, tf.constant(a),
-                                      tf.constant([b])).eval(), val_true)
-      self.assertAllClose(beta.logpdf(xtf, tf.constant([a]),
-                                      tf.constant([b])).eval(), val_true)
 
   def test_0d(self):
     self._test(0.3, a=0.5, b=0.5)
@@ -42,5 +36,6 @@ class test_beta_logpdf_class(tf.test.TestCase):
     self._test([0.5, 0.3, 0.8, 0.1], a=0.5, b=0.5)
 
   def test_2d(self):
-    self._test(np.array([[0.5, 0.3, 0.8, 0.1], [0.1, 0.7, 0.2, 0.4]]),
+    self._test(np.array([[0.5, 0.3, 0.8, 0.1], [0.1, 0.7, 0.2, 0.4]],
+                        dtype=np.float32),
                a=0.5, b=0.5)

--- a/tests/test-stats/test_expon_logpdf.py
+++ b/tests/test-stats/test_expon_logpdf.py
@@ -11,29 +11,27 @@ from scipy import stats
 
 class test_expon_logpdf_class(tf.test.TestCase):
 
-  def _test(self, x, scale=1):
+  def _test(self, x, lam):
     xtf = tf.constant(x)
-    val_true = stats.expon.logpdf(x, scale=scale)
+    val_true = stats.expon.logpdf(x, scale=1.0 / lam)
     with self.test_session():
-      self.assertAllClose(expon.logpdf(xtf, scale=tf.constant(scale)).eval(),
+      self.assertAllClose(expon.logpdf(xtf, lam=tf.constant(lam)).eval(),
                           val_true)
 
   def test_0d(self):
-    self._test(0.3)
-    self._test(0.7)
+    self._test(0.3, lam=1.0)
+    self._test(0.7, lam=1.0)
 
-    self._test(0.3, scale=1.0)
-    self._test(0.7, scale=1.0)
+    self._test(0.3, lam=0.5)
+    self._test(0.7, lam=0.5)
 
-    self._test(0.3, scale=0.5)
-    self._test(0.7, scale=0.5)
-
-    self._test(0.3, scale=5.0)
-    self._test(0.7, scale=5.0)
+    self._test(0.3, lam=5.0)
+    self._test(0.7, lam=5.0)
 
   def test_1d(self):
-    self._test([0.5, 2.3, 5.8, 10.1], scale=5.0)
+    self._test([0.5, 2.3, 5.8, 10.1], lam=5.0)
 
   def test_2d(self):
-    self._test(np.array([[0.5, 2.3, 5.8, 10.1], [0.5, 2.3, 5.8, 10.1]]),
-               scale=5.0)
+    self._test(np.array([[0.5, 2.3, 5.8, 10.1], [0.5, 2.3, 5.8, 10.1]],
+                        dtype=np.float32),
+               lam=5.0)

--- a/tests/test-stats/test_gamma_entropy.py
+++ b/tests/test-stats/test_gamma_entropy.py
@@ -20,19 +20,22 @@ def gamma_entropy_vec(a, scale):
 
 class test_gamma_entropy_class(tf.test.TestCase):
 
-  def _test(self, a, scale=1):
-    val_true = gamma_entropy_vec(a, scale=scale)
+  def _test(self, alpha, beta):
+    val_true = gamma_entropy_vec(alpha, scale=1.0 / beta)
     with self.test_session():
-      self.assertAllClose(gamma.entropy(a, scale).eval(), val_true)
-      self.assertAllClose(gamma.entropy(tf.constant(a),
-                                        tf.constant(scale)).eval(), val_true)
+      self.assertAllClose(gamma.entropy(alpha, beta).eval(), val_true,
+                          atol=1e-4)
+      self.assertAllClose(gamma.entropy(tf.constant(alpha),
+                                        tf.constant(beta)).eval(),
+                          val_true, atol=1e-4)
 
   def test_0d(self):
-    self._test(a=1.0, scale=1.0)
-    self._test(a=1.0, scale=1.0)
+    self._test(alpha=1.0, beta=1.0)
+    self._test(alpha=1.0, beta=1.0)
 
-    self._test(a=0.5, scale=5.0)
-    self._test(a=5.0, scale=0.5)
+    self._test(alpha=0.5, beta=5.0)
+    self._test(alpha=5.0, beta=0.5)
 
   def test_1d(self):
-    self._test(a=[0.5, 1.2, 5.3, 8.7], scale=[0.5, 1.2, 5.3, 8.7])
+    self._test(alpha=np.array([0.5, 1.2, 5.3, 8.7], dtype=np.float32),
+               beta=np.array([0.5, 1.2, 5.3, 8.7], dtype=np.float32))

--- a/tests/test-stats/test_gamma_logpdf.py
+++ b/tests/test-stats/test_gamma_logpdf.py
@@ -11,29 +11,30 @@ from scipy import stats
 
 class test_gamma_logpdf_class(tf.test.TestCase):
 
-  def _test(self, x, a, scale=1):
+  def _test(self, x, alpha, beta):
     xtf = tf.constant(x)
-    val_true = stats.gamma.logpdf(x, a, scale=scale)
+    val_true = stats.gamma.logpdf(x, alpha, scale=1.0 / beta)
     with self.test_session():
-      self.assertAllClose(gamma.logpdf(xtf, tf.constant(a),
-                                       tf.constant(scale)).eval(), val_true)
+      self.assertAllClose(gamma.logpdf(xtf, tf.constant(alpha),
+                                       tf.constant(beta)).eval(), val_true)
 
   def test_0d(self):
-    self._test(0.3, a=0.5)
-    self._test(0.7, a=0.5)
+    self._test(0.3, alpha=0.5, beta=1.0)
+    self._test(0.7, alpha=0.5, beta=1.0)
 
-    self._test(0.3, a=1.0, scale=1.0)
-    self._test(0.7, a=1.0, scale=1.0)
+    self._test(0.3, alpha=1.0, beta=1.0)
+    self._test(0.7, alpha=1.0, beta=1.0)
 
-    self._test(0.3, a=0.5, scale=5.0)
-    self._test(0.7, a=0.5, scale=5.0)
+    self._test(0.3, alpha=0.5, beta=5.0)
+    self._test(0.7, alpha=0.5, beta=5.0)
 
-    self._test(0.3, a=5.0, scale=0.5)
-    self._test(0.7, a=5.0, scale=0.5)
+    self._test(0.3, alpha=5.0, beta=0.5)
+    self._test(0.7, alpha=5.0, beta=0.5)
 
   def test_1d(self):
-    self._test([0.5, 1.2, 5.3, 8.7], a=0.5, scale=0.5)
+    self._test([0.5, 1.2, 5.3, 8.7], alpha=0.5, beta=0.5)
 
   def test_2d(self):
-    self._test(np.array([[0.5, 1.2, 5.3, 8.7], [0.5, 1.2, 5.3, 8.7]]),
-               a=0.5, scale=0.5)
+    self._test(np.array([[0.5, 1.2, 5.3, 8.7], [0.5, 1.2, 5.3, 8.7]],
+                        dtype=np.float32),
+               alpha=0.5, beta=0.5)

--- a/tests/test-stats/test_invgamma_entropy.py
+++ b/tests/test-stats/test_invgamma_entropy.py
@@ -19,19 +19,20 @@ def invgamma_entropy_vec(a, scale):
 
 class test_invgamma_entropy_class(tf.test.TestCase):
 
-  def _test(self, a, scale=1):
-    val_true = invgamma_entropy_vec(a, scale=scale)
+  def _test(self, alpha, beta):
+    val_true = invgamma_entropy_vec(alpha, scale=beta)
     with self.test_session():
-      self.assertAllClose(invgamma.entropy(a, scale).eval(), val_true,
+      self.assertAllClose(invgamma.entropy(alpha, beta).eval(), val_true,
                           atol=1e-4)
-      self.assertAllClose(invgamma.entropy(tf.constant(a),
-                                           tf.constant(scale)).eval(), val_true,
+      self.assertAllClose(invgamma.entropy(tf.constant(alpha),
+                                           tf.constant(beta)).eval(), val_true,
                           atol=1e-4)
 
   def test_0d(self):
-    self._test(a=1.0, scale=1.0)
-    self._test(a=0.5, scale=5.0)
-    self._test(a=5.0, scale=0.5)
+    self._test(alpha=1.0, beta=1.0)
+    self._test(alpha=0.5, beta=5.0)
+    self._test(alpha=5.0, beta=0.5)
 
   def test_1d(self):
-    self._test([0.5, 1.2, 5.3, 8.7], [0.5, 1.2, 5.3, 8.7])
+    self._test(alpha=np.array([0.5, 1.2, 5.3, 8.7], dtype=np.float32),
+               beta=np.array([0.5, 1.2, 5.3, 8.7], dtype=np.float32))

--- a/tests/test-stats/test_invgamma_logpdf.py
+++ b/tests/test-stats/test_invgamma_logpdf.py
@@ -11,30 +11,31 @@ from scipy import stats
 
 class test_invgamma_logpdf_class(tf.test.TestCase):
 
-  def _test(self, x, a, scale=1):
+  def _test(self, x, alpha, beta):
     xtf = tf.constant(x)
-    val_true = stats.invgamma.logpdf(x, a, scale=scale)
+    val_true = stats.invgamma.logpdf(x, alpha, scale=beta)
     with self.test_session():
-      self.assertAllClose(invgamma.logpdf(xtf, a, scale).eval(), val_true)
-      self.assertAllClose(invgamma.logpdf(xtf, tf.constant(a),
-                                          tf.constant(scale)).eval(), val_true)
+      self.assertAllClose(invgamma.logpdf(xtf, alpha, beta).eval(), val_true)
+      self.assertAllClose(invgamma.logpdf(xtf, tf.constant(alpha),
+                                          tf.constant(beta)).eval(), val_true)
 
   def test_0d(self):
-    self._test(0.3, a=0.5)
-    self._test(0.7, a=0.5)
+    self._test(0.3, alpha=0.5, beta=1.0)
+    self._test(0.7, alpha=0.5, beta=1.0)
 
-    self._test(0.3, a=1.0, scale=1.0)
-    self._test(0.7, a=1.0, scale=1.0)
+    self._test(0.3, alpha=1.0, beta=1.0)
+    self._test(0.7, alpha=1.0, beta=1.0)
 
-    self._test(0.3, a=0.5, scale=5.0)
-    self._test(0.7, a=0.5, scale=5.0)
+    self._test(0.3, alpha=0.5, beta=5.0)
+    self._test(0.7, alpha=0.5, beta=5.0)
 
-    self._test(0.3, a=5.0, scale=0.5)
-    self._test(0.7, a=5.0, scale=0.5)
+    self._test(0.3, alpha=5.0, beta=0.5)
+    self._test(0.7, alpha=5.0, beta=0.5)
 
   def test_1d(self):
-    self._test([0.5, 1.2, 5.3, 8.7], a=0.5, scale=0.5)
+    self._test([0.5, 1.2, 5.3, 8.7], alpha=0.5, beta=0.5)
 
   def test_2d(self):
-    self._test(np.array([[0.5, 1.2, 5.3, 8.7], [0.5, 1.2, 5.3, 8.7]]),
-               a=0.5, scale=0.5)
+    self._test(np.array([[0.5, 1.2, 5.3, 8.7], [0.5, 1.2, 5.3, 8.7]],
+                        dtype=np.float32),
+               alpha=0.5, beta=0.5)

--- a/tests/test-stats/test_norm_entropy.py
+++ b/tests/test-stats/test_norm_entropy.py
@@ -20,16 +20,12 @@ def norm_entropy_vec(loc, scale):
 
 class test_norm_entropy_class(tf.test.TestCase):
 
-  def _test(self, loc, scale):
-    val_true = norm_entropy_vec(loc, scale)
+  def _test(self, mu, sigma):
+    val_true = norm_entropy_vec(mu, sigma)
     with self.test_session():
-      self.assertAllClose(norm.entropy(loc, scale).eval(), val_true)
+      self.assertAllClose(norm.entropy(mu, sigma).eval(), val_true)
       self.assertAllClose(
-          norm.entropy(tf.constant(loc), tf.constant(scale)).eval(), val_true)
-
-  def test_empty(self):
-    with self.test_session():
-      self.assertAllClose(norm.entropy().eval(), stats.norm.entropy())
+          norm.entropy(tf.constant(mu), tf.constant(sigma)).eval(), val_true)
 
   def test_0d(self):
     self._test(1.0, 1.0)

--- a/tests/test-stats/test_norm_logpdf.py
+++ b/tests/test-stats/test_norm_logpdf.py
@@ -11,21 +11,26 @@ from scipy import stats
 
 class test_norm_logpdf_class(tf.test.TestCase):
 
-  def _test(self, x, loc=0, scale=1):
+  def _test(self, x, mu, sigma):
     xtf = tf.constant(x)
-    val_true = stats.norm.logpdf(x, loc, scale)
+    val_true = stats.norm.logpdf(x, mu, sigma)
     with self.test_session():
-      self.assertAllClose(norm.logpdf(xtf, loc, scale).eval(), val_true)
+      self.assertAllClose(norm.logpdf(xtf, mu, sigma).eval(), val_true)
       self.assertAllClose(
-          norm.logpdf(xtf, tf.constant(loc), tf.constant(scale)).eval(),
+          norm.logpdf(xtf, tf.constant(mu), tf.constant(sigma)).eval(),
           val_true)
 
   def test_0d(self):
-    self._test(0.0)
-    self._test(0.623)
+    self._test(0.0, 0.0, 1.0)
+    self._test(0.623, 0.0, 1.0)
 
   def test_1d(self):
-    self._test([0.0, 1.0, 0.58, 2.3])
+    self._test([0.0, 1.0, 0.58, 2.3],
+               np.array([0.0] * 4, dtype=np.float32),
+               np.array([1.0] * 4, dtype=np.float32))
 
   def test_2d(self):
-    self._test(np.array([[0.0, 1.0, 0.58, 2.3], [0.1, 1.5, 4.18, 0.3]]))
+    self._test(np.array([[0.0, 1.0, 0.58, 2.3], [0.1, 1.5, 4.18, 0.3]],
+                        dtype=np.float32),
+               np.array([0.0] * 4, dtype=np.float32),
+               np.array([1.0] * 4, dtype=np.float32))

--- a/tests/test-stats/test_t_logpdf.py
+++ b/tests/test-stats/test_t_logpdf.py
@@ -11,20 +11,23 @@ from scipy import stats
 
 class test_t_logpdf_class(tf.test.TestCase):
 
-  def _test(self, x, df, loc=0, scale=1):
+  def _test(self, x, df, mu, sigma):
     xtf = tf.constant(x)
-    val_true = stats.t.logpdf(x, df, loc, scale)
+    val_true = stats.t.logpdf(x, df, mu, sigma)
     with self.test_session():
-      self.assertAllClose(t.logpdf(xtf, df, loc, scale).eval(), val_true)
-      self.assertAllClose(t.logpdf(xtf, df, tf.constant(loc),
-                          tf.constant(scale)).eval(), val_true)
+      self.assertAllClose(t.logpdf(xtf, df, mu, sigma).eval(), val_true)
+      self.assertAllClose(t.logpdf(xtf, df, tf.constant(mu),
+                          tf.constant(sigma)).eval(), val_true)
 
   def test_0d(self):
-    self._test(0.0, df=3)
-    self._test(0.623, df=3)
+    self._test(0.0, 3.0, 0.0, 1.0)
+    self._test(0.623, 3.0, 0.0, 1.0)
 
   def test_1d(self):
-    self._test([0.0, 1.0, 0.58, 2.3], df=3)
+    self._test([0.0, 1.0, 0.58, 2.3], 3.0, 0.0, 1.0)
 
   def test_2d(self):
-    self._test(np.array([[0.0, 1.0, 0.58, 2.3], [0.0, 1.0, 0.58, 2.3]]), df=3)
+    self._test(np.array([[0.0, 1.0, 0.58, 2.3], [0.0, 1.0, 0.58, 2.3]],
+                        dtype=np.float32),
+               3.0, np.array([0.0] * 4, dtype=np.float32),
+               np.array([1.0] * 4, dtype=np.float32))

--- a/tests/test-stats/test_uniform_entropy.py
+++ b/tests/test-stats/test_uniform_entropy.py
@@ -20,18 +20,18 @@ def uniform_entropy_vec(loc, scale):
 
 class test_uniform_entropy_class(tf.test.TestCase):
 
-  def _test(self, loc=0, scale=1):
-    val_true = uniform_entropy_vec(loc, scale)
+  def _test(self, a, b):
+    val_true = uniform_entropy_vec(a, b - a)
     with self.test_session():
-      self.assertAllClose(uniform.entropy(loc, scale).eval(), val_true)
-      self.assertAllClose(uniform.entropy(tf.constant(loc),
-                                          tf.constant(scale)).eval(), val_true)
+      self.assertAllClose(uniform.entropy(a, b).eval(), val_true)
+      self.assertAllClose(uniform.entropy(tf.constant(a),
+                                          tf.constant(b)).eval(), val_true)
 
   def test_0d(self):
-    self._test()
-    self._test(loc=1.0, scale=1.0)
-    self._test(loc=0.5, scale=5.0)
-    self._test(loc=5.0, scale=0.5)
+    self._test(a=1.0, b=2.0)
+    self._test(a=0.5, b=5.0)
+    self._test(a=5.0, b=5.5)
 
   def test_1d(self):
-    self._test([0.5, 0.3, 0.8, 0.2], [0.5, 0.3, 0.8, 0.2])
+    self._test(np.array([0.5, 0.3, 0.8, 0.2], dtype=np.float32),
+               np.array([0.6, 0.4, 0.9, 0.3], dtype=np.float32))

--- a/tests/test-stats/test_uniform_logpdf.py
+++ b/tests/test-stats/test_uniform_logpdf.py
@@ -11,30 +11,31 @@ from scipy import stats
 
 class test_uniform_logpdf_class(tf.test.TestCase):
 
-  def _test(self, x, loc=0, scale=1):
+  def _test(self, x, a, b):
     xtf = tf.constant(x)
-    val_true = stats.uniform.logpdf(x, loc, scale)
+    val_true = stats.uniform.logpdf(x, a, b - a)
     with self.test_session():
-      self.assertAllClose(uniform.logpdf(xtf, loc, scale).eval(), val_true)
-      self.assertAllClose(uniform.logpdf(xtf, tf.constant(loc),
-                                         tf.constant(scale)).eval(), val_true)
+      self.assertAllClose(uniform.logpdf(xtf, a, b).eval(), val_true)
+      self.assertAllClose(uniform.logpdf(xtf, tf.constant(a),
+                                         tf.constant(b)).eval(), val_true)
 
   def test_0d(self):
-    self._test(0.3)
-    self._test(0.7)
+    self._test(0.3, a=0.0, b=1.0)
+    self._test(0.7, a=0.0, b=1.0)
 
-    self._test(1.3, loc=1.0, scale=1.0)
-    self._test(1.7, loc=1.0, scale=1.0)
+    self._test(1.3, a=1.0, b=2.0)
+    self._test(1.7, a=1.0, b=2.0)
 
-    self._test(2.3, loc=0.5, scale=5.0)
-    self._test(2.7, loc=0.5, scale=5.0)
+    self._test(2.3, a=0.5, b=5.0)
+    self._test(2.7, a=0.5, b=5.0)
 
-    self._test(5.3, loc=5.0, scale=0.5)
-    self._test(5.1, loc=5.0, scale=0.5)
+    self._test(5.3, a=5.0, b=5.5)
+    self._test(5.1, a=5.0, b=5.5)
 
   def test_1d(self):
-    self._test([0.5, 0.3, 0.8, 0.2], loc=0.1, scale=0.9)
+    self._test(np.array([0.5, 0.3, 0.8, 0.2], dtype=np.float32), a=0.1, b=0.9)
 
   def test_2d(self):
-    self._test(np.array([[0.5, 0.3, 0.8, 0.2], [0.5, 0.3, 0.8, 0.2]]),
-               loc=0.1, scale=0.9)
+    self._test(np.array([[0.5, 0.3, 0.8, 0.2], [0.5, 0.3, 0.8, 0.2]],
+                        dtype=np.float32),
+               a=0.1, b=0.9)


### PR DESCRIPTION
+ fixes #33; fixes #134 (by adhering to both TensorFlow and SciPy naming); fixes #144

This pull request wraps all of the internal implementation for distributions using `tf.contrib.distributions` in `edward.stats`. This makes the internals more robust, faster, and support more distribution methods.

There's one confusing point: we still have `rvs()` in the distributions, which uses SciPy's standard arguments. All other methods such as `logpmf()`/`logpdf()` now use TensorFlow's standard (if the distribution exists; otherwise it defaults to SciPy's standard).

Also this includes minor miscellaneous fixes.

I'm not sure how long we'll keep around `edward.stats`. After the modeling language, this library may still be useful for use with the model wrappers.