### PR TITLE
Feature/print rvs

### DIFF
--- a/edward/__init__.py
+++ b/edward/__init__.py
@@ -15,7 +15,8 @@ from edward.inferences import Inference, MonteCarlo, VariationalInference, \
     KLpq, KLqp, MFVI, ReparameterizationKLqp, ReparameterizationKLKLqp, \
     ReparameterizationEntropyKLqp, ScoreKLqp, ScoreKLKLqp, ScoreEntropyKLqp, \
     MAP, Laplace
-from edward.models import PyMC3Model, PythonModel, StanModel
+from edward.models import PyMC3Model, PythonModel, StanModel, \
+    RandomVariable
 from edward.util import copy, cumprod, dot, Empty, get_dims, \
     get_session, hessian, kl_multivariate_normal, log_sum_exp, logit, \
     multivariate_rbf, placeholder, rbf, set_seed, tile, to_simplex

--- a/edward/inferences/monte_carlo.py
+++ b/edward/inferences/monte_carlo.py
@@ -100,8 +100,7 @@ class MonteCarlo(Inference):
     super(MonteCarlo, self).__init__(latent_vars, data, model_wrapper)
 
   def initialize(self, *args, **kwargs):
-    min_t = np.amin([
-        qz.distribution.n for qz in six.itervalues(self.latent_vars)])
+    min_t = np.amin([qz.n for qz in six.itervalues(self.latent_vars)])
     kwargs['n_iter'] = min_t
     super(MonteCarlo, self).initialize(*args, **kwargs)
 

--- a/edward/inferences/monte_carlo.py
+++ b/edward/inferences/monte_carlo.py
@@ -150,10 +150,17 @@ class MonteCarlo(Inference):
       if t == 1 or t % self.n_print == 0:
         accept_rate = info_dict['accept_rate']
         print("iter {:d} accept rate {:.2f}".format(t, accept_rate))
+        # Print running mean and standard deviations.
+        sess = get_session()
         for rv in six.itervalues(self.latent_vars):
-          print(rv)
-          std = rv.std().eval()
-          print("std: \n" + std.__str__())
+          try:
+            params = rv.params[:t]
+            mean = tf.reduce_mean(params, 0)
+            std = tf.sqrt(tf.reduce_mean(tf.square(params - mean), 0))
+            mean, std = sess.run([mean, std])
+            print({'mean': mean, 'std': std, 'name': rv.name})
+          except:
+            pass
 
   def build_update(self):
     """Build update, which returns an assign op for parameters in

--- a/edward/inferences/variational_inference.py
+++ b/edward/inferences/variational_inference.py
@@ -174,8 +174,14 @@ class VariationalInference(Inference):
       if t == 1 or t % self.n_print == 0:
         loss = info_dict['loss']
         print("iter {:d} loss {:.2f}".format(t, loss))
+        sess = get_session()
         for rv in six.itervalues(self.latent_vars):
-          print(rv)
+          try:
+            parameters = sess.run(rv.parameters)
+            parameters['name'] = rv.name
+            print(parameters)
+          except:
+            pass
 
   def build_loss(self):
     """Build loss function.

