### PR TITLE
Fixes an issue where a new Div node is created every update

### DIFF
--- a/edward/inferences/monte_carlo.py
+++ b/edward/inferences/monte_carlo.py
@@ -105,6 +105,7 @@ class MonteCarlo(Inference):
     super(MonteCarlo, self).initialize(*args, **kwargs)
 
     self.n_accept = tf.Variable(0, trainable=False)
+    self.n_accept_over_t = self.n_accept / self.t
     self.train = self.build_update()
 
   def update(self, feed_dict=None):
@@ -137,7 +138,7 @@ class MonteCarlo(Inference):
         feed_dict[key] = value
 
     sess = get_session()
-    _, accept_rate = sess.run([self.train, self.n_accept / self.t], feed_dict)
+    _, accept_rate = sess.run([self.train, self.n_accept_over_t], feed_dict)
     t = sess.run(self.increment_t)
     return {'t': t, 'accept_rate': accept_rate}
 


### PR DESCRIPTION
The division in the line
```
_, accept_rate = sess.run([self.train, self.n_accept / self.t], feed_dict)
```
creates a new op every time it's run, which is once per iteration. This is a huge drag on performance.