### PR TITLE
implement collapsed mixture models with Mixture random variable

### DIFF
--- a/docs/tex/tutorials/mixture-gaussian.tex
+++ b/docs/tex/tutorials/mixture-gaussian.tex
@@ -40,24 +40,72 @@ Define the prior on each component $\mathbf{\sigma}_k\in\mathbb{R}^D$ to be
   \text{InverseGamma}(\mathbf{\sigma}_k \mid a, b).
 \end{align*}
 
-Let's build the model in Edward using TensorFlow. This simply requires
-writing down the model's log joint density,
+We build two versions of the model in Edward: one explicitly with the
+mixture assignments $c_n\in\{0,\ldots,K-1\}$ as latent variables,
+and another with them summed out.
+
+The explicit version is as follows:
+
+\begin{lstlisting}[language=Python]
+from edward.models import Categorical, Dirichlet, InverseGamma, Normal
+
+N = 500  # number of data points
+K = 2  # number of components
+D = 2  # dimensionality of data
+
+pi = Dirichlet(alpha=tf.ones(K))
+mu = Normal(mu=tf.zeros([K, D]), sigma=tf.ones([K, D]))
+sigma = InverseGamma(alpha=tf.ones([K, D]), beta=tf.ones([K, D]))
+c = Categorical(logits=tf.ones([N, 1]) * ed.logit(pi))
+x = Normal(mu=tf.gather(mu, c), sigma=tf.gather(sigma, c))
+\end{lstlisting}
+
+The collapsed version marginalizes out the mixture assignments. We
+implement this with the \texttt{Mixture} random variable.
+
+\begin{lstlisting}[language=Python]
+from edward.models import Categorical, Dirichlet, InverseGamma, Mixture, \
+    MultivariateNormalDiag, Normal
+
+N = 500  # number of data points
+K = 2  # number of components
+D = 2  # dimensionality of data
+
+pi = Dirichlet(alpha=tf.ones(K))
+mu = Normal(mu=tf.zeros([K, D]), sigma=tf.ones([K, D]))
+sigma = InverseGamma(alpha=tf.ones([K, D]), beta=tf.ones([K, D]))
+cat = Categorical(logits=tf.ones([N, 1]) * ed.logit(pi))
+components = [
+    MultivariateNormalDiag(mu=tf.ones([N, 1]) * tf.gather(mu, k),
+                           diag_stdev=tf.ones([N, 1]) * tf.gather(sigma, k))
+    for k in range(K)]
+
+x = Mixture(cat=cat, components=components)
+\end{lstlisting}
+
+We experiment with this model using variational inference in the
+\href{/tutorials/unsupervised}{unsupervised learning} tutorial.
+Example scripts using this model can be found
+\href{https://github.com/blei-lab/edward/blob/master/examples/mixture_gaussian_collapsed.py}{here}.
+
+\subsubsection{Remarks: The log-sum-exp trick}
+
+For a collapsed mixture model, implementing the log density can be tricky.
+In general, the log density is
 \begin{align*}
   \log p(\pi) +
   \Big[ \sum_{k=1}^K \log p(\mathbf{\mu}_k) + \log
   p(\mathbf{\sigma}_k) \Big] +
-  \sum_{n=1}^N \log p(\mathbf{x}_n \mid \pi, \mu, \sigma).
+  \sum_{n=1}^N \log p(\mathbf{x}_n \mid \pi, \mu, \sigma),
 \end{align*}
-Writing
-the model's log-likelihood can be tricky:
+where the likelihood is
 \begin{align*}
   \sum_{n=1}^N \log p(\mathbf{x}_n \mid \pi, \mu, \sigma)
   &=
   \sum_{n=1}^N \log \sum_{k=1}^K \pi_k \, \text{Normal}(\mathbf{x}_n \mid
   \mu_k, \sigma_k).
 \end{align*}
-To prevent numerical instability, we'd like to work on the log-scale
-when calculating densities,
+To prevent numerical instability, we'd like to work on the log-scale,
 \begin{align*}
   \sum_{n=1}^N \log p(\mathbf{x}_n \mid \pi, \mu, \sigma)
   &=
@@ -66,8 +114,8 @@ when calculating densities,
 \end{align*}
 This expression involves a log sum exp operation, which is
 numerically unstable as exponentiation will often lead to one value
-dominating the rest. Therefore we use the log-sum-exp trick,
-which is based on the identity
+dominating the rest. Therefore we use the log-sum-exp trick.
+It is based on the identity
 \begin{align*}
   \mathbf{x}_{\mathrm{max}}
   &=
@@ -83,79 +131,7 @@ which is based on the identity
   \mathbf{x}_{\mathrm{max}}).
 \end{align*}
 Subtracting the maximum value before taking the log-sum-exp leads to
