### PR TITLE
Eliminated redundant computation in repeated calls to leapfrog() function

### DIFF
--- a/edward/inferences/hmc.py
+++ b/edward/inferences/hmc.py
@@ -76,9 +76,9 @@ class HMC(MonteCarlo):
     # Simulate Hamiltonian dynamics.
     new_sample = old_sample
     new_r_sample = old_r_sample
-    for _ in range(self.n_steps):
-      new_sample, new_r_sample = leapfrog(new_sample, new_r_sample,
-                                          self.step_size, self._log_joint)
+    new_sample, new_r_sample = leapfrog(new_sample, new_r_sample,
+                                        self.step_size, self._log_joint,
+                                        self.n_steps)
 
     # Calculate acceptance ratio.
     ratio = tf.reduce_sum([0.5 * tf.reduce_sum(tf.square(r))
@@ -152,18 +152,23 @@ class HMC(MonteCarlo):
     return log_joint
 
 
-def leapfrog(z_old, r_old, step_size, log_joint):
+def leapfrog(z_old, r_old, step_size, log_joint, n_steps):
   z_new = {}
   r_new = {}
 
-  grad_log_joint = tf.gradients(log_joint(z_old), list(six.itervalues(z_old)))
-  for i, key in enumerate(six.iterkeys(z_old)):
-    z, r = z_old[key], r_old[key]
-    r_new[key] = r + 0.5 * step_size * grad_log_joint[i]
-    z_new[key] = z + step_size * r_new[key]
+  for key in z_old:
+    z_new[key] = z_old[key]
+    r_new[key] = r_old[key]
 
-  grad_log_joint = tf.gradients(log_joint(z_new), list(six.itervalues(z_new)))
-  for i, key in enumerate(six.iterkeys(z_old)):
-    r_new[key] += 0.5 * step_size * grad_log_joint[i]
+  grad_log_joint = tf.gradients(log_joint(z_old), list(six.itervalues(z_old)))
+  for n in range(n_steps):
+    for i, key in enumerate(six.iterkeys(z_new)):
+      z, r = z_new[key], r_new[key]
+      r_new[key] = r + 0.5 * step_size * grad_log_joint[i]
+      z_new[key] = z + step_size * r_new[key]
+
+    grad_log_joint = tf.gradients(log_joint(z_new), list(six.itervalues(z_new)))
+    for i, key in enumerate(six.iterkeys(z_new)):
+      r_new[key] += 0.5 * step_size * grad_log_joint[i]
 
   return z_new, r_new

--- a/edward/inferences/hmc.py
+++ b/edward/inferences/hmc.py
@@ -74,9 +74,7 @@ class HMC(MonteCarlo):
       old_r_sample[z] = normal.sample()
 
     # Simulate Hamiltonian dynamics.
-    new_sample = old_sample
-    new_r_sample = old_r_sample
-    new_sample, new_r_sample = leapfrog(new_sample, new_r_sample,
+    new_sample, new_r_sample = leapfrog(old_sample, old_r_sample,
                                         self.step_size, self._log_joint,
                                         self.n_steps)
 
@@ -153,15 +151,11 @@ class HMC(MonteCarlo):
 
 
 def leapfrog(z_old, r_old, step_size, log_joint, n_steps):
-  z_new = {}
-  r_new = {}
+  z_new = z_old.copy()
+  r_new = r_old.copy()
 
-  for key in z_old:
-    z_new[key] = z_old[key]
-    r_new[key] = r_old[key]
-
-  grad_log_joint = tf.gradients(log_joint(z_old), list(six.itervalues(z_old)))
-  for n in range(n_steps):
+  grad_log_joint = tf.gradients(log_joint(z_new), list(six.itervalues(z_new)))
+  for _ in range(n_steps):
     for i, key in enumerate(six.iterkeys(z_new)):
       z, r = z_new[key], r_new[key]
       r_new[key] = r + 0.5 * step_size * grad_log_joint[i]


### PR DESCRIPTION
In the old code, each call to `leapfrog()` computed the gradient twice with respect to latent variables that hadn't changed. This patch eliminates that duplicated computation, resulting in a near 2x speedup.

It works by adding an `n_steps` parameter to `leapfrog()` and moving the loop into the `leapfrog()` function.