### PR TITLE
changed copy() to handle list in RandomVariable _kwargs e.g. in Mixture

### DIFF
--- a/edward/inferences/map.py
+++ b/edward/inferences/map.py
@@ -99,13 +99,14 @@ class MAP(VariationalInference):
 
     super(MAP, self).__init__(latent_vars, data, model_wrapper)
 
-  def build_loss_and_gradients(self):
+  def build_loss_and_gradients(self, var_list):
     """Build loss function. Its automatic differentiation
     is the gradient of
 
     .. math::
       - \log p(x,z)
     """
+    # for now: ignore var_list
     z_mode = {z: qz.value()
               for z, qz in six.iteritems(self.latent_vars)}
     if self.model_wrapper is None:

--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -13,6 +13,14 @@ from tensorflow.core.framework import attr_value_pb2
 from tensorflow.python.framework.ops import set_shapes_for_outputs
 from tensorflow.python.util import compat
 
+def copy_rv(value, dict_swap, scope, replace_itself, copy_q):
+    if isinstance(value, RandomVariable) or \
+        isinstance(value, tf.Variable) or \
+         isinstance(value, tf.Tensor) or \
+            isinstance(value, tf.Operation):
+        value = copy(value, dict_swap, scope, replace_itself, copy_q)
+    return value
+
 
 def copy(org_instance, dict_swap=None, scope="copied",
          replace_itself=False, copy_q=False):
@@ -154,13 +162,11 @@ def copy(org_instance, dict_swap=None, scope="copied",
 
     kwargs = {}
     for key, value in six.iteritems(rv._kwargs):
-      if isinstance(value, RandomVariable) or \
-         isinstance(value, tf.Variable) or \
-         isinstance(value, tf.Tensor) or \
-         isinstance(value, tf.Operation):
-         value = copy(value, dict_swap, scope, True, copy_q)
+      if isinstance(value, list):
+          kwargs[key] = [copy_rv(v, dict_swap, scope, True, copy_q) for v in value]
+      else:
+          kwargs[key] = copy_rv(value, dict_swap, scope, True, copy_q)
 
-      kwargs[key] = value
 
     kwargs['name'] = new_name
     # Create new random variable with copied arguments.

--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -13,13 +13,14 @@ from tensorflow.core.framework import attr_value_pb2
 from tensorflow.python.framework.ops import set_shapes_for_outputs
 from tensorflow.python.util import compat
 
+
 def copy_rv(value, dict_swap, scope, replace_itself, copy_q):
-    if isinstance(value, RandomVariable) or \
-        isinstance(value, tf.Variable) or \
-         isinstance(value, tf.Tensor) or \
-            isinstance(value, tf.Operation):
-        value = copy(value, dict_swap, scope, replace_itself, copy_q)
-    return value
+  if isinstance(value, RandomVariable) or \
+     isinstance(value, tf.Variable) or \
+     isinstance(value, tf.Tensor) or \
+     isinstance(value, tf.Operation):
+      value = copy(value, dict_swap, scope, replace_itself, copy_q)
+  return value
 
 
 def copy(org_instance, dict_swap=None, scope="copied",
@@ -163,10 +164,11 @@ def copy(org_instance, dict_swap=None, scope="copied",
     kwargs = {}
     for key, value in six.iteritems(rv._kwargs):
       if isinstance(value, list):
-          kwargs[key] = [copy_rv(v, dict_swap, scope, True, copy_q) for v in value]
+        kwargs[key] = [
+            copy_rv(v, dict_swap, scope, True, copy_q) for v in value
+        ]
       else:
-          kwargs[key] = copy_rv(value, dict_swap, scope, True, copy_q)
-
+        kwargs[key] = copy_rv(value, dict_swap, scope, True, copy_q)
 
     kwargs['name'] = new_name
     # Create new random variable with copied arguments.


### PR DESCRIPTION
edward.util.copy() fails to properly replace ancestors of the Mixture random variable. The components of a Mixture appear in a list of random variables which edward.util.copy() does not recognize as instances of the RandomVariable type.

This fix covers this case, but only for a list and only one level of nesting allowed. 

Also included is the addition of a var_list argument  to Map.build_loss_and_gradients() so that mixture examples can be tested with MAP inference, but this is not directly related to the copy() problem.