### PR TITLE
Fix python3 random import error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 *.xdy
 *.tdo
 *.pyc
+*.swp
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ script:
   - if [[ "$TEST_MODE" == "PEP8" ]]; then
        PYTHONPATH=$PWD:$PYTHONPATH py.test --pep8 -m pep8 -n0;
     else
-       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/;
+       PYTHONPATH=$PWD:$PYTHONPATH py.test;
     fi
 after_success:
   - coveralls

--- a/edward/stats/distributions.py
+++ b/edward/stats/distributions.py
@@ -1095,9 +1095,3 @@ for _name in sorted(dir(distributions)):
       del _WrapperDistribution
       del _object_name
       del _candidate
-
-# Display only the objects and not their classes in this module.
-_globals_keys = list(six.iterkeys(_globals))
-_globals_values = list(six.itervalues(_globals))
-__all__ = [name for name, method in zip(_globals_keys, _globals_values)
-           if not inspect.isclass(method)]

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,6 @@ ignore=E111,E114
 # Set maximum allowed line length (default: 79)
 max-line-length=80
 
-[pytest]
+[tool:pytest]
 pep8ignore = E111 E114
 pep8maxlinelength = 80


### PR DESCRIPTION
This PR acts as a temporary fix to #309. The problem seems to be that with Python 3 `inspect.isclass` sometimes randomly filters out some of the objects, which causes import error when unit tests try to load these objects. This is by no mean a permanent fix though.