### PR TITLE
Functionality change for TensorFlow variables in variational inference

### DIFF
--- a/edward/inferences/hmc.py
+++ b/edward/inferences/hmc.py
@@ -141,7 +141,8 @@ class HMC(MonteCarlo):
 
       for x in six.iterkeys(self.data):
         if isinstance(x, RandomVariable):
-          x_copy = copy(x, dict_swap, scope='likelihood_' + str(self.scope_iter))
+          x_copy = copy(x, dict_swap,
+                        scope='likelihood_' + str(self.scope_iter))
           log_joint += tf.reduce_sum(x_copy.log_prob(dict_swap[x]))
     else:
       x = self.data

--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -61,7 +61,7 @@ class KLpq(VariationalInference):
     self.n_samples = n_samples
     return super(KLpq, self).initialize(*args, **kwargs)
 
-  def build_loss_and_gradients(self, var_list=None):
+  def build_loss_and_gradients(self, var_list):
     """Build loss function
 
     .. math::
@@ -135,9 +135,6 @@ class KLpq(VariationalInference):
     w_norm = tf.exp(log_w_norm)
 
     loss = tf.reduce_mean(w_norm * log_w)
-    if var_list is None:
-      var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)
-
     grads = tf.gradients(
         -tf.reduce_mean(q_log_prob * tf.stop_gradient(w_norm)),
         [v.ref() for v in var_list])

--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -61,7 +61,7 @@ class KLpq(VariationalInference):
     self.n_samples = n_samples
     return super(KLpq, self).initialize(*args, **kwargs)
 
-  def build_loss_and_gradients(self, scope=None):
+  def build_loss_and_gradients(self, var_list=None):
     """Build loss function
 
     .. math::
@@ -135,8 +135,9 @@ class KLpq(VariationalInference):
     w_norm = tf.exp(log_w_norm)
 
     loss = tf.reduce_mean(w_norm * log_w)
-    var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES,
-                                 scope=scope)
+    if var_list is None:
+      var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)
+
     grads = tf.gradients(
         -tf.reduce_mean(q_log_prob * tf.stop_gradient(w_norm)),
         [v.ref() for v in var_list])

--- a/edward/inferences/klqp.py
+++ b/edward/inferences/klqp.py
@@ -61,7 +61,7 @@ class KLqp(VariationalInference):
     self.n_samples = n_samples
     return super(KLqp, self).initialize(*args, **kwargs)
 
-  def build_loss_and_gradients(self, scope=None):
+  def build_loss_and_gradients(self, var_list=None):
     """Wrapper for the KLqp loss function.
 
     .. math::
@@ -101,20 +101,21 @@ class KLqp(VariationalInference):
       else:
         loss = build_reparam_loss(self)
 
-      var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES,
-                                   scope=scope)
+      if var_list is None:
+        var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)
+
       grads = tf.gradients(loss, [v.ref() for v in var_list])
       grads_and_vars = list(zip(grads, var_list))
       return loss, grads_and_vars
     else:
       if is_analytic_kl:
-        return build_score_kl_loss_and_gradients(self, scope)
+        return build_score_kl_loss_and_gradients(self, var_list)
       # Analytic entropies may lead to problems around
       # convergence; for now it is deactivated.
       # elif is_analytic_entropy:
-      #    return build_score_entropy_loss_and_gradients(self, scope)
+      #    return build_score_entropy_loss_and_gradients(self, var_list)
       else:
-        return build_score_loss_and_gradients(self, scope)
+        return build_score_loss_and_gradients(self, var_list)
 
 
 MFVI = KLqp  # deprecated synonym
@@ -233,8 +234,8 @@ class ScoreKLqp(VariationalInference):
     self.n_samples = n_samples
     return super(ScoreKLqp, self).initialize(*args, **kwargs)
 
-  def build_loss_and_gradients(self, scope=None):
-    return build_score_loss_and_gradients(self, scope)
+  def build_loss_and_gradients(self, var_list=None):
+    return build_score_loss_and_gradients(self, var_list)
 
 
 class ScoreKLKLqp(VariationalInference):
@@ -262,8 +263,8 @@ class ScoreKLKLqp(VariationalInference):
     self.n_samples = n_samples
     return super(ScoreKLKLqp, self).initialize(*args, **kwargs)
 
-  def build_loss_and_gradients(self, scope=None):
-    return build_score_kl_loss_and_gradients(self, scope)
+  def build_loss_and_gradients(self, var_list=None):
+    return build_score_kl_loss_and_gradients(self, var_list)
 
 
 class ScoreEntropyKLqp(VariationalInference):
@@ -291,8 +292,8 @@ class ScoreEntropyKLqp(VariationalInference):
     self.n_samples = n_samples
     return super(ScoreEntropyKLqp, self).initialize(*args, **kwargs)
 
-  def build_loss_and_gradients(self, scope=None):
-    return build_score_entropy_loss_and_gradients(self, scope)
+  def build_loss_and_gradients(self, var_list=None):
+    return build_score_entropy_loss_and_gradients(self, var_list)
 
 
 def build_reparam_loss(inference):
@@ -466,7 +467,7 @@ def build_reparam_entropy_loss(inference):
   return loss
 
 
-def build_score_loss_and_gradients(inference, scope=None):
+def build_score_loss_and_gradients(inference, var_list=None):
   """Build loss function and gradients based on the score function
   estimator (Paisley et al., 2012).
 