--- a/edward/models/random_variable.py
+++ b/edward/models/random_variable.py
@@ -31,22 +31,29 @@ class RandomVariable(object):
   RandomVariable wraps a distribution class from tf.contrib.distributions.
   The distribution's class methods populate this class' namespace.
   """
-  def __init__(self, dist_cls, name=None, **dist_args):
+  def __init__(self, dist_cls, **dist_args):
     tf.add_to_collection(RANDOM_VARIABLE_COLLECTION, self)
     self._dist_cls = dist_cls
     self._dist_args = dist_args
-    with tf.name_scope(name, "RandomVariable", dist_args.values()) as scope:
-      self._name = scope
-      self._dist = dist_cls(**dist_args)
-      self._value = self._dist.sample()
+    self._dist = dist_cls(**dist_args)
+    self._value = self._dist.sample()
 
-  @property
-  def name(self):
-    return self._name
+  def __str__(self):
+    return '<ed.RandomVariable \'' + self.name.__str__() + '\' ' + \
+           'shape=' + self._value.get_shape().__str__() + ' ' \
+           'dtype=' + self.dtype.__repr__() + \
+           '>'
+
+  def __repr__(self):
+    return self.__str__()
 
   @property
   def distribution(self):
     return self._dist
+
+  @property
+  def name(self):
+    return self.distribution.name
 
   @property
   def dtype(self):

--- a/edward/models/random_variables.py
+++ b/edward/models/random_variables.py
@@ -14,439 +14,142 @@ distributions = tf.contrib.distributions
 
 class Bernoulli(RandomVariable, distributions.Bernoulli):
   def __init__(self, *args, **kwargs):
-    super(Bernoulli, self).__init__(distributions.Bernoulli, *args, **kwargs)
-
-  @property
-  def logits(self):
-    return self.distribution.logits
-
-  @property
-  def p(self):
-    return self.distribution.p
-
-  @property
-  def q(self):
-    """1-p."""
-    return self.distribution.q
+    super(Bernoulli, self).__init__(*args, **kwargs)
 
 
 class Beta(RandomVariable, distributions.Beta):
   def __init__(self, *args, **kwargs):
-    super(Beta, self).__init__(distributions.Beta, *args, **kwargs)
-
-  @property
-  def a(self):
-    """Shape parameter."""
-    return self.distribution.a
-
-  @property
-  def b(self):
-    """Shape parameter."""
-    return self.distribution.b
+    super(Beta, self).__init__(*args, **kwargs)
 
 
 # class Binomial(RandomVariable, distributions.Binomial):
 #   def __init__(self, *args, **kwargs):
-#     super(Binomial, self).__init__(distributions.Binomial, *args, **kwargs)
-
-#   @property
-#   def n(self):
-#     """Number of trials."""
-#     return self.distribution.n
-
-#   @property
-#   def logits(self):
-#     """Log-odds."""
-#     return self.distribution.logits
-
-#   @property
-#   def p(self):
-#     """Probability of success."""
-#     return self.distribution.p
+#     super(Binomial, self).__init__(*args, **kwargs)
 
 
 class Categorical(RandomVariable, distributions.Categorical):
   def __init__(self, *args, **kwargs):
-    super(Categorical, self).__init__(
-        distributions.Categorical, *args, **kwargs)
-
-  @property
-  def num_classes(self):
-    return self.distribution.num_classes
-
-  @property
-  def logits(self):
-    return self.distribution.logits
+    super(Categorical, self).__init__(*args, **kwargs)
 
 
 class Chi2(RandomVariable, distributions.Chi2):
   def __init__(self, *args, **kwargs):
-    super(Chi2, self).__init__(distributions.Chi2, *args, **kwargs)
-
-  @property
-  def df(self):
-    return self.distribution.df
+    super(Chi2, self).__init__(*args, **kwargs)
 
 
 class Dirichlet(RandomVariable, distributions.Dirichlet):
   def __init__(self, *args, **kwargs):
-    super(Dirichlet, self).__init__(distributions.Dirichlet, *args, **kwargs)
-
-  @property
-  def alpha(self):
-    """Shape parameter."""
-    return self.distribution.alpha
+    super(Dirichlet, self).__init__(*args, **kwargs)
 
 
 # class DirichletMultinomial(RandomVariable,
 #                            distributions.DirichletMultinomial):
 #   def __init__(self, *args, **kwargs):
-#     super(DirichletMultinomial, self).__init__(
-#         distributions.DirichletMultinomial, *args, **kwargs)
-
-#   @property
-#   def n(self):
-#     """Parameter defining this distribution."""
-#     return self.distribution.n
-
-#   @property
-#   def alpha(self):
-#     """Parameter defining this distribution."""
-#     return self.distribution.alpha
+#     super(DirichletMultinomial, self).__init__(*args, **kwargs)
 
 
 class Exponential(RandomVariable, distributions.Exponential):
   def __init__(self, *args, **kwargs):
-    super(Exponential, self).__init__(
-        distributions.Exponential, *args, **kwargs)
-
-  @property
-  def lam(self):
-    return self.distribution.lam
+    super(Exponential, self).__init__(*args, **kwargs)
 
 
 class Gamma(RandomVariable, distributions.Gamma):
   def __init__(self, *args, **kwargs):
-    super(Gamma, self).__init__(distributions.Gamma, *args, **kwargs)
-
-  @property
-  def alpha(self):
-    """Shape parameter."""
-    return self.distribution.alpha
-
-  @property
-  def beta(self):
-    """Inverse scale parameter."""
-    return self.distribution.beta
+    super(Gamma, self).__init__(*args, **kwargs)
 
 
 class InverseGamma(RandomVariable, distributions.InverseGamma):
   def __init__(self, *args, **kwargs):
-    super(InverseGamma, self).__init__(
-        distributions.InverseGamma, *args, **kwargs)
-
-  @property
-  def alpha(self):
-    """Shape parameter."""
-    return self.distribution.alpha
-
-  @property
-  def beta(self):
-    """Scale parameter."""
-    return self.distribution.beta
+    super(InverseGamma, self).__init__(*args, **kwargs)
 
 
 class Laplace(RandomVariable, distributions.Laplace):
   def __init__(self, *args, **kwargs):
-    super(Laplace, self).__init__(distributions.Laplace, *args, **kwargs)
-
-  @property
-  def loc(self):
-    """Distribution parameter for the location."""
-    return self.distribution.loc
-
-  @property
-  def scale(self):
-    """Distribution parameter for scale."""
-    return self.distribution.scale
+    super(Laplace, self).__init__(*args, **kwargs)
 
 
 class Mixture(RandomVariable, distributions.Mixture):
   def __init__(self, *args, **kwargs):
-    super(Mixture, self).__init__(
-        distributions.Mixture, *args, **kwargs)
-
-  @property
-  def cat(self):
-    return self.mixture.cat
-
-  @property
-  def components(self):
-    return self.mixture.components
-
-  @property
-  def num_components(self):
-    return self.mixture.num_components
+    super(Mixture, self).__init__(*args, **kwargs)
 
 
 # class Multinomial(RandomVariable, distributions.Multinomial):
 #   def __init__(self, *args, **kwargs):
-#     super(Multinomial, self).__init__(
-#         distributions.Multinomial, *args, **kwargs)
-
-#   @property
-#   def n(self):
-#     """Number of trials."""
-#     return self.distribution.n
-
-#   @property
-#   def p(self):
-#     """Event probabilities."""
-#     return self.distribution.p
-
-#   @property
-#   def logits(self):
-#     """Log-odds."""
-#     return self.distribution.logits
+#     super(Multinomial, self).__init__(*args, **kwargs)
 
 
 class MultivariateNormalCholesky(RandomVariable,
                                  distributions.MultivariateNormalCholesky):
   def __init__(self, *args, **kwargs):
-    super(MultivariateNormalCholesky, self).__init__(
-        distributions.MultivariateNormalCholesky, *args, **kwargs)
-
-  @property
-  def mu(self):
-    return self.distribution.mu
-
-  @property
-  def sigma(self):
-    """Dense (batch) covariance matrix, if available."""
-    return self.distribution.sigma
+    super(MultivariateNormalCholesky, self).__init__(*args, **kwargs)
 
 
 class MultivariateNormalDiag(RandomVariable,
                              distributions.MultivariateNormalDiag):
   def __init__(self, *args, **kwargs):
-    super(MultivariateNormalDiag, self).__init__(
-        distributions.MultivariateNormalDiag, *args, **kwargs)
-
-  @property
-  def mu(self):
-    return self.distribution.mu
-
-  @property
-  def sigma(self):
-    """Dense (batch) covariance matrix, if available."""
-    return self.distribution.sigma
+    super(MultivariateNormalDiag, self).__init__(*args, **kwargs)
 
 
 class MultivariateNormalDiagPlusVDVT(RandomVariable,
                                      distributions.
                                      MultivariateNormalDiagPlusVDVT):
   def __init__(self, *args, **kwargs):
-    super(MultivariateNormalDiagPlusVDVT, self).__init__(
-        distributions.MultivariateNormalDiagPlusVDVT, *args, **kwargs)
-
-  @property
-  def mu(self):
-    return self.distribution.mu
-
-  @property
-  def sigma(self):
-    """Dense (batch) covariance matrix, if available."""
-    return self.distribution.sigma
+    super(MultivariateNormalDiagPlusVDVT, self).__init__(*args, **kwargs)
 
 
 class MultivariateNormalFull(RandomVariable,
                              distributions.MultivariateNormalFull):
   def __init__(self, *args, **kwargs):
-    super(MultivariateNormalFull, self).__init__(
-        distributions.MultivariateNormalFull, *args, **kwargs)
-
-  @property
-  def mu(self):
-    return self.distribution.mu
-
-  @property
-  def sigma(self):
-    """Dense (batch) covariance matrix, if available."""
-    return self.distribution.sigma
+    super(MultivariateNormalFull, self).__init__(*args, **kwargs)
 
 
 class Normal(RandomVariable, distributions.Normal):
   def __init__(self, *args, **kwargs):
-    super(Normal, self).__init__(distributions.Normal, *args, **kwargs)
-
-  @property
-  def mu(self):
-    """Distribution parameter for the mean."""
-    return self.distribution.mu
-
-  @property
-  def sigma(self):
-    """Distribution parameter for standard deviation."""
-    return self.distribution.sigma
+    super(Normal, self).__init__(*args, **kwargs)
 
 
 # class Poisson(RandomVariable, distributions.Poisson):
 #   def __init__(self, *args, **kwargs):
-#     super(Poisson, self).__init__(distributions.Poisson, *args, **kwargs)
-
-#   @property
-#   def lam(self):
-#     """Rate parameter."""
-#     return self.distribution.lam
+#     super(Poisson, self).__init__(*args, **kwargs)
 
 
 class QuantizedDistribution(RandomVariable,
                             distributions.QuantizedDistribution):
   def __init__(self, *args, **kwargs):
-    super(QuantizedDistribution, self).__init__(
-        distributions.QuantizedDistribution, *args, **kwargs)
-
-  @property
-  def base_distribution(self):
-    """Base distribution, p(x)."""
-    return self.distribution.base_distribution
+    super(QuantizedDistribution, self).__init__(*args, **kwargs)
 
 
 class StudentT(RandomVariable, distributions.StudentT):
   def __init__(self, *args, **kwargs):
-    super(StudentT, self).__init__(distributions.StudentT, *args, **kwargs)
-
-  @property
-  def df(self):
-    """Degrees of freedom in these Student's t distribution(s)."""
-    return self.distribution.df
-
-  @property
-  def mu(self):
-    """Locations of these Student's t distribution(s)."""
-    return self.distribution.mu
-
-  @property
-  def sigma(self):
-    """Scaling factors of these Student's t distribution(s)."""
-    return self.distribution.sigma
+    super(StudentT, self).__init__(*args, **kwargs)
 
 
 class TransformedDistribution(RandomVariable,
                               distributions.TransformedDistribution):
   def __init__(self, *args, **kwargs):
