### PR TITLE
Require TensorFlow 1.0.0rc0 instead of 1.0.0a0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author_email="dustin@cs.columbia.edu",
     packages=['edward', 'edward.criticisms', 'edward.inferences',
               'edward.models', 'edward.stats', 'edward.util'],
-    install_requires=['tensorflow>=1.0.0a0',
+    install_requires=['tensorflow>=1.0.0rc0',
                       'numpy>=1.7',
                       'six>=1.10.0'],
     extras_require={'stan': ['pystan>=2.0.1.3'],


### PR DESCRIPTION
**EDIT:**  
~~While installing Edward via setup.py/pip on Windows is fine. On Linux, pip complains that TensorFlow 1.0.0rc0 isn't compatible with 1.0.0a0~~