@@ -513,8 +514,9 @@ def build_score_loss_and_gradients(inference, scope=None):
 
   losses = p_log_prob - q_log_prob
   loss = -tf.reduce_mean(losses)
-  var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES,
-                               scope=scope)
+  if var_list is None:
+    var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)
+
   grads = tf.gradients(
       -tf.reduce_mean(q_log_prob * tf.stop_gradient(losses)),
       [v.ref() for v in var_list])
@@ -522,7 +524,7 @@ def build_score_loss_and_gradients(inference, scope=None):
   return loss, grads_and_vars
 
 
-def build_score_kl_loss_and_gradients(inference, scope=None):
+def build_score_kl_loss_and_gradients(inference, var_list=None):
   """Build loss function and gradients based on the score function
   estimator (Paisley et al., 2012).
 
@@ -577,8 +579,9 @@ def build_score_kl_loss_and_gradients(inference, scope=None):
                         for qz in six.itervalues(inference.latent_vars)])
 
   loss = -(tf.reduce_mean(p_log_lik) - kl)
-  var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES,
-                               scope=scope)
+  if var_list is None:
+    var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)
+
   grads = tf.gradients(
       -(tf.reduce_mean(q_log_prob * tf.stop_gradient(p_log_lik)) - kl),
       [v.ref() for v in var_list])
@@ -586,7 +589,7 @@ def build_score_kl_loss_and_gradients(inference, scope=None):
   return loss, grads_and_vars
 
 
-def build_score_entropy_loss_and_gradients(inference, scope=None):
+def build_score_entropy_loss_and_gradients(inference, var_list=None):
   """Build loss function and gradients based on the score function
   estimator (Paisley et al., 2012).
 
@@ -637,8 +640,9 @@ def build_score_entropy_loss_and_gradients(inference, scope=None):
                              for qz in six.itervalues(inference.latent_vars)])
 
   loss = -(tf.reduce_mean(p_log_prob) + q_entropy)
