### PR TITLE
tease out variable inits from inference.initialize()

### DIFF
--- a/edward/inferences/variational_inference.py
+++ b/edward/inferences/variational_inference.py
@@ -72,6 +72,7 @@ class VariationalInference(Inference):
       to use PrettyTensor optimizer (when using PrettyTensor).
       Defaults to TensorFlow.
     """
+    super(VariationalInference, self).initialize(*args, **kwargs)
     self.n_minibatch = n_minibatch
     self.loss = tf.constant(0.0)
 
@@ -138,8 +139,6 @@ class VariationalInference(Inference):
 
       # Note PrettyTensor cannot use global_step.
       self.train = pt.apply_optimizer(optimizer, losses=[loss])
-
-    return super(VariationalInference, self).initialize(*args, **kwargs)
 
   def update(self, feed_dict=None):
     """Run one iteration of optimizer for variational inference.

--- a/examples/bayesian_nn.py
+++ b/examples/bayesian_nn.py
@@ -78,8 +78,11 @@ data = {y: y_train}
 inference = ed.MFVI({W_0: qW_0, b_0: qb_0,
                      W_1: qW_1, b_1: qb_1,
                      W_2: qW_2, b_2: qb_2}, data)
-
 inference.initialize(n_print=100)
+
+init = tf.initialize_all_variables()
+init.run()
+
 for _ in range(1000):
   info_dict = inference.update()
   t, loss = info_dict['t'], info_dict['loss']

--- a/examples/getting_started_example.py
+++ b/examples/getting_started_example.py
@@ -70,7 +70,7 @@ qb_1 = Normal(mu=tf.Variable(tf.random_normal([1])),
 data = {y: y_train}
 inference = ed.MFVI({W_0: qW_0, b_0: qb_0,
                      W_1: qW_1, b_1: qb_1}, data)
-inference.initialize()
+
 
 # Sample functions from variational model to visualize fits.
 rs = np.random.RandomState(0)
@@ -82,6 +82,10 @@ for s in range(10):
                          qb_0.sample(), qb_1.sample())]
 
 mus = tf.pack(mus)
+
+sess = ed.get_session()
+init = tf.initialize_all_variables()
+init.run()
 
 
 # FIRST VISUALIZATION (prior)

--- a/examples/normal_idiomatic_tf.py
+++ b/examples/normal_idiomatic_tf.py
@@ -22,6 +22,10 @@ qz = Normal(mu=tf.Variable(tf.random_normal([])),
 
 inference = ed.MFVI({z: qz})
 inference.initialize(n_print=50)
+
+init = tf.initialize_all_variables()
+init.run()
+
 for _ in range(250):
   info_dict = inference.update()
   inference.print_progress(info_dict)

--- a/examples/normal_normal_tensorboard.py
+++ b/examples/normal_normal_tensorboard.py
@@ -23,8 +23,4 @@ data = {x: np.array([0.0] * 50, dtype=np.float32)}
 
 # analytic solution: N(mu=0.0, sigma=\sqrt{1/51}=0.140)
 inference = ed.MFVI({mu: qmu}, data)
-
-inference.initialize(logdir='train')
-for t in range(1001):
-  info_dict = inference.update()
-  inference.print_progress(t, info_dict)
+inference.run(logdir='train')

--- a/examples/tf_convolutional_vae.py
+++ b/examples/tf_convolutional_vae.py
@@ -141,6 +141,9 @@ with tf.variable_scope("model") as scope:
 with tf.variable_scope("model", reuse=True) as scope:
   p_rep = model.sample_prior(N_MINIBATCH)
 
+init = tf.initialize_all_variables()
+init.run()
+
 n_epoch = 100
 n_iter_per_epoch = 1000
 for epoch in range(n_epoch):

--- a/examples/vae.py
+++ b/examples/vae.py
@@ -42,6 +42,9 @@ inference = ed.MFVI({z: qz}, data)
 optimizer = tf.train.RMSPropOptimizer(0.01, epsilon=1.0)
 inference.initialize(optimizer=optimizer)
 
+init = tf.initialize_all_variables()
+init.run()
+
 n_epoch = 100
 n_iter_per_epoch = 1000
 for epoch in range(n_epoch):

--- a/tests/test-inferences/test_data.py
+++ b/tests/test-inferences/test_data.py
@@ -2,21 +2,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
-import numpy as np
 import edward as ed
+import numpy as np
 import six
+import tensorflow as tf
 
 from edward.models import Normal
-from edward.stats import norm
-
-
-class NormalModel:
-  """p(x, mu) = Normal(x; mu, 1) Normal(mu; 0, 1)"""
-  def log_prob(self, xs, zs):
-    log_prior = norm.logpdf(zs['mu'], 0.0, 1.0)
-    log_lik = tf.reduce_sum(norm.logpdf(xs['x'], zs['mu'], 1.0))
-    return log_lik + log_prior
 
 
 class test_inference_data_class(tf.test.TestCase):
@@ -35,76 +26,91 @@ class test_inference_data_class(tf.test.TestCase):
         features={'outcome': tf.FixedLenFeature([], tf.int64)})
     return features['outcome']
 
-  def _test(self, sess, data, n_minibatch, x=None, is_file=False):
-    model = NormalModel()
-    qmu = Normal(mu=tf.Variable(tf.random_normal([1])),
-                 sigma=tf.constant([1.0]))
+  def _test(self, sess, x_data, n_minibatch, x_val=None, is_file=False):
+    mu = Normal(mu=0.0, sigma=1.0)
+    if n_minibatch is None:
+      x = Normal(mu=tf.ones(10) * mu, sigma=1.0)
+    else:
+      x = Normal(mu=tf.ones(n_minibatch) * mu, sigma=1.0)
 
