### PR TITLE
Include `feed_dict` kwarg in `Inference.run()`

### DIFF
--- a/docs/tex/tutorials/decoder.tex
+++ b/docs/tex/tutorials/decoder.tex
@@ -54,6 +54,8 @@ from 0 and 1.
 
 An example script using this model can found
 \href{https://github.com/blei-lab/edward/blob/master/examples/vae.py}
+{here}. An example with a convolutional architecture can be found
+\href{https://github.com/blei-lab/edward/blob/master/examples/convolutional_vae_prettytensor.py}
 {here}.
 %We experiment with this model in the
 %\href{/tutorials/variational-autoencoder}{variational auto-encoder} tutorial.

--- a/docs/tex/tutorials/inference-networks.tex
+++ b/docs/tex/tutorials/inference-networks.tex
@@ -95,6 +95,9 @@ gradients of the variational objective.
 An example script using this variational model can found
 \href{https://github.com/blei-lab/edward/blob/master/examples/vae.py}
 {here}.
+An example with a convolutional architecture can be found
+\href{https://github.com/blei-lab/edward/blob/master/examples/convolutional_vae_prettytensor.py}
+{here}.
 %We experiment with this model in the
 %\href{/tutorials/variational-autoencoder}{variational auto-encoder} tutorial.
 

--- a/edward/inferences/inference.py
+++ b/edward/inferences/inference.py
@@ -164,7 +164,13 @@ class Inference(object):
     else:
       init = tf.initialize_variables(variables)
 
-    init.run()
+    # Feed placeholders in case initialization depends on them.
+    feed_dict = {}
+    for key, value in six.iteritems(self.data):
+      if isinstance(key, tf.Tensor):
+        feed_dict[key] = value
+
+    init.run(feed_dict)
 
     if use_coordinator:
       # Start input enqueue threads.

--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -77,15 +77,15 @@ class KLpq(VariationalInference):
         q_log_prob[s] += tf.reduce_sum(
             qz.log_prob(tf.stop_gradient(z_sample[z])))
 
-      # Form dictionary in order to replace conditioning on prior or
-      # observed variable with conditioning on posterior sample or
-      # observed data.
-      dict_swap = z_sample
-      for x, obs in six.iteritems(self.data):
-        if isinstance(x, RandomVariable):
-          dict_swap[x] = obs
-
       if self.model_wrapper is None:
+        # Form dictionary in order to replace conditioning on prior or
+        # observed variable with conditioning on posterior sample or
+        # observed data.
+        dict_swap = z_sample
+        for x, obs in six.iteritems(self.data):
+          if isinstance(x, RandomVariable):
+            dict_swap[x] = obs
+
         for z in six.iterkeys(self.latent_vars):
           z_copy = copy(z, dict_swap, scope='inference_' + str(s))
           p_log_prob[s] += tf.reduce_sum(z_copy.log_prob(z_sample[z]))

--- a/edward/inferences/klqp.py
+++ b/edward/inferences/klqp.py
@@ -285,15 +285,15 @@ def build_reparam_loss(inference):
       z_sample[z] = qz_copy.value()
       q_log_prob[s] += tf.reduce_sum(qz.log_prob(z_sample[z]))
 
-    # Form dictionary in order to replace conditioning on prior or
-    # observed variable with conditioning on posterior sample or
-    # observed data.
-    dict_swap = z_sample
-    for x, obs in six.iteritems(inference.data):
-      if isinstance(x, RandomVariable):
-        dict_swap[x] = obs
-
     if inference.model_wrapper is None:
+      # Form dictionary in order to replace conditioning on prior or
+      # observed variable with conditioning on posterior sample or
+      # observed data.
+      dict_swap = z_sample
+      for x, obs in six.iteritems(inference.data):
+        if isinstance(x, RandomVariable):
+          dict_swap[x] = obs
+
       for z in six.iterkeys(inference.latent_vars):
         z_copy = copy(z, dict_swap, scope='inference_' + str(s))
         p_log_prob[s] += tf.reduce_sum(z_copy.log_prob(z_sample[z]))
@@ -339,15 +339,15 @@ def build_reparam_loss_kl(inference):
       qz_copy = copy(qz, scope='inference_' + str(s))
       z_sample[z] = qz_copy.value()
 
-    # Form dictionary in order to replace conditioning on prior or
-    # observed variable with conditioning on posterior sample or
-    # observed data.
-    dict_swap = z_sample
-    for x, obs in six.iteritems(inference.data):
-      if isinstance(x, RandomVariable):
-        dict_swap[x] = obs
-
     if inference.model_wrapper is None:
+      # Form dictionary in order to replace conditioning on prior or
+      # observed variable with conditioning on posterior sample or
+      # observed data.
+      dict_swap = z_sample
+      for x, obs in six.iteritems(inference.data):
+        if isinstance(x, RandomVariable):
+          dict_swap[x] = obs
+
       for x, obs in six.iteritems(inference.data):
         if isinstance(x, RandomVariable):
           x_copy = copy(x, dict_swap, scope='inference_' + str(s))
@@ -366,7 +366,6 @@ def build_reparam_loss_kl(inference):
     kl = tf.reduce_sum([tf.reduce_sum(kl_multivariate_normal(qz.mu, qz.sigma))
                         for qz in six.itervalues(inference.latent_vars)])
 
-  p_log_lik = tf.pack(p_log_lik)
   inference.loss = -(tf.reduce_mean(p_log_lik) - kl)
   return inference.loss
 
@@ -395,15 +394,15 @@ def build_reparam_loss_entropy(inference):
       qz_copy = copy(qz, scope='inference_' + str(s))
       z_sample[z] = qz_copy.value()
 
-    # Form dictionary in order to replace conditioning on prior or
-    # observed variable with conditioning on posterior sample or
-    # observed data.
-    dict_swap = z_sample
-    for x, obs in six.iteritems(inference.data):
-      if isinstance(x, RandomVariable):
-        dict_swap[x] = obs
-
     if inference.model_wrapper is None:
+      # Form dictionary in order to replace conditioning on prior or
+      # observed variable with conditioning on posterior sample or
+      # observed data.
+      dict_swap = z_sample
+      for x, obs in six.iteritems(inference.data):
+        if isinstance(x, RandomVariable):
+          dict_swap[x] = obs
+
       for z in six.iterkeys(inference.latent_vars):
         z_copy = copy(z, dict_swap, scope='inference_' + str(s))
         p_log_prob[s] += tf.reduce_sum(z_copy.log_prob(z_sample[z]))
@@ -449,15 +448,15 @@ def build_score_loss(inference):
       q_log_prob[s] += tf.reduce_sum(
           qz.log_prob(tf.stop_gradient(z_sample[z])))
 
-    # Form dictionary in order to replace conditioning on prior or
-    # observed variable with conditioning on posterior sample or
-    # observed data.
-    dict_swap = z_sample
-    for x, obs in six.iteritems(inference.data):
-      if isinstance(x, RandomVariable):
-        dict_swap[x] = obs
-
     if inference.model_wrapper is None:
+      # Form dictionary in order to replace conditioning on prior or
+      # observed variable with conditioning on posterior sample or
+      # observed data.
+      dict_swap = z_sample
+      for x, obs in six.iteritems(inference.data):
+        if isinstance(x, RandomVariable):
+          dict_swap[x] = obs
+
       for z in six.iterkeys(inference.latent_vars):
         z_copy = copy(z, dict_swap, scope='inference_' + str(s))
         p_log_prob[s] += tf.reduce_sum(z_copy.log_prob(z_sample[z]))
@@ -508,15 +507,15 @@ def build_score_loss_kl(inference):
       q_log_prob[s] += tf.reduce_sum(
           qz.log_prob(tf.stop_gradient(z_sample[z])))
 
-    # Form dictionary in order to replace conditioning on prior or
-    # observed variable with conditioning on posterior sample or
-    # observed data.
-    dict_swap = z_sample
-    for x, obs in six.iteritems(inference.data):
-      if isinstance(x, RandomVariable):
-        dict_swap[x] = obs
-
     if inference.model_wrapper is None:
+      # Form dictionary in order to replace conditioning on prior or
+      # observed variable with conditioning on posterior sample or
+      # observed data.
+      dict_swap = z_sample
+      for x, obs in six.iteritems(inference.data):
+        if isinstance(x, RandomVariable):
+          dict_swap[x] = obs
+
       for x, obs in six.iteritems(inference.data):
         if isinstance(x, RandomVariable):
           x_copy = copy(x, dict_swap, scope='inference_' + str(s))
@@ -567,15 +566,15 @@ def build_score_loss_entropy(inference):
       q_log_prob[s] += tf.reduce_sum(
           qz.log_prob(tf.stop_gradient(z_sample[z])))
 
-    # Form dictionary in order to replace conditioning on prior or
-    # observed variable with conditioning on posterior sample or
-    # observed data.
-    dict_swap = z_sample
-    for x, obs in six.iteritems(inference.data):
-      if isinstance(x, RandomVariable):
-        dict_swap[x] = obs
-
     if inference.model_wrapper is None:
+      # Form dictionary in order to replace conditioning on prior or
+      # observed variable with conditioning on posterior sample or
+      # observed data.
+      dict_swap = z_sample
+      for x, obs in six.iteritems(inference.data):
+        if isinstance(x, RandomVariable):
+          dict_swap[x] = obs
+
       for z in six.iterkeys(inference.latent_vars):
         z_copy = copy(z, dict_swap, scope='inference_' + str(s))
         p_log_prob[s] += tf.reduce_sum(z_copy.log_prob(z_sample[z]))

--- a/edward/inferences/variational_inference.py
+++ b/edward/inferences/variational_inference.py
@@ -102,9 +102,9 @@ class VariationalInference(Inference):
       raise TypeError()
 
     loss = self.build_loss()
+    var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES,
+                                 scope=scope)
     if not use_prettytensor:
-      var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES,
-                                   scope=scope)
       self.train = optimizer.minimize(loss, global_step=global_step,
                                       var_list=var_list)
     else:
@@ -112,8 +112,9 @@ class VariationalInference(Inference):
         raise NotImplementedError("PrettyTensor optimizer does not accept "
                                   "a variable scope.")
 
-      # Note PrettyTensor cannot use global_step.
-      self.train = pt.apply_optimizer(optimizer, losses=[loss])
+      self.train = pt.apply_optimizer(optimizer, losses=[loss],
+                                      global_step=global_step,
+                                      var_list=var_list)
 
   def update(self, feed_dict=None):
     """Run one iteration of optimizer for variational inference.

--- a/examples/tf_mixture_gaussian_laplace.py
+++ b/examples/tf_mixture_gaussian_laplace.py
@@ -92,7 +92,7 @@ K = 2
 D = 2
 model = MixtureGaussian(K, D)
 
-with tf.variable_scope("variational"):
+with tf.variable_scope("posterior"):
   qpi = PointMass(params=ed.to_simplex(tf.Variable(tf.random_normal([K - 1]))))
   qmu = PointMass(params=tf.Variable(tf.random_normal([K * D])))
   qsigma = PointMass(params=tf.exp(tf.Variable(tf.random_normal([K * D]))))

--- a/examples/vae.py
+++ b/examples/vae.py
@@ -17,9 +17,10 @@ from progressbar import ETA, Bar, Percentage, ProgressBar
 from scipy.misc import imsave
 from tensorflow.examples.tutorials.mnist import input_data
 
+ed.set_seed(42)
+
 M = 100  # batch size during training
 d = 2  # latent variable dimension
-ed.set_seed(42)
 
 # Probability model (subgraph)
 z = Normal(mu=tf.zeros([M, d]), sigma=tf.ones([M, d]))

--- a/examples/vae_convolutional_prettytensor.py
+++ b/examples/vae_convolutional_prettytensor.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+"""Convolutional variational auto-encoder for binarized MNIST.
+
+The neural networks are written with Pretty Tensor.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import edward as ed
+import os
+import prettytensor as pt
+import tensorflow as tf
+
+from tf_convolutional_vae_util import deconv2d
+from edward.models import Bernoulli, Normal
+from progressbar import ETA, Bar, Percentage, ProgressBar
+from scipy.misc import imsave
+from tensorflow.examples.tutorials.mnist import input_data
+
+
+def generative_network(z):
+  """Generative network to parameterize generative model. It takes
+  latent variables as input and outputs the likelihood parameters.
+
+  logits = neural_network(z)
+  """
+  with pt.defaults_scope(activation_fn=tf.nn.elu,
+                         batch_normalize=True,
+                         learned_moments_update_rate=0.0003,
+                         variance_epsilon=0.001,
+                         scale_after_normalization=True):
+    return (pt.wrap(z).
+            reshape([N_MINIBATCH, 1, 1, d]).
+            deconv2d(3, 128, edges='VALID').
+            deconv2d(5, 64, edges='VALID').
+            deconv2d(5, 32, stride=2).
+            deconv2d(5, 1, stride=2, activation_fn=None).
+            flatten()).tensor
+
+
+def inference_network(x):
+  """Inference network to parameterize variational model. It takes
+  data as input and outputs the variational parameters.
+
+  mu, sigma = neural_network(x)
+  """
+  with pt.defaults_scope(activation_fn=tf.nn.elu,
+                         batch_normalize=True,
+                         learned_moments_update_rate=0.0003,
+                         variance_epsilon=0.001,
+                         scale_after_normalization=True):
+    params = (pt.wrap(x).
+              reshape([N_MINIBATCH, 28, 28, 1]).
+              conv2d(5, 32, stride=2).
+              conv2d(5, 64, stride=2).
+              conv2d(5, 128, edges='VALID').
+              dropout(0.9).
+              flatten().
+              fully_connected(d * 2, activation_fn=None)).tensor
+
+  # Return list of vectors where mean[i], stddev[i] are the
+  # parameters of the local variational factor for data point i.
+  mu = params[:, :d]
+  sigma = tf.nn.softplus(params[:, d:])
+  return mu, sigma
+
+
+ed.set_seed(42)
+
+N_MINIBATCH = 128  # batch size during training
+d = 10  # latent variable dimension
+DATA_DIR = "data/mnist"
+IMG_DIR = "img"
+
+if not os.path.exists(DATA_DIR):
+  os.makedirs(DATA_DIR)
+if not os.path.exists(IMG_DIR):
+  os.makedirs(IMG_DIR)
+
+# DATA. MNIST batches are fed at training time.
+mnist = input_data.read_data_sets(DATA_DIR, one_hot=True)
+
+# MODEL
+z = Normal(mu=tf.zeros([N_MINIBATCH, d]), sigma=tf.ones([N_MINIBATCH, d]))
+logits = generative_network(z.value())
+x = Bernoulli(logits=logits)
+
+# INFERENCE
+x_ph = ed.placeholder(tf.float32, [N_MINIBATCH, 28 * 28])
+mu, sigma = inference_network(x_ph)
+qz = Normal(mu=mu, sigma=sigma)
+
+# Bind p(x, z) and q(z | x) to the same placeholder for x.
+data = {x: x_ph}
+inference = ed.MFVI({z: qz}, data)
+optimizer = tf.train.AdamOptimizer(0.01, epsilon=1.0)
+inference.initialize(optimizer=optimizer, use_prettytensor=True)
+
+init = tf.initialize_all_variables()
+init.run()
+
+n_epoch = 100
+n_iter_per_epoch = 1000
+for epoch in range(n_epoch):
+  avg_loss = 0.0
+
+  widgets = ["epoch #%d|" % epoch, Percentage(), Bar(), ETA()]
+  pbar = ProgressBar(n_iter_per_epoch, widgets=widgets)
+  pbar.start()
+  for t in range(n_iter_per_epoch):
+    pbar.update(t)
+    x_train, _ = mnist.train.next_batch(N_MINIBATCH)
+    info_dict = inference.update(feed_dict={x_ph: x_train})
+    avg_loss += info_dict['loss']
+
+  # Take average over all ELBOs during the epoch, and over minibatch
+  # of data points (images).
+  avg_loss = avg_loss / n_iter_per_epoch
+  avg_loss = avg_loss / N_MINIBATCH
+
+  # Print a lower bound to the average marginal likelihood for an
+  # image.
+  print("log p(x) >= {:0.3f}".format(avg_loss))
+
+  # Visualize hidden representations.
+  imgs = tf.sigmoid(logits).eval()
+  for b in range(N_MINIBATCH):
+    imsave(os.path.join(IMG_DIR, '%d.png') % b,
+           imgs[b].reshape(28, 28))


### PR DESCRIPTION
Allow user to include keyword argument `feed_dict` when calling `run` on `Inference` objects.

Covers cases where including mappings to placeholders in `data` fails.