-    super(TransformedDistribution, self).__init__(
-        distributions.TransformedDistribution, *args, **kwargs)
-
-  @property
-  def base_distribution(self):
-    """Base distribution, p(x)."""
-    return self.distribution.base_distribution
-
-  @property
-  def transform(self):
-    """Function transforming x => y."""
-    return self.distribution.transform
-
-  @property
-  def inverse(self):
-    """Inverse function of transform, y => x."""
-    return self.distribution.inverse
-
-  @property
-  def log_det_jacobian(self):
-    """Function computing the log determinant of the Jacobian of transform."""
-    return self.distribution.log_det_jacobian
+    super(TransformedDistribution, self).__init__(*args, **kwargs)
 
 
 class Uniform(RandomVariable, distributions.Uniform):
   def __init__(self, *args, **kwargs):
-    super(Uniform, self).__init__(distributions.Uniform, *args, **kwargs)
-
-  @property
-  def a(self):
-    return self.distribution.a
-
-  @property
-  def b(self):
-    return self.distribution.b
+    super(Uniform, self).__init__(*args, **kwargs)
 
 
 class WishartCholesky(RandomVariable, distributions.WishartCholesky):
   def __init__(self, *args, **kwargs):
-    super(WishartCholesky, self).__init__(
-        distributions.WishartCholesky, *args, **kwargs)
-
-  @property
-  def df(self):
-    """Wishart distribution degree(s) of freedom."""
-    return self.distribution.df
-
-  def scale(self):
-    """Wishart distribution scale matrix."""
-    return self.distribution.scale()
-
-  @property
-  def scale_operator_pd(self):
-    """Wishart distribution scale matrix as an OperatorPD."""
-    return self.distribution.scale_operator_pd
-
-  @property
-  def cholesky_input_output_matrices(self):
-    """Boolean indicating if `Tensor` input/outputs are Cholesky factorized."""
-    return self.distribution.cholesky_input_output_matrices
-
-  @property
-  def dimension(self):
-    """Dimension of underlying vector space. The `p` in `R^(p*p)`."""
-    return self.distribution.dimension
+    super(WishartCholesky, self).__init__(*args, **kwargs)
 
 
 class WishartFull(RandomVariable, distributions.WishartFull):
   def __init__(self, *args, **kwargs):