-    inference = ed.MFVI({'mu': qmu}, data, model)
+    qmu = Normal(mu=tf.Variable(tf.random_normal([])),
+                 sigma=tf.constant(1.0))
+
+    data = {x: x_data}
+    inference = ed.MFVI({mu: qmu}, data)
     inference.initialize(n_minibatch=n_minibatch)
 
-    if x is not None:
+    init = tf.initialize_all_variables()
+    init.run()
+
+    # Start input enqueue threads.
+    coord = tf.train.Coordinator()
+    threads = tf.train.start_queue_runners(coord=coord)
+
+    if x_val is not None:
       # Placeholder setting.
       # Check data is same as data fed to it.
-      feed_dict = {inference.data['x']: x}
+      feed_dict = {inference.data[x]: x_val}
       # avoid directly fetching placeholder
-      data_id = {k: tf.identity(v) for k, v in
-                 six.iteritems(inference.data)}
+      data_id = [tf.identity(v) for v in six.itervalues(inference.data)]
       val = sess.run(data_id, feed_dict)
-      assert np.all(val['x'] == x)
+      assert np.all(val == x_val)
     elif is_file:
       # File reader setting.
       # Check data varies by session run.
-      val = sess.run(inference.data)
-      val_1 = sess.run(inference.data)
-      assert not np.all(val['x'] == val_1['x'])
+      val = sess.run(inference.data[x])
+      val_1 = sess.run(inference.data[x])
+      assert not np.all(val == val_1)
     elif n_minibatch is None:
       # Preloaded full setting.
       # Check data is full data.
-      val = sess.run(inference.data)
-      assert np.all(val['x'] == data['x'])
+      val = sess.run(inference.data[x])
+      assert np.all(val == data[x])
     elif n_minibatch == 1:
       # Preloaded batch setting, with n_minibatch=1.
       # Check data is randomly shuffled.
-      assert not np.all([sess.run(inference.data)['x'] == data['x'][i]
+      assert not np.all([sess.run(inference.data)[x] == data[x][i]
                          for i in range(10)])
     else:
       # Preloaded batch setting.
       # Check data is randomly shuffled.
       val = sess.run(inference.data)
-      assert not np.all(val['x'] == data['x'][:n_minibatch])
+      assert not np.all(val[x] == data[x][:n_minibatch])
       # Check data varies by session run.
       val_1 = sess.run(inference.data)
-      assert not np.all(val['x'] == val_1['x'])
+      assert not np.all(val[x] == val_1[x])
 
     inference.finalize()
 
+    coord.request_stop()
+    coord.join(threads)
+
   def test_preloaded_full(self):
     with self.test_session() as sess:
-      data = {'x': np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])}
-      self._test(sess, data, None)
+      x_data = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+      self._test(sess, x_data, None)
 
   def test_preloaded_batch_1(self):
     with self.test_session() as sess:
-      data = {'x': np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])}
-      self._test(sess, data, 1)
+      x_data = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+      self._test(sess, x_data, 1)
 
   def test_preloaded_batch_5(self):
     with self.test_session() as sess:
-      data = {'x': np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])}
-      self._test(sess, data, 5)
+      x_data = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+      self._test(sess, x_data, 5)
 
   def test_feeding(self):
     with self.test_session() as sess:
-      x = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-      data = {'x': tf.placeholder(tf.float32)}
-      self._test(sess, data, None, x)
+      x_val = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+      x_data = tf.placeholder(tf.float32)
+      self._test(sess, x_data, None, x_val)
 
   def test_read_file(self):
     with self.test_session() as sess:
-      x = self.read_and_decode_single_example("tests/data/toy_data.tfrecords")
-      data = {'x': x}
-      self._test(sess, data, None, is_file=True)
+      x_data = self.read_and_decode_single_example(
+          "tests/data/toy_data.tfrecords")
+      self._test(sess, x_data, None, is_file=True)
 
 if __name__ == '__main__':
   ed.set_seed(1512351)


### PR DESCRIPTION
One-time TensorFlow calls are taken out of `inference.initialize()`. `inference.initialize()` is now only concerned with initialization of the inference algorithm itself; see [docstrings](https://github.com/blei-lab/edward/blob/b0494b0759a186087f75dba5d2b3fb8a96b39f19/edward/inferences/inference.py#L121).

Here are two applications you can now do with this pull request.

You run variational inference to learn an approximate posterior.  You then use the approximate posterior as a proposal distribution; you run Metropolis-Hastings.
```python
inference_proposal = ed.KLqp({z: qz}, {x: x_data})
inference_proposal.run()

empirical_z_params = tf.Variable(tf.zeros(1e4))
empirical_z = Empirical(params=empirical_z_params)

inference = ed.MetropolisHastings(
    {z: empirical_z}, 
    proposal_vars={z: qz}, 
    data={x: x_data})
inference.run(variables=[empirical_z_params])
```

You roll your own EM algorithm, using MAP for some latent variables and VI for other latent variables.
```python
inference_e = ed.KLqp({z: qz}, {x: x_data})
inference_m = ed.MAP({beta: qbeta}, {x: x_data})

inference_e.initialize(n_iter=1e4)
inference_m.initialize(n_iter=1e4)

init = tf.initialize_all_variables()
init.run()

for _ in range(inference_e.n_iter):
  inference_e.update()
  inference_m.update()
```
(with the caveat that i haven't thought about how to handle conditionals in such an algorithm here, where we are e.g., doing vi on `p(z | x, beta)` and not `p(z | x)`. my guess is that this should be implicit somehow.)