### PR TITLE
use build_loss_and_gradients()

### DIFF
--- a/docs/tex/tutorials/klpq.tex
+++ b/docs/tex/tutorials/klpq.tex
@@ -140,6 +140,8 @@ $q(z\;;\;\lambda)$ iteratively gets closer to the posterior $p(z \mid x)$.
 
 \subsubsection{Implementation}
 
+\textbf{Note: These details are outdated since Edward v1.1.3.}
+
 We implement $\text{KL}(q\|p)$ minimization with the importance
 sampling gradient in the class \texttt{KLpq}. It inherits from
 \texttt{VariationalInference}, which provides a collection of default

--- a/docs/tex/tutorials/klqp-reparam.tex
+++ b/docs/tex/tutorials/klqp-reparam.tex
@@ -119,6 +119,8 @@ faster convergence in a large set of problems.
 
 \subsubsection{Implementation}
 
+\textbf{Note: These details are outdated since Edward v1.1.3.}
+
 We implement $\text{KL}(q\|p)$ minimization with the
 reparameterization gradient in the class \texttt{MFVI} (mean-field
 variational inference). It inherits from

--- a/docs/tex/tutorials/klqp-score.tex
+++ b/docs/tex/tutorials/klqp-score.tex
@@ -97,6 +97,8 @@ This is an unbiased estimate of the actual gradient of the ELBO.
 
 \subsubsection{Implementation}
 
+\textbf{Note: These details are outdated since Edward v1.1.3.}
+
 We implement $\text{KL}(q\|p)$ minimization with the score function
 gradient in the class \texttt{MFVI} (mean-field variational
 inference). It inherits from \texttt{VariationalInference}, which

--- a/docs/tex/tutorials/map-laplace.tex
+++ b/docs/tex/tutorials/map-laplace.tex
@@ -35,6 +35,8 @@ gradient).
 
 \subsubsection{Implementation}
 
+\textbf{Note: These details are outdated since Edward v1.1.3.}
+
 Edward implements the Laplace approximation by extending the class built for
 \href{/tutorials/map}{MAP estimation}, as it requires an estimate of the
 posterior mode, $z_\text{MAP}$.

--- a/docs/tex/tutorials/map.tex
+++ b/docs/tex/tutorials/map.tex
@@ -92,6 +92,8 @@ efficient to distribute.
 
 \subsubsection{Implementation}
 
+\textbf{Note: These details are outdated since Edward v1.1.3.}
+
 In Edward, we view MAP estimation as a special case of
 \href{/tutorials/klqp}{$KL(q\|p)$ minimization}, where the variational
 distribution is a point mass (delta function) distribution. This makes

--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -33,7 +33,7 @@ class KLpq(VariationalInference):
     self.n_samples = n_samples
     return super(KLpq, self).initialize(*args, **kwargs)
 
-  def build_loss(self):
+  def build_loss_and_gradients(self, var_list):
     """Build loss function. Its automatic differentiation
     is a stochastic gradient of
 
@@ -105,5 +105,9 @@ class KLpq(VariationalInference):
     log_w_norm = log_w - log_sum_exp(log_w)
     w_norm = tf.exp(log_w_norm)
 
-    self.loss = tf.reduce_mean(w_norm * log_w)
-    return -tf.reduce_mean(q_log_prob * tf.stop_gradient(w_norm))
+    loss = tf.reduce_mean(w_norm * log_w)
+    gradients = tf.gradients(
+        -tf.reduce_mean(q_log_prob * tf.stop_gradient(w_norm)),
+        var_list)
+    grads_and_vars = [(grad, var) for grad, var in zip(gradients, var_list)]
+    return loss, grads_and_vars

--- a/edward/inferences/klqp.py
+++ b/edward/inferences/klqp.py
@@ -11,20 +11,14 @@ from edward.util import copy, kl_multivariate_normal
 
 
 class KLqp(VariationalInference):
-  """Variational inference with the KL divergence.
-
-  This class implements a variety of "black-box" variational inference
-  techniques (Ranganath et al., 2014) that minimize
+  """Variational inference with the KL divergence
 
   .. math::
 
     KL( q(z; \lambda) || p(z | x) ).
 
-  This is equivalent to maximizing the objective function (Jordan et al., 1999)
-
-  .. math::
-
-    ELBO =  E_{q(z; \lambda)} [ \log p(x, z) - \log q(z; \lambda) ].
+  This class minimizes the objective by automatically selecting from a
+  variety of black box inference techniques.
   """
   def __init__(self, *args, **kwargs):
     super(KLqp, self).__init__(*args, **kwargs)
@@ -61,28 +55,20 @@ class KLqp(VariationalInference):
 
     KLqp supports
 
-    1. score function gradients
-    2. reparameterization gradients
+    1. score function gradients (Paisley et al., 2012)
+    2. reparameterization gradients (Kingma and Welling, 2014)
 
     of the loss function.
 
