### PR TITLE
Make edward compatible with Tensorflow 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ install:
   - pip install numpydoc
   - pip install git+https://github.com/pymc-devs/pymc3
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.11.0rc0-cp27-none-linux_x86_64.whl;
+      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.12.0rc0-cp27-none-linux_x86_64.whl;
     elif [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
-      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.11.0rc0-cp34-cp34m-linux_x86_64.whl;
+      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.12.0rc0-cp34-cp34m-linux_x86_64.whl;
     fi
   - python setup.py install
 script:

--- a/docs/notebooks/getting-started.ipynb
+++ b/docs/notebooks/getting-started.ipynb
@@ -233,7 +233,7 @@
     "inference = ed.MFVI({W_0: qW_0, b_0: qb_0,\n",
     "                     W_1: qW_1, b_1: qb_1}, data)\n",
     "inference.initialize()\n",
-    "tf.initialize_all_variables().run()"
+    "tf.global_variables_initializer().run()"
    ]
   },
   {

--- a/docs/tex/api/inference.tex
+++ b/docs/tex/api/inference.tex
@@ -51,7 +51,7 @@ Inference also supports fine control of the training procedure.
 inference = ed.Inference({z: qz, beta: qbeta}, {x: x_train})
 inference.initialize()
 
-tf.initialize_all_variables().run()
+tf.global_variables_initializer().run()
 
 for _ in range(inference.n_iter):
   info_dict = inference.update()

--- a/docs/tex/tutorials/mixture-density-network.tex
+++ b/docs/tex/tutorials/mixture-density-network.tex
@@ -130,7 +130,7 @@ sess = ed.get_session()
 K.set_session(sess)
 inference.initialize()
 
-init = tf.initialize_all_variables()
+init = tf.global_variables_initializer()
 init.run()
 \end{lstlisting}
 

--- a/edward/inferences/hmc.py
+++ b/edward/inferences/hmc.py
@@ -102,7 +102,7 @@ class HMC(MonteCarlo):
     # Update Empirical random variables.
     assign_ops = []
     variables = {x.name: x for x in
-                 tf.get_default_graph().get_collection(tf.GraphKeys.VARIABLES)}
+                 tf.get_default_graph().get_collection(tf.GraphKeys.GLOBAL_VARIABLES)}
     for z, qz in six.iteritems(self.latent_vars):
       variable = variables[qz.params.op.inputs[0].op.inputs[0].name]
       assign_ops.append(tf.scatter_update(variable, self.t, sample[z]))

--- a/edward/inferences/inference.py
+++ b/edward/inferences/inference.py
@@ -214,7 +214,7 @@ class Inference(object):
       self.train_writer = tf.train.SummaryWriter(logdir, tf.get_default_graph())
 
     if variables is None:
-      init = tf.initialize_all_variables()
+      init = tf.global_variables_initializer()
     else:
       init = tf.initialize_variables(variables)
 

--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -141,6 +141,6 @@ class KLpq(VariationalInference):
     loss = tf.reduce_mean(w_norm * log_w)
     grads = tf.gradients(
         -tf.reduce_mean(q_log_prob * tf.stop_gradient(w_norm)),
-        [v.ref() for v in var_list])
+        [v.value() for v in var_list])
     grads_and_vars = list(zip(grads, var_list))
     return loss, grads_and_vars

--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -141,6 +141,6 @@ class KLpq(VariationalInference):
     loss = tf.reduce_mean(w_norm * log_w)
     grads = tf.gradients(
         -tf.reduce_mean(q_log_prob * tf.stop_gradient(w_norm)),
-        [v.value() for v in var_list])
+        var_list)
     grads_and_vars = list(zip(grads, var_list))
     return loss, grads_and_vars

--- a/edward/inferences/klqp.py
+++ b/edward/inferences/klqp.py
@@ -105,7 +105,7 @@ class KLqp(VariationalInference):
       if var_list is None:
         var_list = tf.trainable_variables()
 
