### PR TITLE
Fix type error in initializing TensorFlow computation graph for inference.

### DIFF
--- a/edward/inferences/inference.py
+++ b/edward/inferences/inference.py
@@ -132,8 +132,15 @@ class Inference(object):
               raise TypeError("Observed variable bindings do not have same "
                               "shape.")
 
-            # If value is a np.ndarray, store it in the graph.
-            ph = tf.placeholder(tf.float32, value.shape)
+            # If value is a np.ndarray, store it in the graph. Assign its
+            # placeholder to an appropriate data type.
+            if np.issubdtype(value.dtype, np.float):
+              ph_type = tf.float32
+            elif np.issubdtype(value.dtype, np.int):
+              ph_type = tf.int32
+            else:
+              raise TypeError("Data value has an unsupported type.")
+            ph = tf.placeholder(ph_type, value.shape)
             var = tf.Variable(ph, trainable=False, collections=[])
             self.data[key] = var
             sess.run(var.initializer, {ph: value})

--- a/tests/test-inferences/test_bayesian_nn.py
+++ b/tests/test-inferences/test_bayesian_nn.py
@@ -20,6 +20,7 @@ def four_layer_nn(x, W_1, W_2, W_3, b_1, b_2):
 class test_inference_bayesian_nn_class(tf.test.TestCase):
 
   def test_monte_carlo(self):
+    tf.InteractiveSession()
     ed.set_seed(42)
 
     # DATA

--- a/tests/test-inferences/test_integer_variables.py
+++ b/tests/test-inferences/test_integer_variables.py
@@ -1,0 +1,50 @@
+"""Test that integer variables are handled properly during initialization."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import edward as ed
+import numpy as np
+import tensorflow as tf
+
+from edward.models import Normal, Categorical
+
+
+def neural_network(x, W_0, W_1, b_0, b_1):
+  h = tf.tanh(tf.matmul(x, W_0) + b_0)
+  h = tf.tanh(tf.matmul(h, W_1) + b_1)
+  return h
+
+
+class test_integer_init(tf.test.TestCase):
+
+  def test_integer(self):
+    X_train = np.zeros([100, 10]).astype(np.float32)
+    y_train = np.zeros(100).astype(np.int32)
+    N, D = X_train.shape
+    n_hidden = 10
+    K = 10
+    W_0 = Normal(mu=tf.zeros([D, n_hidden]), sigma=tf.ones([D, n_hidden]))
+    W_1 = Normal(mu=tf.zeros([n_hidden, K]), sigma=tf.ones([n_hidden, K]))
+    b_0 = Normal(mu=tf.zeros(n_hidden), sigma=tf.ones(n_hidden))
+    b_1 = Normal(mu=tf.zeros(K), sigma=tf.ones(K))
+
+    y = Categorical(logits=neural_network(X_train, W_0, W_1, b_0, b_1))
+
+    softplus = tf.nn.softplus
+    qW_0 = Normal(mu=tf.Variable(tf.random_normal([D, n_hidden])),
+                  sigma=softplus(tf.Variable(tf.random_normal([D, n_hidden]))))
+    qW_1 = Normal(mu=tf.Variable(tf.random_normal([n_hidden, K])),
+                  sigma=softplus(tf.Variable(tf.random_normal([n_hidden, K]))))
+    qb_0 = Normal(mu=tf.Variable(tf.random_normal([n_hidden])),
+                  sigma=softplus(tf.Variable(tf.random_normal([n_hidden]))))
+    qb_1 = Normal(mu=tf.Variable(tf.random_normal([K])),
+                  sigma=softplus(tf.Variable(tf.random_normal([K]))))
+    inference = ed.KLqp({W_0: qW_0, b_0: qb_0, W_1: qW_1, b_1: qb_1},
+                        data={y: y_train})
+    inference.run()
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tests/test-inferences/test_integer_variables.py
+++ b/tests/test-inferences/test_integer_variables.py
@@ -20,6 +20,7 @@ def neural_network(x, W_0, W_1, b_0, b_1):
 class test_integer_init(tf.test.TestCase):
 
   def test_integer(self):
+    tf.InteractiveSession()     # Eliminates graph dependencies between tests.
     X_train = np.zeros([100, 10]).astype(np.float32)
     y_train = np.zeros(100).astype(np.int32)
     N, D = X_train.shape


### PR DESCRIPTION
@nfoti and I discovered a bug when doing inference in a neural net with a softmax final layer (e.g. for multiclass classification). This PR fixes it.