-    super(WishartFull, self).__init__(
-        distributions.WishartFull, *args, **kwargs)
-
-  @property
-  def df(self):
-    """Wishart distribution degree(s) of freedom."""
-    return self.distribution.df
-
-  def scale(self):
-    """Wishart distribution scale matrix."""
-    return self.distribution.scale()
-
-  @property
-  def scale_operator_pd(self):
-    """Wishart distribution scale matrix as an OperatorPD."""
-    return self.distribution.scale_operator_pd
-
-  @property
-  def cholesky_input_output_matrices(self):
-    """Boolean indicating if `Tensor` input/outputs are Cholesky factorized."""
-    return self.distribution.cholesky_input_output_matrices
-
-  @property
-  def dimension(self):
-    """Dimension of underlying vector space. The `p` in `R^(p*p)`."""
-    return self.distribution.dimension
+    super(WishartFull, self).__init__(*args, **kwargs)
 
 
 class Empirical(RandomVariable, distributions_Empirical):
   def __init__(self, *args, **kwargs):
-    super(Empirical, self).__init__(distributions_Empirical, *args, **kwargs)
-
-  @property
-  def params(self):
-    """Distribution parameter."""
-    return self.distribution.params
+    super(Empirical, self).__init__(*args, **kwargs)
 
 
 class PointMass(RandomVariable, distributions_PointMass):
   def __init__(self, *args, **kwargs):
-    super(PointMass, self).__init__(distributions_PointMass, *args, **kwargs)
-
-  @property
-  def params(self):
-    """Distribution parameter."""
-    return self.distribution.params
+    super(PointMass, self).__init__(*args, **kwargs)

--- a/edward/models/random_variables.py
+++ b/edward/models/random_variables.py
@@ -16,13 +16,6 @@ class Bernoulli(RandomVariable, distributions.Bernoulli):
   def __init__(self, *args, **kwargs):
     super(Bernoulli, self).__init__(distributions.Bernoulli, *args, **kwargs)
 
-  def __str__(self):
-    try:
-      p = self.p.eval()
-      return "p: \n" + p.__str__()
-    except:
-      return super(Bernoulli, self).__str__()
-
   @property
   def logits(self):
     return self.distribution.logits
@@ -41,15 +34,6 @@ class Beta(RandomVariable, distributions.Beta):
   def __init__(self, *args, **kwargs):
     super(Beta, self).__init__(distributions.Beta, *args, **kwargs)
 
-  def __str__(self):
-    try:
-      sess = get_session()
-      a, b = sess.run([self.a, self.b])
-      return "a: \n" + a.__str__() + "\n" + \
-             "b: \n" + b.__str__()
-    except:
-      return super(Beta, self).__str__()
-
   @property
   def a(self):
     """Shape parameter."""
@@ -64,15 +48,6 @@ class Beta(RandomVariable, distributions.Beta):
 # class Binomial(RandomVariable, distributions.Binomial):
 #   def __init__(self, *args, **kwargs):
 #     super(Binomial, self).__init__(distributions.Binomial, *args, **kwargs)
-
-#   def __str__(self):
-#     try:
-#       sess = get_session()
-#       n, p = sess.run([self.n, self.p])
-#       return "n: \n" + n.__str__() + "\n" + \
-#              "p: \n" + p.__str__()
-#     except:
-#       return super(Binomial, self).__str__()
 
 #   @property
 #   def n(self):
@@ -95,13 +70,6 @@ class Categorical(RandomVariable, distributions.Categorical):
     super(Categorical, self).__init__(
         distributions.Categorical, *args, **kwargs)
 
-  def __str__(self):
-    try:
-      logits = self.logits.eval()
-      return "logits: \n" + logits.__str__()
-    except:
-      return super(Categorical, self).__str__()
-
   @property
   def num_classes(self):
     return self.distribution.num_classes
@@ -115,13 +83,6 @@ class Chi2(RandomVariable, distributions.Chi2):
   def __init__(self, *args, **kwargs):
     super(Chi2, self).__init__(distributions.Chi2, *args, **kwargs)
 
