### PR TITLE
Inference compositionality

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -71,12 +71,22 @@ PAGES = [
         'parent_pages': [],
         'child_pages': [
             'inference-classes.tex',
+            'inference-compositionality.tex',
             'inference-development.tex',
         ],
     },
     {
         'page': 'inference-classes.tex',
         'title': 'Classes',
+        'source_pages': [],
+        'parent_pages': [
+            'inference.tex'
+        ],
+        'child_pages': [],
+    },
+    {
+        'page': 'inference-compositionality.tex',
+        'title': 'Compositionality',
         'source_pages': [],
         'parent_pages': [
             'inference.tex'

--- a/docs/tex/api/inference-compositionality.tex
+++ b/docs/tex/api/inference-compositionality.tex
@@ -46,24 +46,6 @@ Laplace variational inference \citep{wang2013variational};
 and
 structured variational auto-encoders \citep{johnson2016composing}.
 
-One can also do this without passing in the random variables
-explicitly as part of the data, restricting the inner integral to be
-approximated with one sample.
-\begin{lstlisting}[language=Python]
-qbeta = PointMass()
-qz = RandomVariable()
-
-inference_e = ed.KLqp({z: qz}, data={x: x_train, beta: qbeta.value()})
-inference_m = ed.MAP({beta: qbeta}, data={x: x_train, z: qz.value()})
-
-for _ in range(10000):
-  inference_e.update()
-  inference_m.update()
-\end{lstlisting}
-Note this is equivalent for the E-step, as the $q(\beta)$ is a point mass
-anyways. In general, passing the whole random variable vs a sample
-are different: the former can use multiple samples.
-
 \subsubsection{Message passing algorithms}
 
 Message passing algorithms operate on the posterior distribution using

--- a/docs/tex/api/inference-compositionality.tex
+++ b/docs/tex/api/inference-compositionality.tex
@@ -1,0 +1,132 @@
+\title{Composing Inferences}
+
+{{navbar}}
+
+\subsubsection{Composing Inferences}
+
+Core to Edward's design is compositionality. Compositionality enables
+fine control of inference, where we can write inference as a
+collection of separate inference programs.
+
+We outline how to write popular classes of compositional inferences
+using Edward: hybrid algorithms and message passing algorithms.
+We use the running example of a mixture model.
+
+\subsubsection{Hybrid algorithms}
+
+Hybrid algorithms leverage different inferences for each latent
+variable in the posterior.
+As an example, we demonstrate variational EM, with an approximate
+E-step over local variables and an M-step over global variables.
+We alternate with one update of each \citep{neal1993new}.
+
+\begin{lstlisting}[language=Python]
+qbeta = PointMass(params=tf.Variable(tf.zeros([K, D])))
+qz = Categorical(logits=tf.Variable(tf.zeros[N, K]))
+
+inference_e = ed.VariationalInference({z: qz}, data={x: x_data, beta: qbeta})
+inference_m = ed.MAP({beta: qbeta}, data={x: x_data, z: qz})
+...
+for _ in range(10000):
+  inference_e.update()
+  inference_m.update()
+\end{lstlisting}
+
+In \texttt{data}, we include bindings of prior latent
+variables to posterior latent variables. This performs
+conditional inference, where only a subset of the posterior is
+inferred while the rest are fixed using other inferences.
+
+This extends to many algorithms: for example,
+exact EM for exponential families;
+contrastive divergence \citep{hinton2002training};
+pseudo-marginal and ABC methods \citep{andrieu2009pseudo};
+Gibbs sampling within variational inference \citep{wang2012truncation};
+Laplace variational inference \citep{wang2013variational};
+and
+structured variational auto-encoders \citep{johnson2016composing}.
+
+One can also do this without passing in the random variables
+explicitly as part of the data, restricting the inner integral to be
+approximated with one sample.
+\begin{lstlisting}[language=Python]
+qbeta = PointMass()
+qz = RandomVariable()
+
+inference_e = ed.KLqp({z: qz}, data={x: x_train, beta: qbeta.value()})
+inference_m = ed.MAP({beta: qbeta}, data={x: x_train, z: qz.value()})
+
+for _ in range(10000):
+  inference_e.update()
+  inference_m.update()
+\end{lstlisting}
+Note this is equivalent for the E-step, as the $q(\beta)$ is a point mass
+anyways. In general, passing the whole random variable vs a sample
+are different: the former can use multiple samples.
+
+\subsubsection{Message passing algorithms}
+
+Message passing algorithms operate on the posterior distribution using
+a collection of local inferences \citep{koller2009probabilistic}.
+As an example, we demonstrate expectation propagation. We split a
+mixture model to be over two random variables \texttt{x1} and
+\texttt{x2} along with their latent mixture assignments \texttt{z1}
+and \texttt{z2}.
+
+\begin{lstlisting}[language=Python]
+N1 = 1000  # number of data points in first data set
+N2 = 2000  # number of data points in second data set
+D = 2  # data dimension
+K = 5  # number of clusters
+
+# MODEL
+beta = Normal(mu=tf.zeros([K, D]), sigma=tf.ones([K, D]))
+z1 = Categorical(logits=tf.zeros([N1, K]))
+z2 = Categorical(logits=tf.zeros([N2, K]))
+x1 = Normal(mu=tf.gather(beta, z1), sigma=tf.ones([N1, D]))
+x2 = Normal(mu=tf.gather(beta, z2), sigma=tf.ones([N2, D]))
+
+# INFERENCE
+qbeta = Normal(mu=tf.Variable(tf.zeros([K, D])),
+               sigma=tf.nn.softplus(tf.Variable(tf.zeros([K, D]))))
+qz1 = Categorical(logits=tf.Variable(tf.zeros[N1, K]))
+qz2 = Categorical(logits=tf.Variable(tf.zeros[N2, K]))
+
+inference_z1 = ed.KLpq({beta: qbeta, z1: qz1}, {x1: x1_train})
+inference_z2 = ed.KLpq({beta: qbeta, z2: qz2}, {x2: x2_train})
+...
+for _ in range(10000):
+  inference_z1.update()
+  inference_z2.update()
+\end{lstlisting}
+
+We alternate updates for each local inference, where the global
+posterior factor $q(\beta)$ is shared across both inferences
+\citep{gelman2014expectation}.
+
+This extends to many algorithms: for example,
+classical message passing, which performs exact local inferences;
+Gibbs sampling, which draws samples from conditionally conjugate
+inferences \citep{geman1984stochastic};
+expectation propagation, which locally minimizes
+$\text{KL}(p || q)$ over exponential families \citep{minka2001expectation};
+integrated nested Laplace
+approximation, which performs local Laplace approximations
+\citep{rue2009approximate};
+and
+all the instantiations of EP-like algorithms in
+\citet{gelman2014expectation}.
+
+In the above, we perform local inferences split over individual random
+variables. At the moment, Edward does not support local inferences
+within a random variable itself. We cannot do local inferences when
+representing the random variable for all data points and their cluster
+membership as \texttt{x} and \texttt{z} rather than \texttt{x1},
+\texttt{x2}, \texttt{z1}, and \texttt{z2}.
+
+With TensorFlow's distributed training, note that compositionality
+enables \emph{distributed} message passing over a cluster with many
+workers. The computation can be further sped up with the use of GPUs
+via data and model parallelism.
+
+\subsubsection{References}\label{references}

--- a/docs/tex/api/inference.tex
+++ b/docs/tex/api/inference.tex
@@ -96,6 +96,27 @@ from high-level libraries such as Keras and TensorFlow Slim. See
 the \href{/api/model-compositionality}{model compositionality} page
 for more details.
 
+\textbf{Conditional inference}.
+In conditional inference, only a subset of the posterior is inferred
+while the rest are fixed using other inferences. The inference
+problem is
+\begin{equation*}
+q(\beta)q(\mathbf{z})\approx
+p(\mathbf{z}, \beta\mid\mathbf{x}_{\text{train}})
+\end{equation*}
+where parameters in $q(\beta)$ are estimated and $q(\mathbf{z})$ is
+fixed.
+%
+In Edward, we enable conditioning by binding random variables to other
+random variables in \texttt{data}.
+\begin{lstlisting}[language=Python]
+inference = ed.Inference({beta: qbeta}, {x: x_train, z: qz})
+\end{lstlisting}
+
+In the \href{/api/inference-compositionality}{compositionality page},
+we describe how to construct inference by composing
+many conditional inference algorithms.
+
 \textbf{Implicit prior samples}.
 Latent variables can be defined in the model without any posterior
 inference over them. They are implicitly marginalized out with a

--- a/docs/tex/bib.bib
+++ b/docs/tex/bib.bib
@@ -387,3 +387,137 @@ title = {Swift: {C}ompiled Inference for Probabilistic Programming Languages},
 journal = {arXiv preprint arXiv:1606.09242},
 year = {2016},
 }
+
+@article{doucet2000on,
+  author = {Doucet, Arnaud and Godsill, Simon and Andrieu, Christophe},
+  title = {{On sequential Monte Carlo sampling methods for Bayesian filtering}},
+  journal = {Statistics and Computing},
+  year = {2000},
+  volume = {10},
+  number = {3},
+  pages = {197--208}
+}
+
+@inproceedings{broderick2013streaming,
+  author = {Broderick, Tamara and Boyd, Nicholas and Wibisono, Andre and Wilson, Ashia C and Jordan, Michael I},
+  title = {Streaming Variational {B}ayes},
+  booktitle = {Neural Information Processing Systems},
+  year = {2013},
+}
+
+@inproceedings{mcinerney2015population,
+  author = {McInerney, James and Ranganath, Rajesh and Blei, David M},
+  title = {{The Population Posterior and Bayesian Inference on Streams}},
+  booktitle = {Neural Information Processing Systems},
+  year = {2015}
+}
+
+@inproceedings{binder1997space,
+  title={Space-efficient inference in dynamic probabilistic networks},
+  author={Binder, John and Murphy, Kevin and Russell, Stuart},
+  booktitle={International Joint Conference on Artificial Intelligence},
+  year={1997},
+}
+
+@inproceedings{johnson2014stochastic,
+  title={Stochastic Variational Inference for {B}ayesian Time Series Models},
+  author={Johnson, Matthew and Willsky, Alan S},
+  booktitle={International Conference on Machine Learning},
+  year={2014}
+}
+
+@inproceedings{foti2014stochastic,
+  title={Stochastic variational inference for hidden {M}arkov models},
+  author={Foti, Nicholas and Xu, Jason and Laird, Dillon and Fox, Emily},
+  booktitle={Neural Information Processing Systems},
+  year={2014}
+}
+
+@article{geman1984stochastic,
+  title={Stochastic relaxation, Gibbs distributions, and the Bayesian restoration of images},
+  author={Geman, Stuart and Geman, Donald},
+  journal={IEEE Transactions on pattern analysis and machine intelligence},
+  number={6},
+  pages={721--741},
+  year={1984},
+  publisher={IEEE}
+}
+
+@article{wang2013variational,
+  title={Variational inference in nonconjugate models},
+  author={Wang, Chong and Blei, David M},
+  journal={Journal of Machine Learning Research},
+  volume={14},
+  pages={1005--1031},
+  year={2013}
+}
+
+@article{johnson2016composing,
+  author = {Johnson, Matthew J and Duvenaud, David and Wiltschko, Alexander B and Datta, Sandeep R and Adams, Ryan P},
+  title = {{Composing graphical models with neural networks for structured representations and fast inference}},
+  journal = {arXiv preprint arXiv:1603.06277},
+  year = {2016},
+}
+
+@inproceedings{wang2012truncation,
+  title={Truncation-free online variational inference for Bayesian nonparametric models},
+  author={Wang, Chong and Blei, David M},
+  booktitle={Neural Information Processing Systems},
+  pages={413--421},
+  year={2012}
+}
+
+@article{andrieu2009pseudo,
+  title={The pseudo-marginal approach for efficient Monte Carlo computations},
+  author={Andrieu, Christophe and Roberts, Gareth O},
+  journal={The Annals of Statistics},
+  pages={697--725},
+  year={2009},
+  publisher={JSTOR}
+}
+
+@article{rue2009approximate,
+  title={Approximate Bayesian inference for latent Gaussian models by using integrated nested Laplace approximations},
+  author={Rue, H{\aa}vard and Martino, Sara and Chopin, Nicolas},
+  journal={Journal of the royal statistical society: Series b (statistical methodology)},
+  volume={71},
+  number={2},
+  pages={319--392},
+  year={2009},
+  publisher={Wiley Online Library}
+}
+
+@inproceedings{minka2001expectation,
+  title={Expectation propagation for approximate Bayesian inference},
+  author={Minka, Thomas P.},
+  booktitle={Proceedings of the Seventeenth conference on Uncertainty in artificial intelligence},
+  pages={362--369},
+  year={2001},
+  organization={Morgan Kaufmann Publishers Inc.}
+}
+
+@inproceedings{neal1993new,
+    author = {Radford M. Neal and Geoffrey E. Hinton},
+    title = {A New View of the EM Algorithm that Justifies Incremental and Other Variants},
+    booktitle = {Learning in Graphical Models},
+    year = {1993},
+    pages = {355--368},
+}
+
+@article{hinton2002training,
+  title={Training products of experts by minimizing contrastive divergence},
+  author={Hinton, Geoffrey E.},
+  journal={Neural Computation},
+  volume={14},
+  number={8},
+  pages={1771--1800},
+  year={2002},
+  publisher={MIT Press}
+}
+
+@article{gelman2014expectation,
+  author = {Gelman, Andrew and Vehtari, Aki and Jyl{\"a}nki, Pasi and Robert, Christian and Chopin, Nicolas and Cunningham, John P},
+  title = {{Expectation propagation as a way of life}},
+  journal = {arXiv preprint arXiv:1412.4869},
+  year = {2014},
+}

--- a/edward/inferences/hmc.py
+++ b/edward/inferences/hmc.py
@@ -13,6 +13,21 @@ from edward.util import copy
 class HMC(MonteCarlo):
   """Hamiltonian Monte Carlo, also known as hybrid Monte Carlo
   (Duane et al., 1987; Neal, 2011).
+
+  Notes
+  -----
+  In conditional inference, we infer z in p(z, \beta | x) while fixing
+  inference over \beta using another distribution q(\beta).
+  HMC substitutes the model's log marginal density
+
+  .. math::
+
+    log p(x, z) = log E_{q(\beta)} [ p(x, z, \beta) ]
+                \approx log p(x, z, \beta^*)
+
+  leveraging a single Monte Carlo sample, where \beta^* ~
+  q(\beta). This is unbiased (and therefore asymptotically exact as a
+  pseudo-marginal method) if q(\beta) = p(\beta | x).
   """
   def __init__(self, *args, **kwargs):
     """

--- a/edward/inferences/inference.py
+++ b/edward/inferences/inference.py
@@ -126,6 +126,14 @@ class Inference(object):
             self.data[key] = var
             sess.run(var.initializer, {ph: value})
           elif isinstance(value, RandomVariable):
+            if isinstance(key, RandomVariable):
+              if key.value().get_shape() != value.value().get_shape():
+                raise TypeError("Observed variable bindings do not have same "
+                                "shape.")
+            else:
+              raise TypeError("Data cannot have a string bound to a "
+                              "RandomVariable.")
+
             self.data[key] = value
           else:
             raise TypeError("Data value has an invalid type.")

--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -30,6 +30,21 @@ class KLpq(VariationalInference):
     E_{p(z | x; \lambda)} [ \log p(x, z; \theta) ]
 
   with respect to \theta.
+
+  In conditional inference, we infer z in p(z, \beta | x) while fixing
+  inference over \beta using another distribution q(\beta).
+  During gradient calculation, instead of using the model's density
+
+  .. math::
+
+    \log p(x, z^{(s)}), where z^{(s)} ~ q(z; \lambda),
+
+  for each sample s=1,...,S, KLpq uses
+
+  .. math::
+
+    \log p(x, z^{(s)}, \beta^{(s)}), where
+    z^{(s)} ~ q(z; \lambda) and \beta^{(s)} ~ q(beta).
   """
   def __init__(self, *args, **kwargs):
     super(KLpq, self).__init__(*args, **kwargs)

--- a/edward/inferences/klqp.py
+++ b/edward/inferences/klqp.py
@@ -30,6 +30,21 @@ class KLqp(VariationalInference):
     E_{q(z; \lambda)} [ \log p(x, z; \theta) ]
 
   with respect to \theta.
+
+  In conditional inference, we infer z in p(z, \beta | x) while fixing
+  inference over \beta using another distribution q(\beta).
+  During gradient calculation, instead of using the model's density
+
+  .. math::
+
+    \log p(x, z^{(s)}), where z^{(s)} ~ q(z; \lambda),
+
+  for each sample s=1,...,S, KLqp uses
+
+  .. math::
+
+    \log p(x, z^{(s)}, \beta^{(s)}), where
+    z^{(s)} ~ q(z; \lambda) and \beta^{(s)} ~ q(beta).
   """
   def __init__(self, *args, **kwargs):
     super(KLqp, self).__init__(*args, **kwargs)

--- a/edward/inferences/map.py
+++ b/edward/inferences/map.py
@@ -35,6 +35,14 @@ class MAP(VariationalInference):
 
   This class also minimizes the loss with respect to any model
   parameters p(z | x; \theta).
+
+  In conditional inference, we infer z in p(z, \beta | x) while fixing
+  inference over \beta using another distribution q(\beta).
+  MAP optimizes E_{q(\beta)} [ \log p(x, z, \beta) ], leveraging a
+  single Monte Carlo sample, \log p(x, z, \beta^*), where \beta^* ~
+  q(\beta). This is a lower bound to the marginal density \log p(x,
+  z), and it is exact if q(\beta) = p(\beta | x) (up to
+  stochasticity).
   """
   def __init__(self, latent_vars=None, data=None, model_wrapper=None):
     """

--- a/edward/inferences/metropolis_hastings.py
+++ b/edward/inferences/metropolis_hastings.py
@@ -12,6 +12,22 @@ from edward.util import copy
 
 class MetropolisHastings(MonteCarlo):
   """Metropolis-Hastings.
+
+  Notes
+  -----
+  In conditional inference, we infer z in p(z, \beta | x) while fixing
+  inference over \beta using another distribution q(\beta).
+  To calculate the acceptance ratio, MetropolisHastings uses an
+  estimate of the marginal density,
+
+  .. math::
+
+    p(x, z) = E_{q(\beta)} [ p(x, z, \beta) ]
+            \approx p(x, z, \beta^*)
+
+  leveraging a single Monte Carlo sample, where \beta^* ~
+  q(\beta). This is unbiased (and therefore asymptotically exact as a
+  pseudo-marginal method) if q(\beta) = p(\beta | x).
   """
   def __init__(self, latent_vars, proposal_vars, data=None, model_wrapper=None):
     """

--- a/edward/inferences/sgld.py
+++ b/edward/inferences/sgld.py
@@ -12,6 +12,21 @@ from edward.util import copy
 
 class SGLD(MonteCarlo):
   """Stochastic gradient Langevin dynamics (Welling and Teh, 2011).
+
+  Notes
+  -----
+  In conditional inference, we infer z in p(z, \beta | x) while fixing
+  inference over \beta using another distribution q(\beta).
+  SGLD substitutes the model's log marginal density
+
+  .. math::
+
+    log p(x, z) = log E_{q(\beta)} [ p(x, z, \beta) ]
+                \approx log p(x, z, \beta^*)
+
+  leveraging a single Monte Carlo sample, where \beta^* ~
+  q(\beta). This is unbiased (and therefore asymptotically exact as a
+  pseudo-marginal method) if q(\beta) = p(\beta | x).
   """
   def __init__(self, *args, **kwargs):
     """

--- a/examples/factor_analysis.py
+++ b/examples/factor_analysis.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+"""Logistic factor analysis on MNIST. Using Monte Carlo EM, with HMC
+for the E-step and MAP for the M-step. We fit to just one data
+point in MNIST.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import edward as ed
+import os
+import tensorflow as tf
+
+from edward.models import Bernoulli, Empirical, Normal
+from progressbar import ETA, Bar, Percentage, ProgressBar
+from scipy.misc import imsave
+from tensorflow.contrib import slim
+from tensorflow.examples.tutorials.mnist import input_data
+
+
+def generative_network(z):
+  """Generative network to parameterize generative model. It takes
+  latent variables as input and outputs the likelihood parameters.
+
+  logits = neural_network(z)
+  """
+  net = slim.fully_connected(z, 28 * 28, activation_fn=None)
+  net = slim.flatten(net)
+  return net
+
+
+ed.set_seed(42)
+
+N = 1  # number of data points
+d = 10  # latent dimension
+DATA_DIR = "data/mnist"
+IMG_DIR = "img"
+
+if not os.path.exists(DATA_DIR):
+  os.makedirs(DATA_DIR)
+if not os.path.exists(IMG_DIR):
+  os.makedirs(IMG_DIR)
+
+# DATA
+mnist = input_data.read_data_sets(DATA_DIR, one_hot=True)
+x_train, _ = mnist.train.next_batch(N)
+
+# MODEL
+z = Normal(mu=tf.zeros([N, d]), sigma=tf.ones([N, d]))
+logits = generative_network(z)
+x = Bernoulli(logits=logits)
+
+# INFERENCE
+T = int(100 * 1000)
+qz = Empirical(params=tf.Variable(tf.random_normal([T, N, d])))
+
+inference_e = ed.HMC({z: qz}, data={x: x_train})
+inference_e.initialize()
+
+inference_m = ed.MAP(data={x: x_train, z: tf.gather(qz.params, inference_e.t)})
+optimizer = tf.train.AdamOptimizer(0.01, epsilon=1.0)
+inference_m.initialize(optimizer=optimizer)
+
+init = tf.initialize_all_variables()
+init.run()
+
+n_iter_per_epoch = 100
+n_epoch = T // n_iter_per_epoch
+for epoch in range(n_epoch):
+  avg_loss = 0.0
+
+  widgets = ["epoch #%d|" % epoch, Percentage(), Bar(), ETA()]
+  pbar = ProgressBar(n_iter_per_epoch, widgets=widgets)
+  pbar.start()
+  for t in range(n_iter_per_epoch):
+    pbar.update(t)
+    info_dict_e = inference_e.update()
+    info_dict_m = inference_m.update()
+    avg_loss += info_dict_m['loss']
+
+  print("Acceptance Rate:")
+  print(info_dict_e['accept_rate'])
+
+  # Print a lower bound to the average marginal likelihood for an
+  # image.
+  avg_loss = avg_loss / n_iter_per_epoch
+  avg_loss = avg_loss / N
+  print("log p(x) >= {:0.3f}".format(avg_loss))
+
+  # Prior predictive check.
+  imgs = x.value().eval()
+  for m in range(N):
+    imsave(os.path.join(IMG_DIR, '%d.png') % m, imgs[m].reshape(28, 28))

--- a/tests/test-inferences/test_inference.py
+++ b/tests/test-inferences/test_inference.py
@@ -32,21 +32,27 @@ class test_inference_class(tf.test.TestCase):
 
   def test_data(self):
     x = Normal(mu=0.0, sigma=1.0)
+    qx = Normal(mu=0.0, sigma=1.0)
+    qx_misshape = Normal(mu=tf.constant([0.0]), sigma=tf.constant([1.0]))
     x_ph = ed.placeholder(tf.float32)
 
     ed.Inference()
     ed.Inference(data={x: tf.constant(0.0)})
     ed.Inference(data={x_ph: tf.constant(0.0)})
     ed.Inference(data={x: x_ph})
+    ed.Inference(data={x: qx})
     self.assertRaises(TypeError, ed.Inference, data={5: tf.constant(0.0)})
     self.assertRaises(TypeError, ed.Inference, data={x: 'a'})
     self.assertRaises(TypeError, ed.Inference, data={x_ph: x})
+    self.assertRaises(TypeError, ed.Inference, data={x: qx_misshape})
 
   def test_model_wrapper(self):
     model = NormalNormal()
     qmu = Normal(mu=tf.Variable(0.0), sigma=tf.constant(1.0))
 
     ed.Inference({'mu': qmu}, model_wrapper=model)
+    self.assertRaises(TypeError, ed.Inference, data={'x': qmu},
+                      model_wrapper=model)
 
 if __name__ == '__main__':
   tf.test.main()


### PR DESCRIPTION
+ issues: fix #9 

This implements compositionality of inference, where we can write inference as a collection of separate inference programs. also see section 4.4 of [iclr submission](http://openreview.net/forum?id=Hy6b4Pqee)

Work in progress. Adding pull request now to discuss during implementation.