### PR TITLE
Adding comment on helper functions for MDN tutorial

### DIFF
--- a/docs/tex/tutorials/mixture-density-network.tex
+++ b/docs/tex/tutorials/mixture-density-network.tex
@@ -192,7 +192,7 @@ We see that it converges after 400 iterations.
 Let's look at how a few individual examples perform. Note that as this
 is an inverse problem we can't get the answer correct, but we can hope
 that the truth lies in area where the model has high probability. This code relies on helper functions
-available in the full script aboves.
+available in the full script above.
 
 In this plot the truth is the vertical grey line while the blue line is the prediction of the mixture density network. As you can see, we didn't do too bad.
 

--- a/docs/tex/tutorials/mixture-density-network.tex
+++ b/docs/tex/tutorials/mixture-density-network.tex
@@ -191,7 +191,10 @@ We see that it converges after 400 iterations.
 
 Let's look at how a few individual examples perform. Note that as this
 is an inverse problem we can't get the answer correct, but we can hope
-that the truth lies in area where the model has high probability.
+that the truth lies in area where the model has high probability. This code relies on helper functions
+available in the full script 
+\href{https://github.com/blei-lab/edward/blob/master/examples/tf_mixture_density_network_demo.py}
+{here}.
 
 In this plot the truth is the vertical grey line while the blue line is the prediction of the mixture density network. As you can see, we didn't do too bad.
 

--- a/docs/tex/tutorials/mixture-density-network.tex
+++ b/docs/tex/tutorials/mixture-density-network.tex
@@ -192,9 +192,7 @@ We see that it converges after 400 iterations.
 Let's look at how a few individual examples perform. Note that as this
 is an inverse problem we can't get the answer correct, but we can hope
 that the truth lies in area where the model has high probability. This code relies on helper functions
-available in the full script 
-\href{https://github.com/blei-lab/edward/blob/master/examples/tf_mixture_density_network_demo.py}
-{here}.
+available in the full script aboves.
 
 In this plot the truth is the vertical grey line while the blue line is the prediction of the mixture density network. As you can see, we didn't do too bad.
 


### PR DESCRIPTION
Adding a short sentence near the end of the MDN tutorial to note that its necessary to grab the helper functions from the full script to run the code in the tutorial.