### PR TITLE
Rasch model

### DIFF
--- a/examples/rasch_model.py
+++ b/examples/rasch_model.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+"""Rasch model (Rasch, 1960) using variational inference."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import edward as ed
+import matplotlib.pyplot as plt
+import numpy as np
+import tensorflow as tf
+
+from edward.models import Bernoulli, Normal
+from scipy.special import expit
+
+# DATA
+nsubj = 200
+nitem = 25
+trait_true = np.random.normal(size=[nsubj, 1])
+thresh_true = np.random.normal(size=[1, nitem])
+X_data = np.random.binomial(1, expit(trait_true - thresh_true))
+
+# MODEL
+trait = Normal(mu=tf.zeros([nsubj, 1]), sigma=tf.ones([nsubj, 1]))
+thresh = Normal(mu=tf.zeros([1, nitem]), sigma=tf.ones([1, nitem]))
+X = Bernoulli(logits=tf.sub(trait, thresh))
+
+# INFERENCE
+q_trait = Normal(
+    mu=tf.Variable(tf.random_normal([nsubj, 1])),
+    sigma=tf.nn.softplus(tf.Variable(tf.random_normal([nsubj, 1]))))
+q_thresh = Normal(
+    mu=tf.Variable(tf.random_normal([1, nitem])),
+    sigma=tf.nn.softplus(tf.Variable(tf.random_normal([1, nitem]))))
+
+inference = ed.KLqp({trait: q_trait, thresh: q_thresh},
+                    data={X: X_data})
+inference.run(n_iter=2500, n_samples=10)
+
+# CRITICISM
+# Check that the approximate posterior mean captures the true traits.
+plt.scatter(trait_true, q_trait.mean().eval())
+plt.show()
+
+print("MSE between true traits and inferred posterior mean:")
+print(np.mean(np.square(trait_true - q_trait.mean().eval())))


### PR DESCRIPTION
A simple implementation of the Rasch model in item response theory. (also see #346)

```
python rasch_model.py
## Iteration    1 [  0%]: Loss = 5476.080
## Iteration  250 [ 10%]: Loss = 3062.469
## Iteration  500 [ 20%]: Loss = 3072.561
## Iteration  750 [ 30%]: Loss = 3062.746
## Iteration 1000 [ 40%]: Loss = 3062.882
## Iteration 1250 [ 50%]: Loss = 3058.824
## Iteration 1500 [ 60%]: Loss = 3067.787
## Iteration 1750 [ 70%]: Loss = 3061.325
## Iteration 2000 [ 80%]: Loss = 3060.995
## Iteration 2250 [ 90%]: Loss = 3060.363
## Iteration 2500 [100%]: Loss = 3063.963
## MSE between true traits and inferred posterior mean:
## 0.202594817092
```
Plot of the true traits by the inferred posterior means.
<img width="752" alt="screen shot 2017-01-17 at 2 06 56 pm" src="https://cloud.githubusercontent.com/assets/2569867/22035725/0c00b1f4-dcbf-11e6-9d9b-6509b3af23c5.png">


### Reviewer suggestions:

Would love it if you took a look @mdzeig. Otherwise I'll just merge it.