### PR TITLE
Feature/refactor inference methods

### DIFF
--- a/docs/source/inferences.rst
+++ b/docs/source/inferences.rst
@@ -77,22 +77,22 @@ Currently, Edward has most of its inference infrastructure within the
 The ``MonteCarlo`` class is still under development. We welcome
 researchers to make significant advances here!
 
-Let's focus on ``VariationalInference``. The main method in
-``VariationalInference`` is ``run()``.
+Let's look at ``Inference``. The main method in
+``Inference`` is ``run()``.
 
 .. code:: python
 
-  class VariationalInference(Inference):
-    """Base class for variational inference methods.
+  class Inference(object):
+    """Base class for Edward inference methods.
     """
     ...
     def run(self, *args, **kwargs):
-      """A simple wrapper to run variational inference.
+      """A simple wrapper to run inference.
       """
       self.initialize(*args, **kwargs)
-      for t in range(self.n_iter+1):
-        loss = self.update()
-        self.print_progress(t, loss)
+      for t in range(self.n_iter + 1):
+        info_dict = self.update()
+        self.print_progress(t, info_dict)
 
       self.finalize()
 
@@ -105,10 +105,10 @@ setting the number of iterations. Then, within a loop it calls
 calls ``finalize()`` which runs the last steps as the inference
 algorithm terminates.
 
-Developing a new variational inference algorithm is as simple as
+For example, developing a new variational inference algorithm is as simple as
 inheriting from ``VariationalInference`` or one of its derived
 classes. ``VariationalInference`` implements many default methods such
-as ``run()`` above. Let's go through ``initialize()`` as an example.
+as ``initialize()`` above. Let's go through snippets from this method.
 
 .. code:: python
 

--- a/edward/inferences/inference.py
+++ b/edward/inferences/inference.py
@@ -116,3 +116,81 @@ class Inference(object):
         else:
           # If key is a placeholder, then don't modify its fed value.
           self.data[key] = value
+
+  def run(self, *args, **kwargs):
+    """A simple wrapper to run inference.
+
+    1. Initialize via ``initialize``.
+    2. Run ``update`` for ``self.n_iter`` iterations.
+    3. While running, ``print_progress``.
+    4. Finalize via ``finalize``.
+
+    Parameters
+    ----------
+    *args
+      Passed into ``initialize``.
+    **kwargs
+      Passed into ``initialize``.
+    """
+    self.initialize(*args, **kwargs)
+    for t in range(self.n_iter + 1):
+      info_dict = self.update()
+      self.print_progress(t, info_dict)
+
+    self.finalize()
+
+  def initialize(self, n_iter=1000, n_print=100, logdir=None):
+    """Initialize inference algorithm.
+
+    Parameters
+    ----------
+    n_iter : int, optional
+      Number of iterations for algorithm.
+    n_print : int, optional
+      Number of iterations for each print progress. To suppress print
+      progress, then specify None.
+    logdir : str, optional
+      Directory where event file will be written. For details,
+      see `tf.train.SummaryWriter`. Default is to write nothing.
+    """
+    self.n_iter = n_iter
+    self.n_print = n_print
+
+    if logdir is not None:
+      train_writer = tf.train.SummaryWriter(logdir, tf.get_default_graph())
+
+    init = tf.initialize_all_variables()
+    init.run()
+
+    # Start input enqueue threads.
+    self.coord = tf.train.Coordinator()
+    self.threads = tf.train.start_queue_runners(coord=self.coord)
+
+  def update(self):
+    """Run one iteration of inference.
+
+    Returns
+    -------
+    dict
+      Dictionary of algorithm-specific information.
+    """
+    return {}
+
+  def print_progress(self, t, info_dict):
+    """Print progress to output.
+
+    Parameters
+    ----------
+    t : int
+      Iteration counter.
+    info_dict : dict
+      Dictionary of algorithm-specific information.
+    """
+    pass
+
+  def finalize(self):
+    """Function to call after convergence.
+    """
+    # Ask threads to stop.
+    self.coord.request_stop()
+    self.coord.join(self.threads)


### PR DESCRIPTION
Several `VariationalInference` methods are now placed inside `Inference`. This allows these methods to be accessed by `MonteCarlo`.

Note that this assumes all inference algorithms are iterative. We can tease out the iterative abstraction later when we add non-iterative algorithms, i.e., which admit closed-form solutions. For example, conjugate inference or even ordinary least squares.