### PR TITLE
specify initial value in RandomVariable models

### DIFF
--- a/edward/models/random_variable.py
+++ b/edward/models/random_variable.py
@@ -69,9 +69,9 @@ class RandomVariable(object):
                         self.get_event_shape().as_list())
       value_shape = t_value.get_shape().as_list()
       if value_shape != expected_shape:
-        raise valueerror(
-          "incompatible shape for initialization argument 'value'."
-          "expected '%s', got '%s'" % (expected_shape, value_shape))
+        raise ValueError(
+            "incompatible shape for initialization argument 'value'."
+            "expected '%s', got '%s'" % (expected_shape, value_shape))
       else:
         self._value = t_value
     else:

--- a/edward/models/random_variable.py
+++ b/edward/models/random_variable.py
@@ -53,10 +53,14 @@ class RandomVariable(object):
   """
   def __init__(self, *args, **kwargs):
     # storing args, kwargs for easy graph copying
-    value = kwargs.pop('value', None)
     self._args = args
     self._kwargs = kwargs
+
+    # need to temporarily pop value before __init__
+    value = kwargs.pop('value', None)
     super(RandomVariable, self).__init__(*args, **kwargs)
+    self._kwargs['value'] = value  # reinsert (needed for copying)
+
     tf.add_to_collection(RANDOM_VARIABLE_COLLECTION, self)
 
     if value is not None:

--- a/edward/models/random_variable.py
+++ b/edward/models/random_variable.py
@@ -60,18 +60,18 @@ class RandomVariable(object):
     tf.add_to_collection(RANDOM_VARIABLE_COLLECTION, self)
 
     if value is not None:
-        t_value = tf.convert_to_tensor(value, self.dtype)
-        expected_shape = (self.get_batch_shape().as_list() +
-                          self.get_event_shape().as_list())
-        value_shape = t_value.get_shape().as_list()
-        if value_shape != expected_shape:
-          raise ValueError(
-              "Incompatible shape for initialization argument 'value'."
-              "Expected '%s', got '%s'" % (expected_shape, value_shape))
-        else:
-            self._value = t_value
+      t_value = tf.convert_to_tensor(value, self.dtype)
+      expected_shape = (self.get_batch_shape().as_list() +
+                        self.get_event_shape().as_list())
+      value_shape = t_value.get_shape().as_list()
+      if value_shape != expected_shape:
+        raise valueerror(
+          "incompatible shape for initialization argument 'value'."
+          "expected '%s', got '%s'" % (expected_shape, value_shape))
+      else:
+        self._value = t_value
     else:
-        self._value = self.sample()
+      self._value = self.sample()
 
   def __str__(self):
     return '<ed.RandomVariable \'' + self.name.__str__() + '\' ' + \

--- a/tests/test-models/test_random_variable_init_value.py
+++ b/tests/test-models/test_random_variable_init_value.py
@@ -8,7 +8,7 @@ import tensorflow as tf
 from edward.models import RandomVariable
 
 from edward.models import *
-from edward.util import get_dims
+from edward.util import get_dims, copy
 
 
 def _test(RV, value, *args, **kwargs):
@@ -18,6 +18,13 @@ def _test(RV, value, *args, **kwargs):
                     rv.get_event_shape().as_list())
   assert value_shape == 0
   assert rv.dtype == rv._value.dtype
+
+def _test_copy(RV, value, *args, **kwargs):
+  rv1 = RV(*args, value=value, **kwargs)
+  rv2 = copy(rv1)
+  value_shape1 = rv1._value.get_shape().as_list()
+  value_shape2 = rv2._value.get_shape().as_list()
+  assert value_shape1 == value_shape2
 
 
 class test_random_variable_init_value_class(tf.test.TestCase):
@@ -33,6 +40,12 @@ class test_random_variable_init_value_class(tf.test.TestCase):
           _test(Normal, 2, mu=[0.5, 0.5], sigma=1.)
           _test(Normal, 2, mu=[0.5], sigma=[1.])
           _test(Normal, [2], mu=0.5, sigma=1.)
+
+  def check_copy(self):
+    with self.test_session():
+      _test_copy(Normal, 2, mu=0.5, sigma=1.)
+      _test_copy(Normal, [2], mu=[0.5], sigma=[1.])
+      _test_copy(Poisson, 2, lam=0.5)
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tests/test-models/test_random_variable_init_value.py
+++ b/tests/test-models/test_random_variable_init_value.py
@@ -16,7 +16,7 @@ def _test(RV, value, *args, **kwargs):
   value_shape = rv._value.get_shape().as_list()
   expected_shape = (rv.get_batch_shape().as_list() +
                     rv.get_event_shape().as_list())
-  assert value_shape == 0
+  assert value_shape == expected_shape 
   assert rv.dtype == rv._value.dtype
 
 
@@ -29,20 +29,19 @@ def _test_copy(RV, value, *args, **kwargs):
 
 
 class test_random_variable_init_value_class(tf.test.TestCase):
-  def check_shape_and_dtype(self):
+  def test_shape_and_dtype(self):
     with self.test_session():
       _test(Normal, 2, mu=0.5, sigma=1.)
       _test(Normal, [2], mu=[0.5], sigma=[1.])
       _test(Poisson, 2, lam=0.5)
 
-  def check_mismatch_raises(self):
+  def test_mismatch_raises(self):
     with self.test_session():
-        with pytest.raises(ValueError):
-          _test(Normal, 2, mu=[0.5, 0.5], sigma=1.)
-          _test(Normal, 2, mu=[0.5], sigma=[1.])
-          _test(Normal, [2], mu=0.5, sigma=1.)
+      self.assertRaises(ValueError, _test, Normal, 2, mu=[0.5, 0.5], sigma=1.)
+      self.assertRaises(ValueError, _test, Normal, 2, mu=[0.5], sigma=[1.])
+      self.assertRaises(ValueError, _test, Normal, [2], mu=0.5, sigma=1.)
 
-  def check_copy(self):
+  def test_copy(self):
     with self.test_session():
       _test_copy(Normal, 2, mu=0.5, sigma=1.)
       _test_copy(Normal, [2], mu=[0.5], sigma=[1.])

--- a/tests/test-models/test_random_variable_init_value.py
+++ b/tests/test-models/test_random_variable_init_value.py
@@ -19,6 +19,7 @@ def _test(RV, value, *args, **kwargs):
   assert value_shape == 0
   assert rv.dtype == rv._value.dtype
 
+
 def _test_copy(RV, value, *args, **kwargs):
   rv1 = RV(*args, value=value, **kwargs)
   rv2 = copy(rv1)

--- a/tests/test-models/test_random_variable_init_value.py
+++ b/tests/test-models/test_random_variable_init_value.py
@@ -16,7 +16,7 @@ def _test(RV, value, *args, **kwargs):
   value_shape = rv._value.get_shape().as_list()
   expected_shape = (rv.get_batch_shape().as_list() +
                     rv.get_event_shape().as_list())
-  assert value_shape == expected_shape 
+  assert value_shape == expected_shape
   assert rv.dtype == rv._value.dtype
 
 

--- a/tests/test-models/test_random_variable_init_value.py
+++ b/tests/test-models/test_random_variable_init_value.py
@@ -12,12 +12,11 @@ from edward.util import get_dims
 
 
 def _test(RV, value, *args, **kwargs):
-  rv = RV(*args, **kwargs, value=value)
+  rv = RV(*args, value=value, **kwargs)
   value_shape = rv._value.get_shape().as_list()
   expected_shape = (rv.get_batch_shape().as_list() +
                     rv.get_event_shape().as_list())
   assert value_shape == 0
-  # assert value_shape == expected_shape
   assert rv.dtype == rv._value.dtype
 
 

--- a/tests/test-models/test_random_variable_init_value.py
+++ b/tests/test-models/test_random_variable_init_value.py
@@ -1,0 +1,39 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import tensorflow as tf
+
+from edward.models import RandomVariable
+
+from edward.models import *
+from edward.util import get_dims
+
+
+def _test(RV, value, *args, **kwargs):
+  rv = RV(*args, **kwargs, value=value)
+  value_shape = rv._value.get_shape().as_list()
+  expected_shape = (rv.get_batch_shape().as_list() +
+                    rv.get_event_shape().as_list())
+  assert value_shape == 0
+  # assert value_shape == expected_shape
+  assert rv.dtype == rv._value.dtype
+
+
+class test_random_variable_init_value_class(tf.test.TestCase):
+  def check_shape_and_dtype(self):
+    with self.test_session():
+      _test(Normal, 2, mu=0.5, sigma=1.)
+      _test(Normal, [2], mu=[0.5], sigma=[1.])
+      _test(Poisson, 2, lam=0.5)
+
+  def check_mismatch_raises(self):
+    with self.test_session():
+        with pytest.raises(ValueError):
+          _test(Normal, 2, mu=[0.5, 0.5], sigma=1.)
+          _test(Normal, 2, mu=[0.5], sigma=[1.])
+          _test(Normal, [2], mu=0.5, sigma=1.)
+
+if __name__ == '__main__':
+  tf.test.main()


### PR DESCRIPTION
- needed for rvs like Poisson with no implemented sample()
- converts value= keyword to tensor of dtype to match distribution
- tests check that dtype of _value attribute is correct and shape
  matches batch_shape + event_shape