-      grads = tf.gradients(loss, [v.value() for v in var_list])
+      grads = tf.gradients(loss, var_list)
       grads_and_vars = list(zip(grads, var_list))
       return loss, grads_and_vars
     else:
@@ -563,7 +563,7 @@ def build_score_loss_and_gradients(inference, var_list):
   loss = -tf.reduce_mean(losses)
   grads = tf.gradients(
       -tf.reduce_mean(q_log_prob * tf.stop_gradient(losses)),
-      [v.value() for v in var_list])
+      var_list)
   grads_and_vars = list(zip(grads, var_list))
   return loss, grads_and_vars
 
@@ -637,7 +637,7 @@ def build_score_kl_loss_and_gradients(inference, var_list):
   loss = -(tf.reduce_mean(p_log_lik) - kl)
   grads = tf.gradients(
       -(tf.reduce_mean(q_log_prob * tf.stop_gradient(p_log_lik)) - kl),
-      [v.value() for v in var_list])
+      var_list)
   grads_and_vars = list(zip(grads, var_list))
   return loss, grads_and_vars
 
@@ -711,6 +711,6 @@ def build_score_entropy_loss_and_gradients(inference, var_list):
   grads = tf.gradients(
       -(tf.reduce_mean(q_log_prob * tf.stop_gradient(p_log_prob)) +
           q_entropy),
-      [v.value() for v in var_list])
+      var_list)
   grads_and_vars = list(zip(grads, var_list))
   return loss, grads_and_vars

--- a/edward/inferences/klqp.py
+++ b/edward/inferences/klqp.py
@@ -105,7 +105,7 @@ class KLqp(VariationalInference):
       if var_list is None:
         var_list = tf.trainable_variables()
 
-      grads = tf.gradients(loss, [v.ref() for v in var_list])
+      grads = tf.gradients(loss, [v.value() for v in var_list])
       grads_and_vars = list(zip(grads, var_list))
       return loss, grads_and_vars
     else:
@@ -563,7 +563,7 @@ def build_score_loss_and_gradients(inference, var_list):
   loss = -tf.reduce_mean(losses)
   grads = tf.gradients(
       -tf.reduce_mean(q_log_prob * tf.stop_gradient(losses)),
-      [v.ref() for v in var_list])
+      [v.value() for v in var_list])
   grads_and_vars = list(zip(grads, var_list))
   return loss, grads_and_vars
 
@@ -637,7 +637,7 @@ def build_score_kl_loss_and_gradients(inference, var_list):
   loss = -(tf.reduce_mean(p_log_lik) - kl)
   grads = tf.gradients(
       -(tf.reduce_mean(q_log_prob * tf.stop_gradient(p_log_lik)) - kl),
-      [v.ref() for v in var_list])
+      [v.value() for v in var_list])
   grads_and_vars = list(zip(grads, var_list))
   return loss, grads_and_vars
 
@@ -711,6 +711,6 @@ def build_score_entropy_loss_and_gradients(inference, var_list):
   grads = tf.gradients(
       -(tf.reduce_mean(q_log_prob * tf.stop_gradient(p_log_prob)) +
           q_entropy),
-      [v.ref() for v in var_list])
+      [v.value() for v in var_list])
   grads_and_vars = list(zip(grads, var_list))
   return loss, grads_and_vars

--- a/edward/inferences/metropolis_hastings.py
+++ b/edward/inferences/metropolis_hastings.py
@@ -139,7 +139,7 @@ class MetropolisHastings(MonteCarlo):
     # Update Empirical random variables.
     assign_ops = []
     variables = {x.name: x for x in
-                 tf.get_default_graph().get_collection(tf.GraphKeys.VARIABLES)}
+                 tf.get_default_graph().get_collection(tf.GraphKeys.GLOBAL_VARIABLES)}
     for z, qz in six.iteritems(self.latent_vars):
       variable = variables[qz.params.op.inputs[0].op.inputs[0].name]
       assign_ops.append(tf.scatter_update(variable, self.t, sample[z]))

