### PR TITLE
Feature/update info

### DIFF
--- a/docs/tex/tut_mixture_density_network.tex
+++ b/docs/tex/tut_mixture_density_network.tex
@@ -140,8 +140,8 @@ NEPOCH = 1000
 train_loss = np.zeros(NEPOCH)
 test_loss = np.zeros(NEPOCH)
 for i in range(NEPOCH):
-    _, train_loss[i] = sess.run([inference.train, inference.loss],
-                                feed_dict={X: X_train, y: y_train})
+    info_dict = inference.update(feed_dict={X: X_train, y: y_train})
+    train_loss[i] = info_dict['loss']
     test_loss[i] = sess.run(inference.loss, feed_dict={X: X_test, y: y_test})
 \end{lstlisting}
 

--- a/docs/tex/tut_supervised_regression.tex
+++ b/docs/tex/tut_supervised_regression.tex
@@ -71,12 +71,11 @@ every 10 iterations.
 \begin{lstlisting}[language=Python]
 data = {X: X_train, y: y_train}
 inference = ed.MFVI({w: qw, b: qb}, data)
-inference.initialize()
 
-sess = ed.get_session()
+inference.initialize()
 for t in range(1001):
-  _, loss = sess.run([inference.train, inference.loss], {X: data[X]})
-  inference.print_progress(t, loss)
+  info_dict = inference.update()
+  inference.print_progress(t, info_dict)
 \end{lstlisting}
 In this case \texttt{MFVI} defaults to minimizing the
 $\text{KL}(q\|p)$ divergence measure using the reparameterization

--- a/examples/bayesian_linear_regression.py
+++ b/examples/bayesian_linear_regression.py
@@ -46,8 +46,8 @@ inference.initialize()
 
 sess = ed.get_session()
 for t in range(1001):
-  _, loss = sess.run([inference.train, inference.loss], {X: data[X]})
-  inference.print_progress(t, loss)
+  info_dict = inference.update()
+  inference.print_progress(t, info_dict)
 
 # CRITICISM
 y_post = ed.copy(y, {w: qw.mean(), b: qb.mean()})

--- a/examples/bayesian_linear_regression_tensor.py
+++ b/examples/bayesian_linear_regression_tensor.py
@@ -35,11 +35,9 @@ qmu_sigma = tf.nn.softplus(tf.Variable(tf.random_normal([p])))
 qbeta = Normal(mu=qmu_mu, sigma=qmu_sigma)
 
 data = {y: y_data}
-
 inference = ed.MFVI({beta: qbeta}, data)
-inference.initialize()
 
-sess = ed.get_session()
+inference.initialize()
 for t in range(501):
-  _, loss = sess.run([inference.train, inference.loss])
-  inference.print_progress(t, loss)
+  info_dict = inference.update()
+  inference.print_progress(t, info_dict)

--- a/examples/bayesian_linear_regression_tensorboard.py
+++ b/examples/bayesian_linear_regression_tensorboard.py
@@ -36,12 +36,11 @@ qbeta = Normal(mu=qmu_mu, sigma=qmu_sigma, name='qbeta')
 
 data = {X: X_train, y: y_train}
 inference = ed.MFVI({beta: qbeta}, data)
-inference.initialize(logdir='train')
 
-sess = ed.get_session()
+inference.initialize(logdir='train')
 for t in range(501):
-  _, loss = sess.run([inference.train, inference.loss], {X: data[X]})
-  inference.print_progress(t, loss)
+  info_dict = inference.update()
+  inference.print_progress(t, info_dict)
 
 y_post = ed.copy(y, {beta: qbeta.mean()})
 # This is equivalent to

