### PR TITLE
Bugfix/recursive sampling

### DIFF
--- a/docs/tex/tut_inference_networks.tex
+++ b/docs/tex/tut_inference_networks.tex
@@ -107,7 +107,7 @@ We define a TensorFlow placeholder \texttt{x_ph} for the neural network's input.
 We define a variational model which is parameterized by the neural network's
 output.
 \begin{lstlisting}[language=Python]
-x_ph = tf.placeholder(tf.float32, [28 * 28])
+x_ph = ed.placeholder(tf.float32, [28 * 28])
 mu, sigma = neural_network(x_ph)
 qz = Normal(mu=mu, sigma=sigma)
 \end{lstlisting}

--- a/docs/tex/tut_mixture_density_network.tex
+++ b/docs/tex/tut_mixture_density_network.tex
@@ -50,8 +50,8 @@ sns.regplot(X_train, y_train, fit_reg=False)
 We define TensorFlow placeholders will be used to manually feed batches of data during inference. This is \href{http://edwardlib.org/api/data.html}{one of many ways} to train models with data in Edward.
 
 \begin{lstlisting}[language=Python]
-X = tf.placeholder(tf.float32, shape=(None, 1))
-y = tf.placeholder(tf.float32, shape=(None, 1))
+X = ed.placeholder(tf.float32, shape=(None, 1))
+y = ed.placeholder(tf.float32, shape=(None, 1))
 data = {'X': X, 'y': y}
 \end{lstlisting}
 

--- a/docs/tex/tut_unsupervised.tex
+++ b/docs/tex/tut_unsupervised.tex
@@ -143,11 +143,11 @@ qmu = Normal(mu=qmu_mu, sigma=qmu_sigma)
 qsigma = InverseGamma(alpha=qsigma_alpha, beta=qsigma_beta)
 \end{lstlisting}
 
-Run mean-field variational inference for 4000 iterations, using a batch
-of 10 datapoints and 50 latent variable samples per iteration.
+Run mean-field variational inference for 2500 iterations, using a batch
+of 20 datapoints and 10 latent variable samples per iteration.
 \begin{lstlisting}[language=Python]
 inference = ed.MFVI({'pi': qpi, 'mu': qmu, 'sigma': qsigma}, data, model)
-inference.run(n_iter=4000, n_samples=10, n_minibatch=10)
+inference.run(n_iter=2500, n_samples=10, n_minibatch=20)
 \end{lstlisting}
 In this case
 \texttt{MFVI} defaults to minimizing the

--- a/edward/util.py
+++ b/edward/util.py
@@ -34,8 +34,8 @@ def copy(org_instance, dict_swap=None, scope="copied",
   dict_swap : dict, optional
     Random variables, variables, tensors, or operations to
     swap with. Its keys are what `org_instance` may depend on,
-    and its values are the corresponding object (of the same type)
-    that is used in exchange.
+    and its values are the corresponding object (not necessarily of
+    the same type) that is used in exchange.
   scope : str, optional
     A scope for the new node(s). This is used to avoid name
     conflicts with the original node(s).
@@ -81,6 +81,9 @@ def copy(org_instance, dict_swap=None, scope="copied",
      not isinstance(org_instance, tf.Tensor) and \
      not isinstance(org_instance, tf.Operation):
     raise TypeError("Could not copy instance: " + str(org_instance))
+
+  if dict_swap is None:
+    dict_swap = {}
 
   # Swap instance if in dictionary.
   if org_instance in dict_swap and replace_itself:

--- a/examples/convolutional_vae.py
+++ b/examples/convolutional_vae.py
@@ -121,7 +121,7 @@ model = NormalBernoulli(n_vars=10)
 # to explicitly represent the variational factors for a mini-batch,
 # q(z_{batch} | x) = prod_{m=1}^{n_data}
 #                    Normal(z_m | mu, sigma = neural_network(x_m))
-x_ph = tf.placeholder(tf.float32, [N_MINIBATCH, 28 * 28])
+x_ph = ed.placeholder(tf.float32, [N_MINIBATCH, 28 * 28])
 mu, sigma = neural_network(x_ph)
 qz = Normal(mu=mu, sigma=sigma)
 
@@ -130,7 +130,7 @@ if not os.path.exists(DATA_DIR):
   os.makedirs(DATA_DIR)
 
 mnist = input_data.read_data_sets(DATA_DIR, one_hot=True)
-x = tf.placeholder(tf.float32, [N_MINIBATCH, 28 * 28])
+x = ed.placeholder(tf.float32, [N_MINIBATCH, 28 * 28])
 data = {'x': x}
 
 sess = ed.get_session()

--- a/examples/mixture_density_network.py
+++ b/examples/mixture_density_network.py
@@ -71,8 +71,8 @@ print("Size of output in training data: {:s}".format(y_train.shape))
 print("Size of features in test data: {:s}".format(X_test.shape))
 print("Size of output in test data: {:s}".format(y_test.shape))
 
-X = tf.placeholder(tf.float32, shape=(None, 1))
-y = tf.placeholder(tf.float32, shape=(None, 1))
+X = ed.placeholder(tf.float32, shape=(None, 1))
+y = ed.placeholder(tf.float32, shape=(None, 1))
 data = {'X': X, 'y': y}
 
 inference = ed.MAP([], data, model)

--- a/examples/mixture_density_network_demo.py
+++ b/examples/mixture_density_network_demo.py
@@ -101,8 +101,8 @@ print("Size of output in test data: {:s}".format(y_test.shape))
 sns.regplot(X_train, y_train, fit_reg=False)
 plt.show()
 
-X = tf.placeholder(tf.float32, shape=(None, 1))
-y = tf.placeholder(tf.float32, shape=(None, 1))
+X = ed.placeholder(tf.float32, shape=(None, 1))
+y = ed.placeholder(tf.float32, shape=(None, 1))
 data = {'X': X, 'y': y}
 
 model = MixtureDensityNetwork(20)

--- a/examples/mixture_gaussian.py
+++ b/examples/mixture_gaussian.py
@@ -145,7 +145,7 @@ qsigma = InverseGamma(alpha=qsigma_alpha, beta=qsigma_beta)
 
 data = {'x': x_train}
 inference = ed.MFVI({'pi': qpi, 'mu': qmu, 'sigma': qsigma}, data, model)
-inference.run(n_iter=4000, n_samples=10, n_minibatch=10)
+inference.run(n_iter=2500, n_samples=10, n_minibatch=20)
 
 # Average per-cluster and per-data point likelihood over many posterior samples.
 log_liks = []


### PR DESCRIPTION
The recursive sampling during inference was actually incorrect before. This made the examples with `n_samples > 1` actually just do one sample. To see this, run `bernoulli.py`, and it will never get the right answer even if you increase `n_samples` to avoid high variance stochastic gradients.

For every new set of latent variables, the model graph must be copied. We can then rely on the `value()` attribute of a RandomVariable for recursive samples. To see this, run `bernoulli.py`. It now works and where we use `n_samples=5`.