### PR TITLE
Fix for some logging issues

### DIFF
--- a/edward/inferences/inference.py
+++ b/edward/inferences/inference.py
@@ -372,4 +372,5 @@ class Inference(object):
   def finalize(self):
     """Function to call after convergence.
     """
-    pass
+    if self.logging:
+      self.train_writer.close()

--- a/edward/inferences/variational_inference.py
+++ b/edward/inferences/variational_inference.py
@@ -142,8 +142,9 @@ class VariationalInference(Inference):
 
     if self.logging and self.n_print != 0:
       if t == 1 or t % self.n_print == 0:
-        summary = sess.run(self.summarize, feed_dict)
-        self.train_writer.add_summary(summary, t)
+        if self.summarize is not None:
+          summary = sess.run(self.summarize, feed_dict)
+          self.train_writer.add_summary(summary, t)
 
     return {'t': t, 'loss': loss}
 


### PR DESCRIPTION
Quick fix for some issues wrt to logging, see #337, [this comment](https://github.com/blei-lab/edward/pull/337#issuecomment-269669196)

- calling `train_writer.close()` once inference is done (forcing flush to disk)
- only running the self.summarize Op if there's anything to log/summarize  (would raise Exception otherwise)