-  def __str__(self):
-    try:
-      df = self.df.eval()
-      return "df: \n" + df.__str__()
-    except:
-      return super(Chi2, self).__str__()
-
   @property
   def df(self):
     return self.distribution.df
@@ -130,13 +91,6 @@ class Chi2(RandomVariable, distributions.Chi2):
 class Dirichlet(RandomVariable, distributions.Dirichlet):
   def __init__(self, *args, **kwargs):
     super(Dirichlet, self).__init__(distributions.Dirichlet, *args, **kwargs)
-
-  def __str__(self):
-    try:
-      alpha = self.alpha.eval()
-      return "alpha: \n" + alpha.__str__()
-    except:
-      return super(Dirichlet, self).__str__()
 
   @property
   def alpha(self):
@@ -149,15 +103,6 @@ class Dirichlet(RandomVariable, distributions.Dirichlet):
 #   def __init__(self, *args, **kwargs):
 #     super(DirichletMultinomial, self).__init__(
 #         distributions.DirichletMultinomial, *args, **kwargs)
-
-#   def __str__(self):
-#     try:
-#       sess = get_session()
-#       n, alpha = sess.run([self.n, self.alpha])
-#       return "n: \n" + n.__str__() + "\n" + \
-#              "alpha: \n" + alpha.__str__()
-#     except:
-#       return super(DirichletMultinomial, self).__str__()
 
 #   @property
 #   def n(self):
@@ -175,13 +120,6 @@ class Exponential(RandomVariable, distributions.Exponential):
     super(Exponential, self).__init__(
         distributions.Exponential, *args, **kwargs)
 
-  def __str__(self):
-    try:
-      lam = self.lam.eval()
-      return "lam: \n" + lam.__str__()
-    except:
-      return super(Exponential, self).__str__()
-
   @property
   def lam(self):
     return self.distribution.lam
@@ -190,15 +128,6 @@ class Exponential(RandomVariable, distributions.Exponential):
 class Gamma(RandomVariable, distributions.Gamma):
   def __init__(self, *args, **kwargs):
     super(Gamma, self).__init__(distributions.Gamma, *args, **kwargs)
-
-  def __str__(self):
-    try:
-      sess = get_session()
-      alpha, beta = sess.run([self.alpha, self.beta])
-      return "alpha: \n" + alpha.__str__() + "\n" + \
-             "beta: \n" + beta.__str__()
-    except:
-      return super(Gamma, self).__str__()
 
   @property
   def alpha(self):
@@ -216,15 +145,6 @@ class InverseGamma(RandomVariable, distributions.InverseGamma):
     super(InverseGamma, self).__init__(
         distributions.InverseGamma, *args, **kwargs)
 
-  def __str__(self):
-    try:
-      sess = get_session()
-      alpha, beta = sess.run([self.alpha, self.beta])
-      return "alpha: \n" + alpha.__str__() + "\n" + \
-             "beta: \n" + beta.__str__()
-    except:
-      return super(InverseGamma, self).__str__()
-
   @property
   def alpha(self):
     """Shape parameter."""
@@ -239,15 +159,6 @@ class InverseGamma(RandomVariable, distributions.InverseGamma):
 class Laplace(RandomVariable, distributions.Laplace):
   def __init__(self, *args, **kwargs):
     super(Laplace, self).__init__(distributions.Laplace, *args, **kwargs)
-
-  def __str__(self):
-    try:
-      sess = get_session()
-      loc, scale = sess.run([self.loc, self.scale])
-      return "loc: \n" + loc.__str__() + "\n" + \
-             "scale: \n" + scale.__str__()
-    except:
-      return super(Laplace, self).__str__()
 
   @property
   def loc(self):
@@ -264,15 +175,6 @@ class Mixture(RandomVariable, distributions.Mixture):
   def __init__(self, *args, **kwargs):
     super(Mixture, self).__init__(
         distributions.Mixture, *args, **kwargs)
-
-  def __str__(self):
-    try:
-      sess = get_session()
-      cat, components = sess.run([self.cat, self.components])
-      return "cat: \n" + n.__str__() + "\n" + \
-             "components: \n" + p.__str__()
-    except:
-      return super(Mixture, self).__str__()
 
   @property
   def cat(self):
@@ -291,15 +193,6 @@ class Mixture(RandomVariable, distributions.Mixture):
 #   def __init__(self, *args, **kwargs):
 #     super(Multinomial, self).__init__(
 #         distributions.Multinomial, *args, **kwargs)
-
-#   def __str__(self):
-#     try:
-#       sess = get_session()
-#       n, p = sess.run([self.n, self.p])
-#       return "n: \n" + n.__str__() + "\n" + \
-#              "p: \n" + p.__str__()
-#     except:
-#       return super(Multinomial, self).__str__()
 
 #   @property
 #   def n(self):