-    If the variational model is a Gaussian distribution, then part of the
-    loss function can be computed analytically.
-
     If the variational model is a normal distribution and the prior is
-    standard normal, then part of the loss function can be computed
-    analytically following Kingma and Welling (2014),
+    standard normal, then loss function can be written as
 
     .. math::
 
-      E[\log p(x | z) + KL],
+      -E_{[\log p(x | z)] + KL( q(z; \lambda) || p(z) ),
 
-    where the KL term is computed analytically.
-
-    Returns
-    -------
-    result :
-      an appropriately selected loss function form
+    where the KL term is computed analytically (Kingma and Welling,
+    2014).
     """
     qz_is_normal = all([isinstance(rv, Normal) for
                        rv in six.itervalues(self.latent_vars)])
@@ -116,9 +102,13 @@ MFVI = KLqp  # deprecated synonym
 
 
 class ReparameterizationKLqp(VariationalInference):
-  """Variational inference with the KL divergence.
+  """Variational inference with the KL divergence
 
-  This class minimizes the KL divergence using the reparameterization
+  .. math::
+
+    KL( q(z; \lambda) || p(z | x) ).
+
+  This class minimizes the objective using the reparameterization
   gradient.
   """
   def __init__(self, *args, **kwargs):
@@ -141,9 +131,13 @@ class ReparameterizationKLqp(VariationalInference):
 
 
 class ReparameterizationKLKLqp(VariationalInference):
-  """Variational inference with the KL divergence.
+  """Variational inference with the KL divergence
 
-  This class minimizes the KL divergence using the reparameterization
+  .. math::
+
+    KL( q(z; \lambda) || p(z | x) ).
+
+  This class minimizes the objective using the reparameterization
   gradient and an analytic KL term.
   """
   def __init__(self, *args, **kwargs):
@@ -166,9 +160,13 @@ class ReparameterizationKLKLqp(VariationalInference):
 
 
 class ReparameterizationEntropyKLqp(VariationalInference):
-  """Variational inference with the KL divergence.
+  """Variational inference with the KL divergence
 
-  This class minimizes the KL divergence using the reparameterization
+  .. math::
+
+    KL( q(z; \lambda) || p(z | x) ).
+
+  This class minimizes the objective using the reparameterization
   gradient and an analytic entropy term.
   """
   def __init__(self, *args, **kwargs):
@@ -192,9 +190,13 @@ class ReparameterizationEntropyKLqp(VariationalInference):
 
 
 class ScoreKLqp(VariationalInference):
-  """Variational inference with the KL divergence.
+  """Variational inference with the KL divergence
 
-  This class minimizes the KL divergence using the score function
+  .. math::
+
+    KL( q(z; \lambda) || p(z | x) ).
+
+  This class minimizes the objective using the score function
   gradient.
   """
   def __init__(self, *args, **kwargs):
@@ -217,10 +219,14 @@ class ScoreKLqp(VariationalInference):
 
 
 class ScoreKLKLqp(VariationalInference):
-  """Variational inference with the KL divergence.
+  """Variational inference with the KL divergence
 
-  This class minimizes the KL divergence using the score function
-  gradient and an analytic KL term.
+  .. math::
+
+    KL( q(z; \lambda) || p(z | x) ).
+
+  This class minimizes the objective using the score function gradient
+  and an analytic KL term.
   """
   def __init__(self, *args, **kwargs):
     super(ScoreKLKLqp, self).__init__(*args, **kwargs)
@@ -242,10 +248,14 @@ class ScoreKLKLqp(VariationalInference):
 
 
 class ScoreEntropyKLqp(VariationalInference):
-  """Variational inference with the KL divergence.
+  """Variational inference with the KL divergence
 
-  This class minimizes the KL divergence using the score function
-  gradient and an analytic entropy term.
+  .. math::
+
+    KL( q(z; \lambda) || p(z | x) ).
+
+  This class minimizes the objective using the score function gradient
+  and an analytic entropy term.
   """
   def __init__(self, *args, **kwargs):
     super(ScoreEntropyKLqp, self).__init__(*args, **kwargs)
@@ -274,7 +284,7 @@ def build_reparam_loss(inference):
 
     -ELBO =  -E_{q(z; \lambda)} [ \log p(x, z) - \log q(z; \lambda) ]
 
-  based on the reparameterization trick. (Kingma and Welling, 2014)
+  based on the reparameterization trick (Kingma and Welling, 2014).
 
   Computed by sampling from :math:`q(z;\lambda)` and evaluating the
   expectation using Monte Carlo sampling.
@@ -325,7 +335,7 @@ def build_reparam_kl_loss(inference):
     -ELBO =  - ( E_{q(z; \lambda)} [ \log p(x | z) ]
           + KL(q(z; \lambda) || p(z)) )
 
-  based on the reparameterization trick. (Kingma and Welling, 2014)
+  based on the reparameterization trick (Kingma and Welling, 2014).
 
   It assumes the KL is analytic.
 
@@ -383,7 +393,7 @@ def build_reparam_entropy_loss(inference):
     -ELBO =  -( E_{q(z; \lambda)} [ \log p(x , z) ]
           + H(q(z; \lambda)) )
 
-  based on the reparameterization trick. (Kingma and Welling, 2014)
+  based on the reparameterization trick (Kingma and Welling, 2014).
 
   It assumes the entropy is analytic.
 
@@ -429,14 +439,8 @@ def build_reparam_entropy_loss(inference):
 
 
 def build_score_loss_and_gradients(inference, var_list):
-  """Build loss function. Its automatic differentiation
-  is a stochastic gradient of
-
-  .. math::
-
-    -ELBO =  -E_{q(z; \lambda)} [ \log p(x, z) - \log q(z; \lambda) ]
-
-  based on the score function estimator. (Paisley et al., 2012)
+  """Build loss function and gradients based on the score function
+  estimator (Paisley et al., 2012).
 
   Computed by sampling from :math:`q(z;\lambda)` and evaluating the
   expectation using Monte Carlo sampling.
@@ -486,15 +490,8 @@ def build_score_loss_and_gradients(inference, var_list):
 
 
 def build_score_kl_loss_and_gradients(inference, var_list):
-  """Build loss function. Its automatic differentiation
-  is a stochastic gradient of
-
-  .. math::
-
-    -ELBO =  - ( E_{q(z; \lambda)} [ \log p(x | z) ]
-           + KL(q(z; \lambda) || p(z)) )
-
-  based on the score function estimator. (Paisley et al., 2012)
+  """Build loss function and gradients based on the score function
+  estimator (Paisley et al., 2012).
 
   It assumes the KL is analytic.
 
@@ -552,15 +549,8 @@ def build_score_kl_loss_and_gradients(inference, var_list):
 
 
 def build_score_entropy_loss_and_gradients(inference, var_list):
-  """Build loss function. Its automatic differentiation
-  is a stochastic gradient of
-
-  .. math::
-
-    -ELBO =  - ( E_{q(z; \lambda)} [ \log p(x, z) ]
-          + H(q(z; \lambda)) )
-
-  based on the score function estimator. (Paisley et al., 2012)
+  """Build loss function and gradients based on the score function
+  estimator (Paisley et al., 2012).
 
   It assumes the entropy is analytic.
 

--- a/edward/inferences/map.py
+++ b/edward/inferences/map.py
@@ -14,7 +14,7 @@ class MAP(VariationalInference):
   """Maximum a posteriori.
 
   We implement this using a ``PointMass`` variational distribution to
-  solve the following optimization problem
+  solve the optimization problem
 
   .. math::
 
@@ -117,8 +117,7 @@ class MAP(VariationalInference):
       x = self.data
       p_log_prob = self.model_wrapper.log_prob(x, z_mode)
 
-    self.loss = -p_log_prob
-    return self.loss
+    return -p_log_prob
 
 
 class Laplace(MAP):

--- a/examples/tf_convolutional_vae.py
+++ b/examples/tf_convolutional_vae.py
@@ -126,7 +126,7 @@ qz = Normal(mu=mu, sigma=sigma)
 
 # Bind p(x, z) and q(z | x) to the same placeholder for x.
 data = {'x': x_ph}
-inference = ed.MFVI({'z': qz}, data, model)
+inference = ed.ReparameterizationKLKLqp({'z': qz}, data, model)
 with tf.variable_scope("model") as scope:
   optimizer = tf.train.AdamOptimizer(0.01, epsilon=1.0)
   inference.initialize(optimizer=optimizer, use_prettytensor=True)

--- a/examples/vae_convolutional_prettytensor.py
+++ b/examples/vae_convolutional_prettytensor.py
@@ -93,7 +93,7 @@ qz = Normal(mu=mu, sigma=sigma)
 
 # Bind p(x, z) and q(z | x) to the same placeholder for x.
 data = {x: x_ph}
-inference = ed.MFVI({z: qz}, data)
+inference = ed.ReparameterizationKLKLqp({z: qz}, data)
 optimizer = tf.train.AdamOptimizer(0.01, epsilon=1.0)
 inference.initialize(optimizer=optimizer, use_prettytensor=True)
 


### PR DESCRIPTION
This enables individual gradient calculations for each parameter.  It follows @bayerj's suggestion (#247), which implements a `build_loss_and_gradients()` method.

(An immediate application I have in mind is Rao-Blackwellized gradients for black box inference.)

Remarks
+ Currently, all variational methods use gradient-based optimization. Whenever we get to discrete optimization, e.g., with conjugate updates, we can do additional refactoring.  For example, `VariationalInference` can have a `build_update()` method analogous to Monte Carlo methods.

todos
+ [x] prettytensor does not support applying manual gradients to an optimizer. figure out how to still support it
+ [x] update `docs/` and inference docstrings