### PR TITLE
RFC: adding support for tf logging in variational inf

### DIFF
--- a/edward/inferences/inference.py
+++ b/edward/inferences/inference.py
@@ -212,7 +212,11 @@ class Inference(object):
     self.initialize(*args, **kwargs)
 
     if logdir is not None:
+      self.logging = True
       self.train_writer = tf.train.SummaryWriter(logdir, tf.get_default_graph())
+      self.summarize = tf.merge_all_summaries()
+    else:
+      self.logging = False
 
     if variables is None:
       init = tf.initialize_all_variables()

--- a/edward/inferences/inference.py
+++ b/edward/inferences/inference.py
@@ -240,7 +240,8 @@ class Inference(object):
       self.coord.request_stop()
       self.coord.join(self.threads)
 
-  def initialize(self, n_iter=1000, n_print=None, n_minibatch=None, scale=None, logdir=None, debug=False):
+  def initialize(self, n_iter=1000, n_print=None, n_minibatch=None, scale=None,
+                 logdir=None, debug=False):
     """Initialize inference algorithm.
 
     Parameters
@@ -319,7 +320,7 @@ class Inference(object):
       self.logging = False
 
     if debug:
-      self.debug=True
+      self.debug = True
       self.op_check = tf.add_check_numerics_ops()
 
   def update(self):

--- a/edward/inferences/klqp.py
+++ b/edward/inferences/klqp.py
@@ -525,11 +525,6 @@ def build_score_loss_and_gradients(inference, var_list):
       if z in inference.scale:
         z_log_prob *= inference.scale[z]
 
-      zsamp = tf.check_numerics(tf.to_float(z_sample[z]), z.name + 'sample')
-      tf.scalar_summary(z.name + str(s), tf.reduce_mean(zsamp))
-      zgrad = tf.check_numerics(tf.stop_gradient(tf.to_float(z_sample[z])), z.name + 'gradient')
-      zlogq = tf.check_numerics(qz.log_prob(zgrad), z.name + 'logq')
-      tf.scalar_summary(z.name + 'logq' + str(s), tf.reduce_sum(zlogq))
       q_log_prob[s] += z_log_prob
 
     if inference.model_wrapper is None:
@@ -546,24 +541,20 @@ def build_score_loss_and_gradients(inference, var_list):
 
       for z in six.iterkeys(inference.latent_vars):
         z_copy = copy(z, dict_swap, scope=scope)
-        tf.check_numerics(z_copy.log_prob(z_sample[z]), z.name + 'logp(z)')
         z_log_prob = tf.reduce_sum(z_copy.log_prob(dict_swap[z]))
         if z in inference.scale:
           z_log_prob *= inference.scale[z]
 
         p_log_prob[s] += z_log_prob
-        tf.scalar_summary(z.name + 'logp(z)' + str(s), tf.reduce_sum(z_copy.log_prob(z_sample[z])))
 
       for x in six.iterkeys(inference.data):
         if isinstance(x, RandomVariable):
           x_copy = copy(x, dict_swap, scope=scope)
-          tf.check_numerics(x_copy.log_prob(obs), x.name + 'logp(x)')
           x_log_prob = tf.reduce_sum(x_copy.log_prob(dict_swap[x]))
           if x in inference.scale:
             x_log_prob *= inference.scale[x]
 
           p_log_prob[s] += x_log_prob
-          tf.scalar_summary(x.name + 'logp(x)' + str(s), tf.reduce_sum(x_copy.log_prob(obs)))
     else:
       x = inference.data
       p_log_prob[s] = inference.model_wrapper.log_prob(x, z_sample)
@@ -575,11 +566,8 @@ def build_score_loss_and_gradients(inference, var_list):
     var_list = tf.trainable_variables()
 
   losses = p_log_prob - q_log_prob
-  tf.scalar_summary('logp', tf.reduce_mean(p_log_prob))
-  tf.scalar_summary('logq', tf.reduce_mean(q_log_prob))
   loss = -tf.reduce_mean(losses)
 
-  tf.scalar_summary('ELBO', -loss)
   grads = tf.gradients(
       -tf.reduce_mean(q_log_prob * tf.stop_gradient(losses)),
       [v.ref() for v in var_list])

--- a/edward/inferences/variational_inference.py
+++ b/edward/inferences/variational_inference.py
@@ -145,6 +145,10 @@ class VariationalInference(Inference):
 
     sess = get_session()
     _, t, loss = sess.run([self.train, self.increment_t, self.loss], feed_dict)
+    if self.logging and self.n_print != 0:
+      if t == 1 or t % self.n_print == 0:
+          summary = sess.run(self.summarize, feed_dict)
+          self.train_writer.add_summary(summary, t)
     return {'t': t, 'loss': loss}
 
   def print_progress(self, info_dict):

--- a/edward/inferences/variational_inference.py
+++ b/edward/inferences/variational_inference.py
@@ -145,6 +145,10 @@ class VariationalInference(Inference):
 
     sess = get_session()
     _, t, loss = sess.run([self.train, self.increment_t, self.loss], feed_dict)
+
+    if self.debug:
+      sess.run(self.op_check)
+    
     if self.logging and self.n_print != 0:
       if t == 1 or t % self.n_print == 0:
           summary = sess.run(self.summarize, feed_dict)

--- a/edward/inferences/variational_inference.py
+++ b/edward/inferences/variational_inference.py
@@ -148,7 +148,7 @@ class VariationalInference(Inference):
 
     if self.debug:
       sess.run(self.op_check)
-    
+
     if self.logging and self.n_print != 0:
       if t == 1 or t % self.n_print == 0:
           summary = sess.run(self.summarize, feed_dict)

--- a/edward/models/random_variable.py
+++ b/edward/models/random_variable.py
@@ -59,7 +59,8 @@ class RandomVariable(object):
     # need to temporarily pop value before __init__
     value = kwargs.pop('value', None)
     super(RandomVariable, self).__init__(*args, **kwargs)
-    self._kwargs['value'] = value  # reinsert (needed for copying)
+    if value is not None:
+      self._kwargs['value'] = value  # reinsert (needed for copying)
 
     tf.add_to_collection(RANDOM_VARIABLE_COLLECTION, self)
 
@@ -70,8 +71,8 @@ class RandomVariable(object):
       value_shape = t_value.get_shape().as_list()
       if value_shape != expected_shape:
         raise ValueError(
-            "incompatible shape for initialization argument 'value'."
-            "expected '%s', got '%s'" % (expected_shape, value_shape))
+            "Incompatible shape for initialization argument 'value'. "
+            "Expected %s, got %s." % (expected_shape, value_shape))
       else:
         self._value = t_value
     else:

--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -185,6 +185,7 @@ def copy(org_instance, dict_swap=None, scope="copied",
   else:  # tf.Operation
     op = org_instance
 
+    # Do not copy queue operations
     if 'Queue' in op.type:
       return op
 

--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -185,6 +185,9 @@ def copy(org_instance, dict_swap=None, scope="copied",
   else:  # tf.Operation
     op = org_instance
 
+    if 'Queue' in op.type:
+      return op
+
     # If it has an original op, copy it.
     if op._original_op is not None:
       new_original_op = copy(op._original_op, dict_swap, scope, True, copy_q)

--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -188,7 +188,7 @@ def copy(org_instance, dict_swap=None, scope="copied",
     # Do not copy queue operations
     if 'Queue' in op.type:
       return op
-      
+
     # If it has an original op, copy it.
     if op._original_op is not None:
       new_original_op = copy(op._original_op, dict_swap, scope, True, copy_q)

--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -188,7 +188,7 @@ def copy(org_instance, dict_swap=None, scope="copied",
     # Do not copy queue operations
     if 'Queue' in op.type:
       return op
-
+      
     # If it has an original op, copy it.
     if op._original_op is not None:
       new_original_op = copy(op._original_op, dict_swap, scope, True, copy_q)


### PR DESCRIPTION
Edward has a lot of nice wrappers to hide TF complexity, but this also makes instrumenting to check for NaNs and Infs, as well as logging, tricky. With this, I can instrument my code and use Tensorboard on the logs.

This is a small patch that allows for logging via TF summary nodes. It calls `tf.merge_all_summaries` in the appropriate place so that summary nodes are run. It also modifies variational inference to create a summary with the same frequency as progress is printed to screen.

I'm not sure I have the time to extend this to other inference methods, but the pattern should be clear.