@@ -323,15 +216,6 @@ class MultivariateNormalCholesky(RandomVariable,
     super(MultivariateNormalCholesky, self).__init__(
         distributions.MultivariateNormalCholesky, *args, **kwargs)
 
-  def __str__(self):
-    try:
-      sess = get_session()
-      mu, sigma = sess.run([self.mu, self.sigma])
-      return "mu: \n" + mu.__str__() + "\n" + \
-             "sigma: \n" + sigma.__str__()
-    except:
-      return super(MultivariateNormalCholesky, self).__str__()
-
   @property
   def mu(self):
     return self.distribution.mu
@@ -347,15 +231,6 @@ class MultivariateNormalDiag(RandomVariable,
   def __init__(self, *args, **kwargs):
     super(MultivariateNormalDiag, self).__init__(
         distributions.MultivariateNormalDiag, *args, **kwargs)
-
-  def __str__(self):
-    try:
-      sess = get_session()
-      mu, sigma = sess.run([self.mu, self.sigma])
-      return "mu: \n" + mu.__str__() + "\n" + \
-             "sigma: \n" + sigma.__str__()
-    except:
-      return super(MultivariateNormalDiag, self).__str__()
 
   @property
   def mu(self):
@@ -374,15 +249,6 @@ class MultivariateNormalDiagPlusVDVT(RandomVariable,
     super(MultivariateNormalDiagPlusVDVT, self).__init__(
         distributions.MultivariateNormalDiagPlusVDVT, *args, **kwargs)
 
-  def __str__(self):
-    try:
-      sess = get_session()
-      mu, sigma = sess.run([self.mu, self.sigma])
-      return "mu: \n" + mu.__str__() + "\n" + \
-             "sigma: \n" + sigma.__str__()
-    except:
-      return super(MultivariateNormalDiag, self).__str__()
-
   @property
   def mu(self):
     return self.distribution.mu
@@ -399,15 +265,6 @@ class MultivariateNormalFull(RandomVariable,
     super(MultivariateNormalFull, self).__init__(
         distributions.MultivariateNormalFull, *args, **kwargs)
 
-  def __str__(self):
-    try:
-      sess = get_session()
-      mu, sigma = sess.run([self.mu, self.sigma])
-      return "mu: \n" + mu.__str__() + "\n" + \
-             "sigma: \n" + sigma.__str__()
-    except:
-      return super(MultivariateNormalFull, self).__str__()
-
   @property
   def mu(self):
     return self.distribution.mu
@@ -421,15 +278,6 @@ class MultivariateNormalFull(RandomVariable,
 class Normal(RandomVariable, distributions.Normal):
   def __init__(self, *args, **kwargs):
     super(Normal, self).__init__(distributions.Normal, *args, **kwargs)
-
-  def __str__(self):
-    try:
-      sess = get_session()
-      mu, sigma = sess.run([self.mu, self.sigma])
-      return "mu: \n" + mu.__str__() + "\n" + \
-             "sigma: \n" + sigma.__str__()
-    except:
-      return super(Normal, self).__str__()
 
   @property
   def mu(self):
@@ -446,14 +294,6 @@ class Normal(RandomVariable, distributions.Normal):
 #   def __init__(self, *args, **kwargs):
 #     super(Poisson, self).__init__(distributions.Poisson, *args, **kwargs)
 
-#   def __str__(self):
-#     try:
-#       sess = get_session()
-#       lam = self.lam.eval()
-#       return "lam: \n" + lam.__str__()
-#     except:
-#       return super(Poisson, self).__str__()
-
 #   @property
 #   def lam(self):
 #     """Rate parameter."""
@@ -466,12 +306,6 @@ class QuantizedDistribution(RandomVariable,
     super(QuantizedDistribution, self).__init__(
         distributions.QuantizedDistribution, *args, **kwargs)
 
-  def __str__(self):
-    try:
-      return self.base_distribution.__str__()
-    except:
-      return super(QuantizedDistribution, self).__str__()
-
   @property
   def base_distribution(self):
     """Base distribution, p(x)."""
@@ -481,16 +315,6 @@ class QuantizedDistribution(RandomVariable,
 class StudentT(RandomVariable, distributions.StudentT):
   def __init__(self, *args, **kwargs):
     super(StudentT, self).__init__(distributions.StudentT, *args, **kwargs)
-
-  def __str__(self):
-    try:
-      sess = get_session()
-      df, mu, sigma = sess.run([self.df, self.mu, self.sigma])
-      return "df: \n" + df.__str__() + "\n" + \
-             "mu: \n" + mu.__str__() + "\n" + \
-             "sigma: \n" + sigma.__str__()
-    except:
-      return super(StudentT, self).__str__()
 
   @property
   def df(self):
@@ -513,12 +337,6 @@ class TransformedDistribution(RandomVariable,
   def __init__(self, *args, **kwargs):
     super(TransformedDistribution, self).__init__(
         distributions.TransformedDistribution, *args, **kwargs)
-
-  def __str__(self):
-    try:
-      return self.base_distribution.__str__()
-    except:
-      return super(TransformedDistribution, self).__str__()
 
   @property
   def base_distribution(self):
@@ -545,15 +363,6 @@ class Uniform(RandomVariable, distributions.Uniform):
   def __init__(self, *args, **kwargs):
     super(Uniform, self).__init__(distributions.Uniform, *args, **kwargs)
 
-  def __str__(self):
-    try:
-      sess = get_session()
-      a, b = sess.run([self.a, self.b])
-      return "a: \n" + a.__str__() + "\n" + \
-             "b: \n" + b.__str__()
-    except:
-      return super(Uniform, self).__str__()
-
   @property
   def a(self):
     return self.distribution.a
@@ -567,15 +376,6 @@ class WishartCholesky(RandomVariable, distributions.WishartCholesky):
   def __init__(self, *args, **kwargs):
     super(WishartCholesky, self).__init__(
         distributions.WishartCholesky, *args, **kwargs)
-
-  def __str__(self):
-    try:
-      sess = get_session()
-      a, b = sess.run([self.a, self.b])
-      return "a: \n" + a.__str__() + "\n" + \
-             "b: \n" + b.__str__()
-    except:
-      return super(WishartCholesky, self).__str__()
 
   @property
   def df(self):
@@ -607,15 +407,6 @@ class WishartFull(RandomVariable, distributions.WishartFull):
     super(WishartFull, self).__init__(
         distributions.WishartFull, *args, **kwargs)
 
-  def __str__(self):
-    try:
-      sess = get_session()
-      a, b = sess.run([self.a, self.b])
-      return "a: \n" + a.__str__() + "\n" + \
-             "b: \n" + b.__str__()
-    except:
-      return super(WishartFull, self).__str__()
-
   @property
   def df(self):
     """Wishart distribution degree(s) of freedom."""
@@ -645,13 +436,6 @@ class Empirical(RandomVariable, distributions_Empirical):
   def __init__(self, *args, **kwargs):
     super(Empirical, self).__init__(distributions_Empirical, *args, **kwargs)
 
-  def __str__(self):
-    try:
-      mean = self.mean().eval()
-      return "mean: \n" + mean.__str__()
-    except:
-      return super(Empirical, self).__str__()
-
   @property
   def params(self):
     """Distribution parameter."""
@@ -661,13 +445,6 @@ class Empirical(RandomVariable, distributions_Empirical):
 class PointMass(RandomVariable, distributions_PointMass):
   def __init__(self, *args, **kwargs):
     super(PointMass, self).__init__(distributions_PointMass, *args, **kwargs)
-
-  def __str__(self):
-    try:
-      params = self.params.eval()
-      return "params: \n" + params.__str__()
-    except:
-      return super(PointMass, self).__str__()
 
   @property
   def params(self):

--- a/edward/models/random_variables.py
+++ b/edward/models/random_variables.py
@@ -2,147 +2,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import inspect
 import tensorflow as tf
 
 from edward.models.empirical import Empirical as distributions_Empirical
 from edward.models.point_mass import PointMass as distributions_PointMass
 from edward.models.random_variable import RandomVariable
-from edward.util import get_session
-
-distributions = tf.contrib.distributions
-
-
-class Bernoulli(RandomVariable, distributions.Bernoulli):
-  def __init__(self, *args, **kwargs):
-    super(Bernoulli, self).__init__(*args, **kwargs)
-
-
-class Beta(RandomVariable, distributions.Beta):
-  def __init__(self, *args, **kwargs):
-    super(Beta, self).__init__(*args, **kwargs)
-
-
-# class Binomial(RandomVariable, distributions.Binomial):
-#   def __init__(self, *args, **kwargs):
-#     super(Binomial, self).__init__(*args, **kwargs)
-
-
-class Categorical(RandomVariable, distributions.Categorical):
-  def __init__(self, *args, **kwargs):
-    super(Categorical, self).__init__(*args, **kwargs)
-
-
-class Chi2(RandomVariable, distributions.Chi2):
-  def __init__(self, *args, **kwargs):
-    super(Chi2, self).__init__(*args, **kwargs)
-
-
-class Dirichlet(RandomVariable, distributions.Dirichlet):
-  def __init__(self, *args, **kwargs):
-    super(Dirichlet, self).__init__(*args, **kwargs)
-
-
-# class DirichletMultinomial(RandomVariable,
-#                            distributions.DirichletMultinomial):
-#   def __init__(self, *args, **kwargs):
-#     super(DirichletMultinomial, self).__init__(*args, **kwargs)
-
-
-class Exponential(RandomVariable, distributions.Exponential):
-  def __init__(self, *args, **kwargs):
-    super(Exponential, self).__init__(*args, **kwargs)
-
-
-class Gamma(RandomVariable, distributions.Gamma):
-  def __init__(self, *args, **kwargs):
-    super(Gamma, self).__init__(*args, **kwargs)
-
-
-class InverseGamma(RandomVariable, distributions.InverseGamma):
-  def __init__(self, *args, **kwargs):
-    super(InverseGamma, self).__init__(*args, **kwargs)
-
-
-class Laplace(RandomVariable, distributions.Laplace):
-  def __init__(self, *args, **kwargs):
-    super(Laplace, self).__init__(*args, **kwargs)
-
-
-class Mixture(RandomVariable, distributions.Mixture):
-  def __init__(self, *args, **kwargs):
-    super(Mixture, self).__init__(*args, **kwargs)
-
-
-# class Multinomial(RandomVariable, distributions.Multinomial):
-#   def __init__(self, *args, **kwargs):
-#     super(Multinomial, self).__init__(*args, **kwargs)
-
-
-class MultivariateNormalCholesky(RandomVariable,
-                                 distributions.MultivariateNormalCholesky):
-  def __init__(self, *args, **kwargs):
-    super(MultivariateNormalCholesky, self).__init__(*args, **kwargs)
-
-
-class MultivariateNormalDiag(RandomVariable,
-                             distributions.MultivariateNormalDiag):
-  def __init__(self, *args, **kwargs):
-    super(MultivariateNormalDiag, self).__init__(*args, **kwargs)
-
-
-class MultivariateNormalDiagPlusVDVT(RandomVariable,
-                                     distributions.
-                                     MultivariateNormalDiagPlusVDVT):
-  def __init__(self, *args, **kwargs):
-    super(MultivariateNormalDiagPlusVDVT, self).__init__(*args, **kwargs)
-
-
-class MultivariateNormalFull(RandomVariable,
-                             distributions.MultivariateNormalFull):
-  def __init__(self, *args, **kwargs):
-    super(MultivariateNormalFull, self).__init__(*args, **kwargs)
-
-
-class Normal(RandomVariable, distributions.Normal):
-  def __init__(self, *args, **kwargs):
-    super(Normal, self).__init__(*args, **kwargs)
-
-
-# class Poisson(RandomVariable, distributions.Poisson):
-#   def __init__(self, *args, **kwargs):
-#     super(Poisson, self).__init__(*args, **kwargs)
-
-
-class QuantizedDistribution(RandomVariable,
-                            distributions.QuantizedDistribution):
-  def __init__(self, *args, **kwargs):
-    super(QuantizedDistribution, self).__init__(*args, **kwargs)
-
-
-class StudentT(RandomVariable, distributions.StudentT):
-  def __init__(self, *args, **kwargs):
-    super(StudentT, self).__init__(*args, **kwargs)
-
-
-class TransformedDistribution(RandomVariable,
-                              distributions.TransformedDistribution):
-  def __init__(self, *args, **kwargs):
-    super(TransformedDistribution, self).__init__(*args, **kwargs)
-
-
-class Uniform(RandomVariable, distributions.Uniform):
-  def __init__(self, *args, **kwargs):
-    super(Uniform, self).__init__(*args, **kwargs)
-
-
-class WishartCholesky(RandomVariable, distributions.WishartCholesky):
-  def __init__(self, *args, **kwargs):
-    super(WishartCholesky, self).__init__(*args, **kwargs)
-
-
-class WishartFull(RandomVariable, distributions.WishartFull):
-  def __init__(self, *args, **kwargs):
-    super(WishartFull, self).__init__(*args, **kwargs)
+from tensorflow.contrib import distributions
 
 
 class Empirical(RandomVariable, distributions_Empirical):
@@ -153,3 +19,25 @@ class Empirical(RandomVariable, distributions_Empirical):
 class PointMass(RandomVariable, distributions_PointMass):
   def __init__(self, *args, **kwargs):
     super(PointMass, self).__init__(*args, **kwargs)
+
+
+# Automatically generate random variable classes from classes in
+# tf.contrib.distributions.
+_globals = globals()
+for _name in sorted(dir(distributions)):
+  _candidate = getattr(distributions, _name)
+  if (inspect.isclass(_candidate) and
+          _candidate != distributions.Distribution and
+          issubclass(_candidate, distributions.Distribution)):
+    _local_name = _name
+
+    class _WrapperRandomVariable(RandomVariable, _candidate):
+      def __init__(self, *args, **kwargs):
+        RandomVariable.__init__(self, *args, **kwargs)
+
+    _WrapperRandomVariable.__name__ = _local_name
+    _globals[_local_name] = _WrapperRandomVariable
+
+    del _WrapperRandomVariable
+    del _candidate
+    del _local_name


### PR DESCRIPTION
+ fixes #275 

The infrastructure of random variables in Edward is changed. There are three primary changes:

+ Random variable __methods__ are automatically generated from `tf.contrib.distributions`. Edward random variables are minimal and adapt naturally to the user's TensorFlow version.
+ Random variables __classes__ are automatically generated from `tf.contrib.distributions`. Edward random variables are minimal and adapt naturally to the user's TensorFlow version.
+ I also changed the printing behavior of random variables and inference's print progress. For the former, it is made to look more TensorFlow-ish.
  ```python
  from edward.models import Bernoulli
  x = Bernoulli(p=0.5)
  print(x)  # random variable
  ## <ed.RandomVariable 'Bernoulli/' shape=() dtype=tf.int32>
  print(x.value())  # its corresponding tensor
  ## Tensor("Bernoulli/sample/Reshape:0", shape=(), dtype=int32)
  ```
  For the latter, it is made more general and slightly less disorienting.

  ```bash
  (venv)dvt ~/Dropbox/github/edward/examples python beta_bernoulli.py
  ## iter 1 loss -8.12
  ## {'a': 1.3998759, 'a_b_sum': 2.6720104, 'b': 1.2721345, 'name': 'Beta_1/'}
  ## iter 50 loss -5.25
  ## {'a': 1.2599709, 'a_b_sum': 2.6640844, 'b': 1.4041135, 'name': 'Beta_1/'}
  ## iter 100 loss -5.46
  ## {'a': 0.76359671, 'a_b_sum': 3.1086113, 'b': 2.3450146, 'name': 'Beta_1/'}
  ## iter 150 loss -6.97
  ## {'a': 1.2843088, 'a_b_sum': 3.920516, 'b': 2.6362073, 'name': 'Beta_1/'}
  ## iter 200 loss -5.63
  ## {'a': 1.0351834, 'a_b_sum': 4.0764694, 'b': 3.0412862, 'name': 'Beta_1/'}
  ## iter 250 loss -8.92
  ## {'a': 1.0897299, 'a_b_sum': 4.4874425, 'b': 3.3977127, 'name': 'Beta_1/'}
  ```
  (Although I realize print progress is still painful to see for high-dimensional problems.)