### PR TITLE
all VariationalInference methods must use build_loss_and_gradients

### DIFF
--- a/docs/tex/api/inference-development.tex
+++ b/docs/tex/api/inference-development.tex
@@ -29,9 +29,12 @@ optimization and sampling). These inherit from \texttt{Inference} and each
 have their own default methods.
 
 For example, developing a new variational inference algorithm is as simple as
-inheriting from \texttt{VariationalInference} or one of its derived
-classes. \texttt{VariationalInference} implements many default methods such
+inheriting from \texttt{VariationalInference} and writing a
+\texttt{build_loss_and_gradients()} method. \texttt{VariationalInference} implements many default methods such
 as \texttt{initialize()} with options for an optimizer.
+For example, see the
+\href{https://github.com/blei-lab/edward/blob/master/examples/tf_iwvi.py}{importance
+weighted variational inference} script.
 
 \begin{center}\rule{3in}{0.4pt}\end{center}
 

--- a/edward/inferences/inference.py
+++ b/edward/inferences/inference.py
@@ -265,7 +265,7 @@ class Inference(object):
     logdir : str, optional
       Directory where event file will be written. For details,
       see `tf.train.SummaryWriter`. Default is to write nothing.
-    debug: boolean, optional
+    debug: bool, optional
       If True, add checks for NaN and Inf to all computations in the graph.
       May result in substantially slower execution times.
     """
@@ -319,8 +319,8 @@ class Inference(object):
     else:
       self.logging = False
 
-    if debug:
-      self.debug = True
+    self.debug = debug
+    if self.debug:
       self.op_check = tf.add_check_numerics_ops()
 
   def update(self):

--- a/edward/inferences/map.py
+++ b/edward/inferences/map.py
@@ -99,7 +99,7 @@ class MAP(VariationalInference):
 
     super(MAP, self).__init__(latent_vars, data, model_wrapper)
 
-  def build_loss(self):
+  def build_loss_and_gradients(self):
     """Build loss function. Its automatic differentiation
     is the gradient of
 
@@ -141,7 +141,14 @@ class MAP(VariationalInference):
       x = self.data
       p_log_prob = self.model_wrapper.log_prob(x, z_mode)
 
-    return -p_log_prob
+    loss = -p_log_prob
+
+    if var_list is None:
+      var_list = tf.trainable_variables()
+
+    grads = tf.gradients(loss, [v.ref() for v in var_list])
+    grads_and_vars = list(zip(grads, var_list))
+    return loss, grads_and_vars
 
 
 class Laplace(MAP):


### PR DESCRIPTION
Originally, there were two ways to build variational inference classes: write a method `build_loss` or `build_loss_and_gradients`. This is confusing. Now there is only one way.