-  var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES,
-                               scope=scope)
+  if var_list is None:
+    var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)
+
   grads = tf.gradients(
       -(tf.reduce_mean(q_log_prob * tf.stop_gradient(p_log_prob)) +
           q_entropy),

--- a/edward/inferences/klqp.py
+++ b/edward/inferences/klqp.py
@@ -61,7 +61,7 @@ class KLqp(VariationalInference):
     self.n_samples = n_samples
     return super(KLqp, self).initialize(*args, **kwargs)
 
-  def build_loss_and_gradients(self, var_list=None):
+  def build_loss_and_gradients(self, var_list):
     """Wrapper for the KLqp loss function.
 
     .. math::
@@ -100,9 +100,6 @@ class KLqp(VariationalInference):
       #    loss = build_reparam_entropy_loss(self)
       else:
         loss = build_reparam_loss(self)
-
-      if var_list is None:
-        var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)
 
       grads = tf.gradients(loss, [v.ref() for v in var_list])
       grads_and_vars = list(zip(grads, var_list))
@@ -234,7 +231,7 @@ class ScoreKLqp(VariationalInference):
     self.n_samples = n_samples
     return super(ScoreKLqp, self).initialize(*args, **kwargs)
 
-  def build_loss_and_gradients(self, var_list=None):
+  def build_loss_and_gradients(self, var_list):
     return build_score_loss_and_gradients(self, var_list)
 
 
@@ -263,7 +260,7 @@ class ScoreKLKLqp(VariationalInference):
     self.n_samples = n_samples
     return super(ScoreKLKLqp, self).initialize(*args, **kwargs)
 
-  def build_loss_and_gradients(self, var_list=None):
+  def build_loss_and_gradients(self, var_list):
     return build_score_kl_loss_and_gradients(self, var_list)
 
 
@@ -292,7 +289,7 @@ class ScoreEntropyKLqp(VariationalInference):
     self.n_samples = n_samples
     return super(ScoreEntropyKLqp, self).initialize(*args, **kwargs)
 
-  def build_loss_and_gradients(self, var_list=None):
+  def build_loss_and_gradients(self, var_list):
     return build_score_entropy_loss_and_gradients(self, var_list)
 
 
@@ -467,7 +464,7 @@ def build_reparam_entropy_loss(inference):
   return loss
 
 
-def build_score_loss_and_gradients(inference, var_list=None):
+def build_score_loss_and_gradients(inference, var_list):
   """Build loss function and gradients based on the score function
   estimator (Paisley et al., 2012).
 
@@ -514,9 +511,6 @@ def build_score_loss_and_gradients(inference, var_list=None):
 
   losses = p_log_prob - q_log_prob
   loss = -tf.reduce_mean(losses)
-  if var_list is None:
-    var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)
-
   grads = tf.gradients(
       -tf.reduce_mean(q_log_prob * tf.stop_gradient(losses)),
       [v.ref() for v in var_list])
@@ -524,7 +518,7 @@ def build_score_loss_and_gradients(inference, var_list=None):
   return loss, grads_and_vars
 
 
-def build_score_kl_loss_and_gradients(inference, var_list=None):
+def build_score_kl_loss_and_gradients(inference, var_list):
   """Build loss function and gradients based on the score function
   estimator (Paisley et al., 2012).
 
@@ -579,9 +573,6 @@ def build_score_kl_loss_and_gradients(inference, var_list=None):
                         for qz in six.itervalues(inference.latent_vars)])
 
   loss = -(tf.reduce_mean(p_log_lik) - kl)
-  if var_list is None:
-    var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)
-
   grads = tf.gradients(
       -(tf.reduce_mean(q_log_prob * tf.stop_gradient(p_log_lik)) - kl),
       [v.ref() for v in var_list])
@@ -589,7 +580,7 @@ def build_score_kl_loss_and_gradients(inference, var_list=None):
   return loss, grads_and_vars
 
 
-def build_score_entropy_loss_and_gradients(inference, var_list=None):
+def build_score_entropy_loss_and_gradients(inference, var_list):
   """Build loss function and gradients based on the score function
   estimator (Paisley et al., 2012).
 
@@ -640,9 +631,6 @@ def build_score_entropy_loss_and_gradients(inference, var_list=None):
                              for qz in six.itervalues(inference.latent_vars)])
 
   loss = -(tf.reduce_mean(p_log_prob) + q_entropy)
-  if var_list is None:
-    var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)
-
   grads = tf.gradients(
       -(tf.reduce_mean(q_log_prob * tf.stop_gradient(p_log_prob)) +
           q_entropy),

--- a/edward/inferences/variational_inference.py
+++ b/edward/inferences/variational_inference.py
@@ -78,21 +78,24 @@ class VariationalInference(Inference):
       raise TypeError()
 
     if var_list is None:
-      # Traverse random variable graphs to get default list of variables.
-      var_list = set([])
-      trainables = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)
-      for z, qz in six.iteritems(self.latent_vars):
-        if isinstance(z, RandomVariable):
-          var_list.update(get_variables(z, collection=trainables))
+      if self.model_wrapper is None:
+        # Traverse random variable graphs to get default list of variables.
+        var_list = set([])
+        trainables = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)
+        for z, qz in six.iteritems(self.latent_vars):
+          if isinstance(z, RandomVariable):
+            var_list.update(get_variables(z, collection=trainables))
 
-        var_list.update(get_variables(qz, collection=trainables))
+          var_list.update(get_variables(qz, collection=trainables))
 
-      for x, qx in six.iteritems(self.data):
-        if isinstance(x, RandomVariable) and \
-                not isinstance(qx, RandomVariable):
-          var_list.update(get_variables(x, collection=trainables))
+        for x, qx in six.iteritems(self.data):
+          if isinstance(x, RandomVariable) and \
+                  not isinstance(qx, RandomVariable):
+            var_list.update(get_variables(x, collection=trainables))
 
