### PR TITLE
disable copying for Queue operations

### DIFF
--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -185,6 +185,7 @@ def copy(org_instance, dict_swap=None, scope="copied",
   else:  # tf.Operation
     op = org_instance
 
+    # Do not copy queue operations
     if 'Queue' in op.type:
       return op
 

--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -185,6 +185,9 @@ def copy(org_instance, dict_swap=None, scope="copied",
   else:  # tf.Operation
     op = org_instance
 
+    if 'Queue' in op.type:
+      return op
+
     # If it has an original op, copy it.
     if op._original_op is not None:
       new_original_op = copy(op._original_op, dict_swap, scope, True, copy_q)


### PR DESCRIPTION
A little background:

I'm trying to implement a model using SVI minibatches along [these lines](http://edwardlib.org/api/inference-data-subsampling) but using the `inference.run()` interface. The `run` interface allows me to take a minibatch of anything that's a `RandomVariable`, but it doesn't easily allow subselection of variables specific to individual data points. The example in the docs uses a placeholder variable along with `tf.gather` to subselect data. Thus the options seem to be
1. using the machinery in `run`, which automatically constructs minibatches for `RandomVariables`
2. doing everything by hand (defining a `get_next_batch`, calling `update` in a loop, etc.)

I wound up trying an approach where I simply do the batching myself:
```python
batch_inds, batch_counts = tf.train.batch(tf.train.slice_input_producer([indices, counts]), 
                                          batch_size, 
                                          name='batches')
```
and then construct the model using these nodes to select what terms go into the ELBO. This is exactly what's currently done in `run` for arrays passed as `data`, but also lets me batch `indices`, which is not a `RandomVariable`.

The issue I ran into is that this model hangs. I eventually tracked it down to the fact that `copy` is also copying queue nodes, but without filling these queue copies, so the model is waiting indefinitely for the empty copy queue to be filled. 

The PR is a hack to ensure that queue nodes are not copied but shared like placeholders, which appears to fix the problem.

There might be a more elegant solution, or I might have missed some facility for doing this that's already available.