--- a/examples/bayesian_linear_regression_test.py
+++ b/examples/bayesian_linear_regression_test.py
@@ -52,12 +52,11 @@ qb = Normal(mu=tf.Variable(tf.random_normal([1])),
 
 data = {X: X_train, y: y_train}
 inference = ed.MFVI({w: qw, b: qb}, data)
-inference.initialize(n_samples=5, n_print=50)
 
-sess = ed.get_session()
+inference.initialize(n_samples=5, n_print=50)
 for t in range(251):
-  _, loss = sess.run([inference.train, inference.loss], {X: data[X]})
-  inference.print_progress(t, loss)
+  info_dict = inference.update()
+  inference.print_progress(t, info_dict)
 
 # CRITICISM
 y_post = ed.copy(y, {w: qw.mean(), b: qb.mean()})

--- a/examples/normal_normal.py
+++ b/examples/normal_normal.py
@@ -27,5 +27,5 @@ inference.initialize()
 
 sess = ed.get_session()
 for t in range(1001):
-  _, loss = sess.run([inference.train, inference.loss])
-  inference.print_progress(t, loss)
+  info_dict = inference.update()
+  inference.print_progress(t, info_dict)

--- a/examples/normal_normal_tensorboard.py
+++ b/examples/normal_normal_tensorboard.py
@@ -27,5 +27,5 @@ inference.initialize(logdir='train')
 
 sess = ed.get_session()
 for t in range(1001):
-  _, loss = sess.run([inference.train, inference.loss])
-  inference.print_progress(t, loss)
+  info_dict = inference.update()
+  inference.print_progress(t, info_dict)

--- a/examples/tf_convolutional_vae.py
+++ b/examples/tf_convolutional_vae.py
@@ -130,8 +130,8 @@ if not os.path.exists(DATA_DIR):
   os.makedirs(DATA_DIR)
 
 mnist = input_data.read_data_sets(DATA_DIR, one_hot=True)
-x = ed.placeholder(tf.float32, [N_MINIBATCH, 28 * 28])
-data = {'x': x}
+# Bind p(x, z) and q(z | x) to the same TensorFlow placeholder for x.
+data = {'x': x_ph}
 
 sess = ed.get_session()
 inference = ed.MFVI({'z': qz}, data, model)
@@ -152,9 +152,8 @@ for epoch in range(n_epoch):
   for t in range(n_iter_per_epoch):
     pbar.update(t)
     x_train, _ = mnist.train.next_batch(N_MINIBATCH)
-    _, loss = sess.run([inference.train, inference.loss],
-                       feed_dict={x: x_train, x_ph: x_train})
-    avg_loss += loss
+    info_dict = inference.update(feed_dict={x_ph: x_train})
+    avg_loss += info_dict['loss']
 
   # Take average over all ELBOs during the epoch, and over minibatch
   # of data points (images).

--- a/examples/tf_mixture_density_network.py
+++ b/examples/tf_mixture_density_network.py
@@ -84,8 +84,8 @@ NEPOCH = 20
 train_loss = np.zeros(NEPOCH)
 test_loss = np.zeros(NEPOCH)
 for i in range(NEPOCH):
-  _, train_loss[i] = sess.run([inference.train, inference.loss],
-                              feed_dict={X: X_train, y: y_train})
+  info_dict = inference.update(feed_dict={X: X_train, y: y_train})
+  train_loss[i] = info_dict['loss']
   test_loss[i] = sess.run(inference.loss, feed_dict={X: X_test, y: y_test})
   print("Train Loss: {:0.3f}, Test Loss: {:0.3f}".format(train_loss[i],
                                                          test_loss[i]))

--- a/examples/tf_mixture_density_network_demo.py
+++ b/examples/tf_mixture_density_network_demo.py
@@ -116,8 +116,8 @@ NEPOCH = 1000
 train_loss = np.zeros(NEPOCH)
 test_loss = np.zeros(NEPOCH)
 for i in range(NEPOCH):
-  _, train_loss[i] = sess.run([inference.train, inference.loss],
-                              feed_dict={X: X_train, y: y_train})
+  info_dict = inference.update(feed_dict={X: X_train, y: y_train})
+  train_loss[i] = info_dict['loss']
   test_loss[i] = sess.run(inference.loss, feed_dict={X: X_test, y: y_test})
 
 pred_weights, pred_means, pred_std = \

--- a/examples/vae.py
+++ b/examples/vae.py
@@ -53,9 +53,8 @@ for epoch in range(n_epoch):
     for t in range(n_iter_per_epoch):
         pbar.update(t)
         x_train, _ = mnist.train.next_batch(M)
-        _, loss = sess.run([inference.train, inference.loss],
-                           feed_dict={x_ph: x_train})
-        avg_loss += loss
+        info_dict = inference.update(feed_dict={x_ph: x_train})
+        avg_loss += info_dict['loss']
 
     # Take average over all ELBOs during the epoch, and over minibatch
     # of data points (images).


### PR DESCRIPTION
+ issues: fixes #106 (by using [climin](http://climin.readthedocs.io/en/latest/)'s strategy instead of callbacks); related to #247

Following @bayerj's suggestion in #106, we enable more fine-grained runs of inference. The `update()` method in inference now returns an info dictionary, which contains algorithm specific information.

Instead of the user doing
```python
for t in range(1000):
  _, loss = sess.run([inference.train, inference.loss], feed_dict)
  inference.print_progress(t, loss)
```
the user now does
```python
for t in range(1000):
  info_dict = inference.update(feed_dict)
  inference.print_progress(t, info_dict)
```
`update()` outputs a dictionary `info_dict` of algorithm-specific information. For variational inference, this currently is the loss function evaluated at that iteration.

In addition, `update()` now takes `feed_dict` optionally as input.  This allows the user to manually feed placeholders to `update()`.

This API for manual iterations is also useful as we start to implement more features in the `update` API. For example, when a user wants to update only a subset of the latent variables.

For placeholders that the user feeds during instantiation of the inference algorithm, the user does not have to feed the placeholder during runtime. It is automatically fed, c.f., [`bayesian_linear_regression.py`](https://github.com/blei-lab/edward/blob/1ea48ec7007325e56baa00e2fb55ee83094e390b/examples/bayesian_linear_regression.py).