### PR TITLE
feed placeholders if variable initialization depends on them (#273)

### DIFF
--- a/edward/inferences/inference.py
+++ b/edward/inferences/inference.py
@@ -164,7 +164,13 @@ class Inference(object):
     else:
       init = tf.initialize_variables(variables)
 
-    init.run()
+    # Feed placeholders in case initialization depends on them.
+    feed_dict = {}
+    for key, value in six.iteritems(self.data):
+      if isinstance(key, tf.Tensor):
+        feed_dict[key] = value
+
+    init.run(feed_dict)
 
     if use_coordinator:
       # Start input enqueue threads.


### PR DESCRIPTION
A fresh commit allowing placeholders to be fed if variable initialization depends on them, for instance of the data exceeds the 2Gb limits for Tensors