--- a/edward/inferences/sgld.py
+++ b/edward/inferences/sgld.py
@@ -77,7 +77,7 @@ class SGLD(MonteCarlo):
     # Update Empirical random variables.
     assign_ops = []
     variables = {x.name: x for x in
-                 tf.get_default_graph().get_collection(tf.GraphKeys.VARIABLES)}
+                 tf.get_default_graph().get_collection(tf.GraphKeys.GLOBAL_VARIABLES)}
     for z, qz in six.iteritems(self.latent_vars):
       variable = variables[qz.params.op.inputs[0].op.inputs[0].name]
       assign_ops.append(tf.scatter_update(variable, self.t, sample[z]))

--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -128,7 +128,7 @@ def copy(org_instance, dict_swap=None, scope="copied",
   # Note we check variables via their name and not their type. This
   # is because if we get variables through an op's inputs, it has
   # type tf.Tensor: we can only tell it is a variable via its name.
-  variables = {x.name: x for x in graph.get_collection(tf.GraphKeys.VARIABLES)}
+  variables = {x.name: x for x in graph.get_collection(tf.GraphKeys.GLOBAL_VARIABLES)}
   if org_instance.name in variables:
     return graph.get_tensor_by_name(variables[org_instance.name].name)
 
@@ -182,7 +182,7 @@ def copy(org_instance, dict_swap=None, scope="copied",
         graph.add_to_collection(name, new_tensor)
 
     return new_tensor
-  else:  # tf.Operation
+  elif isinstance(org_instance, tf.Operation):
     op = org_instance
 
     # If it has an original op, copy it.
@@ -282,6 +282,8 @@ def copy(org_instance, dict_swap=None, scope="copied",
           attr_value_pb2.AttrValue(s=compat.as_bytes(graph._container)))
 
     return ret
+  else:
+    raise TypeError("Could not copy instance: " + str(org_instance))
 
 
 def get_ancestors(x, collection=None):

--- a/examples/factor_analysis.py
+++ b/examples/factor_analysis.py
@@ -61,7 +61,7 @@ inference_m = ed.MAP(data={x: x_train, z: tf.gather(qz.params, inference_e.t)})
 optimizer = tf.train.AdamOptimizer(0.01, epsilon=1.0)
 inference_m.initialize(optimizer=optimizer)
 
-init = tf.initialize_all_variables()
+init = tf.global_variables_initializer()
 init.run()
 
 n_iter_per_epoch = 100

--- a/examples/getting_started_example.py
+++ b/examples/getting_started_example.py
@@ -77,7 +77,7 @@ for s in range(10):
 mus = tf.pack(mus)
 
 sess = ed.get_session()
-init = tf.initialize_all_variables()
+init = tf.global_variables_initializer()
 init.run()
 
 

--- a/examples/mixture_gaussian_mh.py
+++ b/examples/mixture_gaussian_mh.py
@@ -70,7 +70,7 @@ inference = ed.MetropolisHastings(
 inference.initialize()
 
 sess = ed.get_session()
-init = tf.initialize_all_variables()
+init = tf.global_variables_initializer()
 init.run()
 
 for _ in range(T):

--- a/examples/normal_idiomatic_tf.py
+++ b/examples/normal_idiomatic_tf.py
@@ -25,7 +25,7 @@ qz = Normal(mu=tf.Variable(tf.random_normal([])),
 inference = ed.KLqp({z: qz})
 inference.initialize(n_iter=250)
 
-init = tf.initialize_all_variables()
+init = tf.global_variables_initializer()
 init.run()
 
 for _ in range(inference.n_iter):

--- a/examples/probabilistic_pca.py
+++ b/examples/probabilistic_pca.py
@@ -51,7 +51,7 @@ qz = Normal(mu=tf.Variable(tf.random_normal([N, K])),
 
 inference = ed.KLqp({w: qw, z: qz}, data={x: x_train})
 
-init = tf.initialize_all_variables()
+init = tf.global_variables_initializer()
 inference.run(n_iter=500, n_print=100, n_samples=10)
 
 sess = ed.get_session()

--- a/examples/probabilistic_pca_subsampling.py
+++ b/examples/probabilistic_pca_subsampling.py
@@ -74,7 +74,7 @@ inference_z.initialize(scale={x: float(N) / M, z: float(N) / M},
                        n_samples=5)
 
 sess = ed.get_session()
-init = tf.initialize_all_variables()
+init = tf.global_variables_initializer()
 init.run()
 
 for t in range(inference_w.n_iter):

--- a/examples/tf_bayesian_linear_regression_plot.py
+++ b/examples/tf_bayesian_linear_regression_plot.py
@@ -84,7 +84,7 @@ data = {'x': x_train, 'y': y_train}
 inference = ed.KLqp({'w': qw, 'b': qb}, data, model)
 inference.initialize(n_samples=5, n_iter=250, n_print=5)
 
-init = tf.initialize_all_variables()
+init = tf.global_variables_initializer()
 init.run()
 
 for t in range(inference.n_iter):

--- a/examples/tf_bayesian_nn.py
+++ b/examples/tf_bayesian_nn.py
@@ -109,7 +109,7 @@ data = {'x': x_train, 'y': y_train}
 inference = ed.KLqp({'z': qz}, data, model)
 inference.initialize()
 
-init = tf.initialize_all_variables()
+init = tf.global_variables_initializer()
 init.run()
 
 for t in range(inference.n_iter):

--- a/examples/tf_bayesian_nn_analytic_kl.py
+++ b/examples/tf_bayesian_nn_analytic_kl.py
@@ -111,7 +111,7 @@ data = {'x': x_train, 'y': y_train}
 inference = ed.KLqp({'z': qz}, data, model)
 inference.initialize(n_print=10)
 
-init = tf.initialize_all_variables()
+init = tf.global_variables_initializer()
 init.run()
 
 for t in range(inference.n_iter):

--- a/examples/tf_convolutional_vae.py
+++ b/examples/tf_convolutional_vae.py
@@ -127,7 +127,7 @@ with tf.variable_scope("model"):
 with tf.variable_scope("model", reuse=True):
   p_rep = tf.sigmoid(model.sample_prior(M))
 
-init = tf.initialize_all_variables()
+init = tf.global_variables_initializer()
 init.run()
 
 n_epoch = 100

--- a/examples/tf_hierarchical_logistic_regression.py
+++ b/examples/tf_hierarchical_logistic_regression.py
@@ -88,7 +88,7 @@ data = {'x': x_train, 'y': y_train}
 inference = ed.KLqp({'w': qw, 'b': qb}, data, model)
 inference.initialize(n_print=5, n_iter=600)
 
-init = tf.initialize_all_variables()
+init = tf.global_variables_initializer()
 init.run()
 
 for t in range(inference.n_iter):

--- a/examples/tf_mixture_density_network.py
+++ b/examples/tf_mixture_density_network.py
@@ -81,7 +81,7 @@ sess = ed.get_session()
 K.set_session(sess)
 inference.initialize()
 
-init = tf.initialize_all_variables()
+init = tf.global_variables_initializer()
 init.run()
 
 n_epoch = 20

--- a/examples/tf_mixture_density_network_demo.py
+++ b/examples/tf_mixture_density_network_demo.py
@@ -117,7 +117,7 @@ sess = ed.get_session()  # Start TF session
 K.set_session(sess)  # Pass session info to Keras
 inference.initialize()
 
-init = tf.initialize_all_variables()
+init = tf.global_variables_initializer()
 init.run()
 
 n_epoch = 1000

--- a/examples/tf_mixture_density_network_slim.py
+++ b/examples/tf_mixture_density_network_slim.py
@@ -69,7 +69,7 @@ inference = ed.MAP([], data, model)
 sess = ed.get_session()
 inference.initialize()
 
-init = tf.initialize_all_variables()
+init = tf.global_variables_initializer()
 init.run()
 
 n_epoch = 20

--- a/examples/vae.py
+++ b/examples/vae.py
@@ -43,7 +43,7 @@ inference = ed.KLqp({z: qz}, data)
 optimizer = tf.train.RMSPropOptimizer(0.01, epsilon=1.0)
 inference.initialize(optimizer=optimizer)
 
-init = tf.initialize_all_variables()
+init = tf.global_variables_initializer()
 init.run()
 
 n_epoch = 100

--- a/examples/vae_convolutional.py
+++ b/examples/vae_convolutional.py
@@ -91,7 +91,7 @@ inference = ed.KLqp({z: qz}, data)
 optimizer = tf.train.AdamOptimizer(0.01, epsilon=1.0)
 inference.initialize(optimizer=optimizer)
 
-init = tf.initialize_all_variables()
+init = tf.global_variables_initializer()
 init.run()
 
 n_epoch = 100

--- a/examples/vae_convolutional_prettytensor.py
+++ b/examples/vae_convolutional_prettytensor.py
@@ -91,7 +91,7 @@ inference = ed.ReparameterizationKLKLqp({z: qz}, data)
 optimizer = tf.train.AdamOptimizer(0.01, epsilon=1.0)
 inference.initialize(optimizer=optimizer, use_prettytensor=True)
 
-init = tf.initialize_all_variables()
+init = tf.global_variables_initializer()
 init.run()
 
 n_epoch = 100

--- a/tests/test-inferences/test_data.py
+++ b/tests/test-inferences/test_data.py
@@ -44,7 +44,7 @@ class test_inference_data_class(tf.test.TestCase):
     inference = ed.KLqp({'mu': qmu}, data, model_wrapper=model)
     inference.initialize(n_minibatch=n_minibatch)
 
-    init = tf.initialize_all_variables()
+    init = tf.global_variables_initializer()
     init.run()
 
     # Start input enqueue threads.

--- a/tests/test-models/test_quantized_distribution_sample.py
+++ b/tests/test-models/test_quantized_distribution_sample.py
@@ -9,12 +9,12 @@ from edward.models import Normal, QuantizedDistribution
 from edward.util import get_dims
 
 
-def _test(base_dist_cls, lower_cutoff, upper_cutoff, n, **base_dist_args):
+def _test(distribution, lower_cutoff, upper_cutoff, n):
   x = QuantizedDistribution(
-      base_dist_cls=base_dist_cls,
+      distribution=distribution,
       lower_cutoff=lower_cutoff,
       upper_cutoff=upper_cutoff,
-      **base_dist_args)
+      validate_args=True)
   val_est = get_dims(x.sample(n))
   val_true = n + get_dims(lower_cutoff)
   assert val_est == val_true
@@ -24,23 +24,23 @@ class test_quantized_distribution_sample_class(tf.test.TestCase):
 
   def test_0d(self):
     with self.test_session():
-      base_dist_cls = Normal
-      lower_cutoff = 0.0
-      upper_cutoff = 2.0
       mu = 0.0
       sigma = 1.0
-      _test(base_dist_cls, lower_cutoff, upper_cutoff, [1], mu=mu, sigma=sigma)
-      _test(base_dist_cls, lower_cutoff, upper_cutoff, [5], mu=mu, sigma=sigma)
+      distribution = Normal(mu=mu, sigma=sigma)
+      lower_cutoff = 0.0
+      upper_cutoff = 2.0
+      _test(distribution, lower_cutoff, upper_cutoff, [1])
+      _test(distribution, lower_cutoff, upper_cutoff, [5])
 
   def test_1d(self):
     with self.test_session():
-      base_dist_cls = Normal
-      lower_cutoff = tf.constant([0.0, 1.0, 2.0, 4.0, 1.0])
-      upper_cutoff = tf.constant([2.0, 3.0, 3.0, 6.0, 2.0])
       mu = tf.zeros(5)
       sigma = tf.ones(5)
-      _test(base_dist_cls, lower_cutoff, upper_cutoff, [1], mu=mu, sigma=sigma)
-      _test(base_dist_cls, lower_cutoff, upper_cutoff, [5], mu=mu, sigma=sigma)
+      distribution = Normal(mu=mu, sigma=sigma)
+      lower_cutoff = tf.constant([0.0, 1.0, 2.0, 4.0, 1.0])
+      upper_cutoff = tf.constant([2.0, 3.0, 3.0, 6.0, 2.0])
+      _test(distribution, lower_cutoff, upper_cutoff, [1])
+      _test(distribution, lower_cutoff, upper_cutoff, [5])
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tests/test-models/test_transformed_distribution_sample.py
+++ b/tests/test-models/test_transformed_distribution_sample.py
@@ -9,16 +9,13 @@ from edward.models import Normal, TransformedDistribution
 from edward.util import get_dims
 
 
-def _test(base_dist_cls, transform, inverse,
-          log_det_jacobian, n, **base_dist_args):
+def _test(distribution, bijector, n):
   x = TransformedDistribution(
-      base_dist_cls=base_dist_cls,
-      transform=transform,
-      inverse=inverse,
-      log_det_jacobian=log_det_jacobian,
-      **base_dist_args)
+      distribution=distribution,
+      bijector=bijector,
+      validate_args=True)
   val_est = get_dims(x.sample(n))
-  val_true = n + get_dims(base_dist_args['mu'])
+  val_true = n + get_dims(distribution.mean())
   assert val_est == val_true
 
 
@@ -27,48 +24,23 @@ class test_transformed_distribution_sample_class(tf.test.TestCase):
   def test_0d(self):
     with self.test_session():
       # log-normal
-      base_dist_cls = Normal
-
-      def transform(x):
-        return tf.sigmoid(x)
-
-      def inverse(y):
-        return tf.log(y) - tf.log(1. - y)
-
-      def log_det_jacobian(x):
-        return tf.reduce_sum(
-            tf.log(tf.sigmoid(x)) + tf.log(1. - tf.sigmoid(x)),
-            reduction_indices=[-1])
-
       mu = 0.0
       sigma = 1.0
-      _test(base_dist_cls, transform, inverse,
-            log_det_jacobian, [1], mu=mu, sigma=sigma)
-      _test(base_dist_cls, transform, inverse,
-            log_det_jacobian, [5], mu=mu, sigma=sigma)
+      distribution = Normal(mu=mu, sigma=sigma)
+
+      _test(distribution, tf.contrib.distributions.bijector.Exp(), [1])
+      _test(distribution, tf.contrib.distributions.bijector.Exp(), [5])
 
   def test_1d(self):
     with self.test_session():
       # log-normal
-      base_dist_cls = Normal
-
-      def transform(x):
-        return tf.sigmoid(x)
-
-      def inverse(y):
-        return tf.log(y) - tf.log(1. - y)
-
-      def log_det_jacobian(x):
-        return tf.reduce_sum(
-            tf.log(tf.sigmoid(x)) + tf.log(1. - tf.sigmoid(x)),
-            reduction_indices=[-1])
-
       mu = tf.zeros(5)
       sigma = tf.ones(5)
-      _test(base_dist_cls, transform, inverse,
-            log_det_jacobian, [1], mu=mu, sigma=sigma)
-      _test(base_dist_cls, transform, inverse,
-            log_det_jacobian, [5], mu=mu, sigma=sigma)
+      distribution = Normal(mu=mu, sigma=sigma)
+
+      _test(distribution, tf.contrib.distributions.bijector.Exp(), [1])
+      _test(distribution, tf.contrib.distributions.bijector.Exp(), [5])
+
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tests/test-util/test_hessian.py
+++ b/tests/test-util/test_hessian.py
@@ -17,7 +17,7 @@ class test_hessian_class(tf.test.TestCase):
       y = tf.pow(x1, tf.constant(2.0)) + tf.constant(2.0) * x1 * x2 + \
           tf.constant(3.0) * tf.pow(x2, tf.constant(2.0)) + \
           tf.constant(4.0) * x1 + tf.constant(5.0) * x2 + tf.constant(6.0)
-      tf.initialize_all_variables().run()
+      tf.global_variables_initializer().run()
       self.assertAllEqual(hessian(y, [x1]).eval(),
                           np.array([[2.0]]))
       self.assertAllEqual(hessian(y, [x2]).eval(),
@@ -32,7 +32,7 @@ class test_hessian_class(tf.test.TestCase):
           tf.constant(4.0) * x1 + tf.constant(5.0) * x2 + tf.constant(6.0)
       x3 = tf.Variable(tf.random_normal([3], dtype=tf.float32))
       z = tf.pow(x2, tf.constant(2.0)) + tf.reduce_sum(x3)
-      tf.initialize_all_variables().run()
+      tf.global_variables_initializer().run()
       self.assertAllEqual(hessian(y, [x1, x2]).eval(),
                           np.array([[2.0, 2.0], [2.0, 6.0]]))
       self.assertAllEqual(hessian(z, [x3]).eval(),
@@ -45,7 +45,7 @@ class test_hessian_class(tf.test.TestCase):
       x1 = tf.Variable(tf.random_normal([3, 2], dtype=tf.float32))
       x2 = tf.Variable(tf.random_normal([2], dtype=tf.float32))
       y = tf.reduce_sum(tf.pow(x1, tf.constant(2.0))) + tf.reduce_sum(x2)
-      tf.initialize_all_variables().run()
+      tf.global_variables_initializer().run()
       self.assertAllEqual(hessian(y, [x1]).eval(),
                           np.diag([2.0] * 6))
       self.assertAllEqual(hessian(y, [x1, x2]).eval(),
@@ -58,7 +58,7 @@ class test_hessian_class(tf.test.TestCase):
       y = tf.pow(x1, tf.constant(2.0)) + tf.constant(2.0) * x1 * x2 + \
           tf.constant(3.0) * tf.pow(x2, tf.constant(2.0)) + \
           tf.constant(4.0) * x1 + tf.constant(5.0) * x2 + tf.constant(6.0)
-      tf.initialize_all_variables().run()
+      tf.global_variables_initializer().run()
       with self.assertRaisesOpError('NaN'):
         hessian(y, [x1]).eval()
       with self.assertRaisesOpError('NaN'):


### PR DESCRIPTION
Initial attempt to add TF 0.12 compatibility. 

I have changed a few things in order to make edward compatible with TF 0.12:

- `tf.initialize_all_variables()` calls have been renamed to `tf.global_variables_initializer()`

- `tf.Variable.ref()` calls are removed. See: https://github.com/tensorflow/tensorflow/commit/c46f70c06985edce4905668a943801040c7a1354#diff-ae1a8f7b66539f000615a4ab7e4b2151R460. `ref()` is an internal function now.

- `tf.GraphKeys.VARIABLES` is replaced with `tf.GraphKeys.GLOBAL_VARIABLES`.

As a side note, even after applying these changes, edward still doesn't work because of the bug introduced in TF 0.12rc0, see: https://github.com/tensorflow/tensorflow/issues/5930 and https://github.com/tensorflow/tensorflow/commit/77cfa97ac784212130e97bc6fa9e6f8acfc86c08 for the fix. Therefore I had to use TF master branch.

There are still 2 test failing, I'm looking into them.