-      var_list = list(var_list)
+        var_list = list(var_list)
+      else:
+        var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)
 
     if getattr(self, 'build_loss_and_gradients', None) is not None:
       self.loss, grads_and_vars = self.build_loss_and_gradients(var_list)

--- a/edward/inferences/variational_inference.py
+++ b/edward/inferences/variational_inference.py
@@ -81,7 +81,7 @@ class VariationalInference(Inference):
       if self.model_wrapper is None:
         # Traverse random variable graphs to get default list of variables.
         var_list = set([])
-        trainables = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)
+        trainables = tf.trainable_variables()
         for z, qz in six.iteritems(self.latent_vars):
           if isinstance(z, RandomVariable):
             var_list.update(get_variables(z, collection=trainables))
@@ -95,7 +95,7 @@ class VariationalInference(Inference):
 
         var_list = list(var_list)
       else:
-        var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)
+        var_list = tf.trainable_variables()
 
     if getattr(self, 'build_loss_and_gradients', None) is not None:
       self.loss, grads_and_vars = self.build_loss_and_gradients(var_list)

--- a/edward/inferences/variational_inference.py
+++ b/edward/inferences/variational_inference.py
@@ -89,7 +89,7 @@ class VariationalInference(Inference):
 
       for x, qx in six.iteritems(self.data):
         if isinstance(x, RandomVariable) and \
-          not isinstance(qx, RandomVariable):
+                not isinstance(qx, RandomVariable):
           var_list.update(get_variables(x, collection=trainables))
 
       var_list = list(var_list)

--- a/edward/inferences/variational_inference.py
+++ b/edward/inferences/variational_inference.py
@@ -22,7 +22,7 @@ class VariationalInference(Inference):
   def __init__(self, *args, **kwargs):
     super(VariationalInference, self).__init__(*args, **kwargs)
 
-  def initialize(self, optimizer=None, scope=None, use_prettytensor=False,
+  def initialize(self, optimizer=None, var_list=None, use_prettytensor=False,
                  *args, **kwargs):
     """Initialize variational inference algorithm.
 
@@ -35,9 +35,9 @@ class VariationalInference(Inference):
       objective. Alternatively, one can pass in the name of a
       TensorFlow optimizer, and default parameters for the optimizer
       will be used.
-    scope : str, optional
-      Scope of TensorFlow variables to optimize over. Default is all
-      trainable variables.
+    var_list : list of tf.Variable, optional
+      List of TensorFlow variables to optimize over. Default is all
+      trainable variables that ``latent_vars`` depends on.
     use_prettytensor : bool, optional
       ``True`` if aim to use TensorFlow optimizer or ``False`` if aim
       to use PrettyTensor optimizer (when using PrettyTensor).
@@ -80,11 +80,13 @@ class VariationalInference(Inference):
       raise TypeError()
 
     if getattr(self, 'build_loss_and_gradients', None) is not None:
-      self.loss, grads_and_vars = self.build_loss_and_gradients(scope=scope)
+      self.loss, grads_and_vars = self.build_loss_and_gradients(
+          var_list=var_list)
     else:
       self.loss = self.build_loss()
-      var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES,
-                                   scope=scope)
+      if var_list is None:
+        var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)
+
       grads_and_vars = optimizer.compute_gradients(self.loss, var_list=var_list)
 
     if not use_prettytensor:


### PR DESCRIPTION
This pull request changes functionality for the TensorFlow variables to optimize over in variational inference.

1. The `scope` argument in `inference.initialize()` is replaced with `var_list`. `var_list` is the list of TensorFlow variables to optimize over.
2. The new default is all trainable parameters that `latent_vars` and ``data`` depend on, excluding those that are only used in conditionals in ``data``.

As one use case, the new default is important to not train TensorFlow variables that appear in the values of `data`, such as in conditional inference, where it is important not to update parameters from other inferences.

The new argument also provides more fine-grained control of the parameters to update.

Remarks
+ The new default is potentially expensive to compute. It requires traversing the model graph to find all trainable parameters.
+ Specifying a default `var_list` presents difficulties with model wrappers. Oftentimes TensorFlow variables within model wrapper classes are not instantiated until the model wrapper is called for the first time; this happens after we create the variable list. Therefore for model wrappers, the default var list is simply all trainable variables rather than something more nuanced.