### PR TITLE
Dependency reference and link to TensorFlow 0.10.0 fixed issue #242

### DIFF
--- a/docs/tex/troubleshooting.tex
+++ b/docs/tex/troubleshooting.tex
@@ -11,7 +11,7 @@ Edward depends on
   \item NumPy (>=1.7)
   \item SciPy (>=0.16)
   \item Six (>=1.1.0)
-  \item TensorFlow (>=0.9.0)
+  \item TensorFlow (>=0.10.0)
 \end{itemize}
 
 We recommend using \texttt{pip} to install \texttt{numpy}, \texttt{scipy}, and
@@ -24,7 +24,7 @@ pip install numpy scipy six
 using \texttt{pip} to install the latest TensorFlow binaries. Please
 follow the
 \href
-{https://www.tensorflow.org/versions/r0.9/get_started/os_setup.html#pip-installation}
+{https://www.tensorflow.org/versions/r0.10/get_started/os_setup.html#pip-installation}
 {instructions} from Google.
 
 \subsubsection{Full Installation}


### PR DESCRIPTION
Changed the dependency to TensorFlow 0.10 in the Troubleshooting page and reference link. This closes issue #242 