### PR TITLE
fix theano NameError in inferences.py, fixes #359

### DIFF
--- a/edward/inferences/inference.py
+++ b/edward/inferences/inference.py
@@ -13,7 +13,9 @@ from edward.util import get_session
 
 try:
   import theano
+  no_theano = False
 except ImportError:
+  no_theano = True
   pass
 
 
@@ -154,7 +156,8 @@ class Inference(object):
             sess.run(var.initializer, {ph: value})
           else:
             self.data[key] = value
-        elif isinstance(key, theano.tensor.sharedvar.TensorSharedVariable):
+        elif ((not no_theano) and
+                isinstance(key, theano.tensor.sharedvar.TensorSharedVariable)):
           self.data[key] = value
         elif isinstance(key, tf.Tensor):
           if isinstance(value, RandomVariable):


### PR DESCRIPTION
When theano isn't installed `inferences.py` can error out. This fixes it and in the process #359.