-more numerically stable output.
-
-\textbf{Note: Model wrappers are deprecated since Edward v1.1.5.
-Reimplementing this under Edward's native language is currently in
-progress.}
-
-\begin{lstlisting}[language=Python]
-class MixtureGaussian:
-  """
-  Mixture of Gaussians
-
-  p(x, z) = [ prod_{n=1}^N sum_{k=1}^K pi_k N(x_n; mu_k, sigma_k) ]
-            [ prod_{k=1}^K N(mu_k; 0, cI) Inv-Gamma(sigma_k; a, b) ]
-            Dirichlet(pi; alpha)
-
-  where z = {pi, mu, sigma} and for known hyperparameters a, b, c, alpha.
-
-  Parameters
-  ----------
-  K : int
-    Number of mixture components.
-  D : float, optional
-    Dimension of the Gaussians.
-  """
-  def __init__(self, K, D):
-    self.K = K
-    self.D = D
-    self.n_vars = (2 * D + 1) * K
-
-    self.a = 1.0
-    self.b = 1.0
-    self.c = 3.0
-    self.alpha = tf.ones([K])
-
-  def log_prob(self, xs, zs):
-    """Return scalar, the log joint density log p(xs, zs)."""
-    x = xs['x']
-    pi, mus, sigmas = zs['pi'], zs['mu'], zs['sigma']
-    log_prior = dirichlet.logpdf(pi, self.alpha)
-    log_prior += tf.reduce_sum(norm.logpdf(mus, 0.0, self.c))
-    log_prior += tf.reduce_sum(invgamma.logpdf(sigmas, self.a, self.b))
-
-    # log-likelihood is
-    # sum_{n=1}^N log sum_{k=1}^K exp( log pi_k + log N(x_n; mu_k, sigma_k) )
-    # Create a K x N matrix, whose entry (k, n) is
-    # log pi_k + log N(x_n; mu_k, sigma_k).
-    N = get_dims(x)[0]
-    matrix = []
-    for k in range(self.K):
-      matrix += [tf.ones(N) * tf.log(pi[k]) +
-                 multivariate_normal_diag.logpdf(x,
-                 mus[(k * self.D):((k + 1) * self.D)],
-                 sigmas[(k * self.D):((k + 1) * self.D)])]
-
-    matrix = tf.pack(matrix)
-    # log_sum_exp() along the rows is a vector, whose nth
-    # element is the log-likelihood of data point x_n.
-    vector = log_sum_exp(matrix, 0)
-    # Sum over data points to get the full log-likelihood.
-    log_lik = tf.reduce_sum(vector)
-
-    return log_prior + log_lik
-
-
-model = MixtureGaussian(K=2, D=2)
-\end{lstlisting}
-
-We experiment with this model using variational inference in the
-\href{/tutorials/unsupervised}{unsupervised learning} tutorial.
-Example scripts using this model can found
-\href{https://github.com/blei-lab/edward/blob/master/examples/tf_mixture_gaussian_map.py}
-{here with MAP estimation} and
-\href{https://github.com/blei-lab/edward/blob/master/examples/tf_mixture_gaussian_laplace.py}
-{here with the Laplace approximation}.
+more numerically stable output. The \texttt{Mixture} random variable
+implements this trick for calculating the log-density.
 
 \subsubsection{References}\label{references}

--- a/docs/tex/tutorials/unsupervised.tex
+++ b/docs/tex/tutorials/unsupervised.tex
@@ -7,7 +7,7 @@ unlabeled data, comprised of training examples $\{x_n\}$.
 
 We demonstrate how to do this in Edward with an example.
 The script is available
-\href{https://github.com/blei-lab/edward/blob/master/examples/tf_mixture_gaussian.py}
+\href{https://github.com/blei-lab/edward/blob/master/examples/mixture_gaussian_collapsed.py}
 {here}.
 
 
@@ -27,8 +27,10 @@ def build_toy_dataset(N):
 
   return x
 
-x_train = build_toy_dataset(500)
-data = {'x': x_train}
+N = 500  # number of data points
+D = 2  # dimensionality of data
+
+x_train = build_toy_dataset(N)
 \end{lstlisting}
 
 We visualize the generated data points.
@@ -41,76 +43,23 @@ plt.show()
 
 \subsubsection{Model}
 
-\textbf{Note: Model wrappers are deprecated since Edward v1.1.5.
-Reimplementing this under Edward's native language is currently in
-progress.}
-
 Posit the model as a mixture of Gaussians. For more details on the
 model, see the
 \href{/tutorials/mixture-gaussian}
 {Mixture of Gaussians tutorial}.
-
-Here we build the model in Edward using TensorFlow, and set the number
-of mixture components to be 2.
+We write it in collapsed form, marginalizing out
+the mixture assignments.
 \begin{lstlisting}[language=Python]
-class MixtureGaussian:
-  """
-  Mixture of Gaussians
+K = 2  # number of components
 
-  p(x, z) = [ prod_{n=1}^N sum_{k=1}^K pi_k N(x_n; mu_k, sigma_k) ]
-            [ prod_{k=1}^K N(mu_k; 0, cI) Inv-Gamma(sigma_k; a, b) ]
-            Dirichlet(pi; alpha)
-
-  where z = {pi, mu, sigma} and for known hyperparameters a, b, c, alpha.
-
-  Parameters
-  ----------
-  K : int
-    Number of mixture components.
-  D : float, optional
-    Dimension of the Gaussians.
-  """
-  def __init__(self, K, D):
-    self.K = K
-    self.D = D
-    self.n_vars = (2 * D + 1) * K
-
-    self.a = 1.0
-    self.b = 1.0
-    self.c = 3.0
-    self.alpha = tf.ones([K])
-
-  def log_prob(self, xs, zs):
-    """Return scalar, the log joint density log p(xs, zs)."""
-    x = xs['x']
-    pi, mus, sigmas = zs['pi'], zs['mu'], zs['sigma']
-    log_prior = dirichlet.logpdf(pi, self.alpha)
-    log_prior += tf.reduce_sum(norm.logpdf(mus, 0.0, self.c))
-    log_prior += tf.reduce_sum(invgamma.logpdf(sigmas, self.a, self.b))
-
-    # log-likelihood is
-    # sum_{n=1}^N log sum_{k=1}^K exp( log pi_k + log N(x_n; mu_k, sigma_k) )
-    # Create a K x N matrix, whose entry (k, n) is
-    # log pi_k + log N(x_n; mu_k, sigma_k).
-    N = get_dims(x)[0]
-    matrix = []
-    for k in range(self.K):
-      matrix += [tf.ones(N) * tf.log(pi[k]) +
-                 multivariate_normal_diag.logpdf(x,
-                 mus[(k * self.D):((k + 1) * self.D)],
-                 sigmas[(k * self.D):((k + 1) * self.D)])]
-
-    matrix = tf.pack(matrix)
-    # log_sum_exp() along the rows is a vector, whose nth
-    # element is the log-likelihood of data point x_n.
-    vector = log_sum_exp(matrix, 0)
-    # Sum over data points to get the full log-likelihood.
-    log_lik = tf.reduce_sum(vector)
-
-    return log_prior + log_lik
-
-
-model = MixtureGaussian(K=2, D=2)
+mu = Normal(mu=tf.zeros([K, D]), sigma=tf.ones([K, D]))
+sigma = InverseGamma(alpha=tf.ones([K, D]), beta=tf.ones([K, D]))
+cat = Categorical(logits=tf.zeros([N, K]))
+components = [
+    MultivariateNormalDiag(mu=tf.ones([N, 1]) * tf.gather(mu, k),
+                           diag_stdev=tf.ones([N, 1]) * tf.gather(sigma, k))
+    for k in range(K)]
+x = Mixture(cat=cat, components=components)
 \end{lstlisting}
 
 
@@ -119,37 +68,30 @@ Perform variational inference.
 %
 The latent variables are the mixture probabilities,
 component means, and component variances.
-Define the variational model to be a Dirichlet $\times$ fully factorized normal
-$\times$ fully factorized inverse Gamma.
-%The latent variables are $\mathbf{z} = (\pi, \mu, \sigma)$.
-%\begin{align*}
-%  q(\mathbf{z} \;;\; \lambda)
-%  &=
-%  \text{Dirichlet}(\mathbf{z}_\pi)
-%  \times
-%  \text{Normal}(\mathbf{z}_\mu)
-%  \times
-%  \text{InverseGamma}(\mathbf{z}_\sigma)
-%\end{align*}
-%
-%The model in Edward is
+Define the variational model to be
+\begin{align*}
+ q(\mu, \sigma \;;\; \lambda)
+ &=
+ \prod_{k=1}^K
+ \text{Normal}(\mu_k; \lambda_{\mu_k})
+ ~
+ \text{InverseGamma}(\sigma_k; \lambda_{\sigma_k}).
+\end{align*}
+The model in Edward is
 \begin{lstlisting}[language=Python]
-qpi_alpha = tf.nn.softplus(tf.Variable(tf.random_normal([K])))
-qmu_mu = tf.Variable(tf.random_normal([K * D]))
-qmu_sigma = tf.nn.softplus(tf.Variable(tf.random_normal([K * D])))
-qsigma_alpha = tf.nn.softplus(tf.Variable(tf.random_normal([K * D])))
-qsigma_beta = tf.nn.softplus(tf.Variable(tf.random_normal([K * D])))
-
-qpi = Dirichlet(alpha=qpi_alpha)
-qmu = Normal(mu=qmu_mu, sigma=qmu_sigma)
-qsigma = InverseGamma(alpha=qsigma_alpha, beta=qsigma_beta)
+qmu = Normal(mu=tf.Variable(tf.random_normal([K, D])),
+             sigma=tf.nn.softplus(tf.Variable(tf.zeros([K, D]))))
+qsigma = InverseGamma(
+  alpha=tf.nn.softplus(tf.Variable(tf.random_normal([K, D]))),
+  beta=tf.nn.softplus(tf.Variable(tf.random_normal([K, D]))))
 \end{lstlisting}
 
-Run variational inference for 2500 iterations, using a batch
-of 20 datapoints and 10 latent variable samples per iteration.
+Run variational inference for 4000 iterations and 20 latent variable
+samples per iteration.
 \begin{lstlisting}[language=Python]
-inference = ed.KLqp({'pi': qpi, 'mu': qmu, 'sigma': qsigma}, data, model)
-inference.run(n_iter=2500, n_samples=10, n_minibatch=20)
+data = {x: x_train}
+inference = ed.KLqp({pi: qpi, mu: qmu, sigma: qsigma}, data)
+inference.run(n_iter=4000, n_samples=20)
 \end{lstlisting}
 In this case
 \texttt{KLqp} defaults to minimizing the
@@ -162,41 +104,33 @@ For more details on inference, see the \href{/tutorials/klqp}{$\text{KL}(q\|p)$ 
 
 We visualize the predicted memberships of each data point.
 We pick the cluster assignment which produces
-the highest log-likelihood for each data point.
-First we output a K x N matrix of log-likelihoods, per
-per-cluster assignment $k$ and per data-point $\mathbf{x}_n$.
+the highest posterior predictive density for each data point.
 
-We do this by adding the \texttt{predict()} method in the
-probability model.
+To do this, we first draw a sample from the posterior and calculate a
+a K x N matrix of log-likelihoods, one for each cluster assignment $k$
+and data point $\mathbf{x}_n$. We perform this averaged over 100
+pwosterior samples.
 \begin{lstlisting}[language=Python]
-class MixtureGaussian:
-  ...
-  def predict(self, xs, zs):
-    """Calculate a K x N matrix of log-likelihoods, per-cluster and
-    per-data point."""
-    x = xs['x']
-    pi, mus, sigmas = zs['pi'], zs['mu'], zs['sigma']
-
-    matrix = []
-    for k in range(self.K):
-      matrix += [multivariate_normal_diag.logpdf(x,
-                 mus[(k * self.D):((k + 1) * self.D)],
-                 sigmas[(k * self.D):((k + 1) * self.D)])]
-
-    return tf.pack(matrix)
-\end{lstlisting}
-Then we evaluate the log-likelihood on the training data
-and take the $\arg\max$ along the rows.
-\begin{lstlisting}[language=Python]
+# Average per-cluster and per-data point likelihood over many posterior samples.
 log_liks = []
-for s in range(100):
-  zrep = {'pi': qpi.sample(()),
-          'mu': qmu.sample(()),
-          'sigma': qsigma.sample(())}
-  log_liks += [model.predict(data, zrep)]
+for _ in range(100):
+  mu_sample = qmu.sample()
+  sigma_sample = qsigma.sample()
+  # Take per-cluster and per-data point likelihood.
+  log_lik = []
+  for k in range(K):
+    x_post = Normal(mu=tf.ones([N, 1]) * tf.gather(mu_sample, k),
+                    sigma=tf.ones([N, 1]) * tf.gather(sigma_sample, k))
+    log_lik.append(tf.reduce_sum(x_post.log_prob(x_train), 1))
+
+  log_lik = tf.pack(log_lik)  # has shape (K, N)
+  log_liks.append(log_lik)
 
 log_liks = tf.reduce_mean(log_liks, 0)
+\end{lstlisting}
 
+We then take the $\arg\max$ along the rows (cluster assignments).
+\begin{lstlisting}[language=Python]
 clusters = tf.argmax(log_liks, 0).eval()
 \end{lstlisting}
 
@@ -204,6 +138,7 @@ Plot the data points, colored by their predicted membership.
 \begin{lstlisting}[language=Python]
 plt.scatter(x_train[:, 0], x_train[:, 1], c=clusters, cmap=cm.bwr)
 plt.axis([-3, 3, -3, 3])
+plt.title("Predicted cluster assignments")
 plt.show()
 \end{lstlisting}
 

--- a/docs/tex/tutorials/unsupervised.tex
+++ b/docs/tex/tutorials/unsupervised.tex
@@ -79,11 +79,12 @@ Define the variational model to be
 \end{align*}
 The model in Edward is
 \begin{lstlisting}[language=Python]
-qmu = Normal(mu=tf.Variable(tf.random_normal([K, D])),
-             sigma=tf.nn.softplus(tf.Variable(tf.zeros([K, D]))))
+qmu = Normal(
+    mu=tf.Variable(tf.random_normal([K, D])),
+    sigma=tf.nn.softplus(tf.Variable(tf.zeros([K, D]))))
 qsigma = InverseGamma(
-  alpha=tf.nn.softplus(tf.Variable(tf.random_normal([K, D]))),
-  beta=tf.nn.softplus(tf.Variable(tf.random_normal([K, D]))))
+    alpha=tf.nn.softplus(tf.Variable(tf.random_normal([K, D]))),
+    beta=tf.nn.softplus(tf.Variable(tf.random_normal([K, D]))))
 \end{lstlisting}
 
 Run variational inference for 4000 iterations and 20 latent variable

--- a/examples/mixture_gaussian_collapsed.py
+++ b/examples/mixture_gaussian_collapsed.py
@@ -54,11 +54,11 @@ x = Mixture(cat=cat, components=components)
 
 # INFERENCE
 qmu = Normal(
-  mu=tf.Variable(tf.random_normal([K, D])),
-  sigma=tf.nn.softplus(tf.Variable(tf.zeros([K, D]))))
+    mu=tf.Variable(tf.random_normal([K, D])),
+    sigma=tf.nn.softplus(tf.Variable(tf.zeros([K, D]))))
 qsigma = InverseGamma(
-  alpha=tf.nn.softplus(tf.Variable(tf.random_normal([K, D]))),
-  beta=tf.nn.softplus(tf.Variable(tf.random_normal([K, D]))))
+    alpha=tf.nn.softplus(tf.Variable(tf.random_normal([K, D]))),
+    beta=tf.nn.softplus(tf.Variable(tf.random_normal([K, D]))))
 
 data = {x: x_train}
 inference = ed.KLqp({mu: qmu, sigma: qsigma}, data)

--- a/examples/mixture_gaussian_collapsed.py
+++ b/examples/mixture_gaussian_collapsed.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+"""Mixture of Gaussians, written in collapsed form.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import edward as ed
+import matplotlib.pyplot as plt
+import matplotlib.cm as cm
+import numpy as np
+import six
+import tensorflow as tf
+
+from edward.models import Categorical, InverseGamma, Mixture, \
+    MultivariateNormalDiag, Normal
+
+plt.style.use('ggplot')
+
+
+def build_toy_dataset(N):
+  pi = np.array([0.4, 0.6])
+  mus = [[1, 1], [-1, -1]]
+  stds = [[0.1, 0.1], [0.1, 0.1]]
+  x = np.zeros((N, 2), dtype=np.float32)
+  for n in range(N):
+    k = np.argmax(np.random.multinomial(1, pi))
+    x[n, :] = np.random.multivariate_normal(mus[k], np.diag(stds[k]))
+
+  return x
+
+
+N = 500  # number of data points
+K = 2  # number of components
+D = 2  # dimensionality of data
+ed.set_seed(42)
+
+# DATA
+x_train = build_toy_dataset(N)
+plt.scatter(x_train[:, 0], x_train[:, 1])
+plt.axis([-3, 3, -3, 3])
+plt.title("Simulated dataset")
+plt.show()
+
+# MODEL
+mu = Normal(mu=tf.zeros([K, D]), sigma=tf.ones([K, D]))
+sigma = InverseGamma(alpha=tf.ones([K, D]), beta=tf.ones([K, D]))
+cat = Categorical(logits=tf.zeros([N, K]))
+components = [
+    MultivariateNormalDiag(mu=tf.ones([N, 1]) * tf.gather(mu, k),
+                           diag_stdev=tf.ones([N, 1]) * tf.gather(sigma, k))
+    for k in range(K)]
+x = Mixture(cat=cat, components=components)
+
+# INFERENCE
+qmu = Normal(
+  mu=tf.Variable(tf.random_normal([K, D])),
+  sigma=tf.nn.softplus(tf.Variable(tf.zeros([K, D]))))
+qsigma = InverseGamma(
+  alpha=tf.nn.softplus(tf.Variable(tf.random_normal([K, D]))),
+  beta=tf.nn.softplus(tf.Variable(tf.random_normal([K, D]))))
+
+data = {x: x_train}
+inference = ed.KLqp({mu: qmu, sigma: qsigma}, data)
+inference.initialize(n_samples=20, n_iter=4000)
+
+sess = ed.get_session()
+init = tf.initialize_all_variables()
+init.run()
+
+for _ in range(inference.n_iter):
+  info_dict = inference.update()
+  inference.print_progress(info_dict)
+  t = info_dict['t']
+  if t % inference.n_print == 0:
+    print("Inferred cluster means:")
+    print(sess.run(qmu.value()))
+
+# Average per-cluster and per-data point likelihood over many posterior samples.
+log_liks = []
+for _ in range(100):
+  mu_sample = qmu.sample()
+  sigma_sample = qsigma.sample()
+  # Take per-cluster and per-data point likelihood.
+  log_lik = []
+  for k in range(K):
+    x_post = Normal(mu=tf.ones([N, 1]) * tf.gather(mu_sample, k),
+                    sigma=tf.ones([N, 1]) * tf.gather(sigma_sample, k))
+    log_lik.append(tf.reduce_sum(x_post.log_prob(x_train), 1))
+
+  log_lik = tf.pack(log_lik)  # has shape (K, N)
+  log_liks.append(log_lik)
+
+log_liks = tf.reduce_mean(log_liks, 0)
+
+# Choose the cluster with the highest likelihood for each data point.
+clusters = tf.argmax(log_liks, 0).eval()
+plt.scatter(x_train[:, 0], x_train[:, 1], c=clusters, cmap=cm.bwr)
+plt.axis([-3, 3, -3, 3])
+plt.title("Predicted cluster assignments")
+plt.show()


### PR DESCRIPTION
The last tutorials written with model wrappers—the mixture of Gaussians and mixture density network—are rewritten in Edward's native language. We use the [`Mixture`](https://www.tensorflow.org/versions/r0.11/api_docs/python/contrib.distributions.html#mixture-models) random variable to collapse the mixture assignments, and which internally calculates the log-density using the log-sum-exp trick.

Neither example works. I think there's an issue with gradients not propagating correctly in the `Mixture` random variable. As inference runs, the parameters hardly change (although they do change, implying that some gradient update is occurring).