### PR TITLE
add docstrings to random variables

### DIFF
--- a/edward/models/random_variables.py
+++ b/edward/models/random_variables.py
@@ -3,7 +3,6 @@ from __future__ import division
 from __future__ import print_function
 
 import inspect
-import tensorflow as tf
 
 from edward.models.empirical import Empirical as distributions_Empirical
 from edward.models.point_mass import PointMass as distributions_PointMass
@@ -30,12 +29,7 @@ for _name in sorted(dir(distributions)):
           _candidate != distributions.Distribution and
           issubclass(_candidate, distributions.Distribution)):
 
-    class _WrapperRandomVariable(RandomVariable, _candidate):
-      def __init__(self, *args, **kwargs):
-        RandomVariable.__init__(self, *args, **kwargs)
+    params = {'__doc__': _candidate.__doc__}
+    _globals[_name] = type(_name, (RandomVariable, _candidate), params)
 
-    _WrapperRandomVariable.__name__ = _name
-    _globals[_name] = _WrapperRandomVariable
-
-    del _WrapperRandomVariable
     del _candidate

--- a/tests/test-models/test_bernoulli_doc.py
+++ b/tests/test-models/test_bernoulli_doc.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+from tensorflow.contrib.distributions import Bernoulli as tfBernoulli
+
+from edward.models import Bernoulli
+
+
+class test_bernoulli_doc_class(tf.test.TestCase):
+
+  def test_0d(self):
+    assert len(Bernoulli.__doc__) > 0
+    assert Bernoulli.__doc__ == tfBernoulli.__doc__
+    assert Bernoulli.__name__ == "Bernoulli"
+
+if __name__ == '__main__':
+  tf.test.main()


### PR DESCRIPTION
Resolution for Issue https://github.com/blei-lab/edward/issues/390.

Reuse the docstrings from the classes in `tensorflow.contrib.distributions` as docstrings for the `RandomVariable` classes in Edward.  Now calling `help()` on a `RandomVariable` class will show information about the distribution and the required parameters.