### PR TITLE
add operator overloading to RandomVariable

### DIFF
--- a/edward/models/random_variable.py
+++ b/edward/models/random_variable.py
@@ -88,6 +88,97 @@ class RandomVariable(object):
   def __repr__(self):
     return self.__str__()
 
+  def __add__(self, other):
+    return tf.add(self, other)
+
+  def __radd__(self, other):
+    return tf.add(other, self)
+
+  def __sub__(self, other):
+    return tf.subtract(self, other)
+
+  def __rsub__(self, other):
+    return tf.subtract(other, self)
+
+  def __mul__(self, other):
+    return tf.multiply(self, other)
+
+  def __rmul__(self, other):
+    return tf.multiply(other, self)
+
+  def __div__(self, other):
+    return tf.div(self, other)
+
+  __truediv__ = __div__
+
+  def __rdiv__(self, other):
+    return tf.div(other, self)
+
+  __rtruediv__ = __rdiv__
+
+  def __floordiv__(self, other):
+    return tf.floor(tf.div(self, other))
+
+  def __rfloordiv__(self, other):
+    return tf.floor(tf.div(other, self))
+
+  def __mod__(self, other):
+    return tf.mod(self, other)
+
+  def __rmod__(self, other):
+    return tf.mod(other, self)
+
+  def __lt__(self, other):
+    return tf.less(self, other)
+
+  def __le__(self, other):
+    return tf.less_equal(self, other)
+
+  def __gt__(self, other):
+    return tf.greater(self, other)
+
+  def __ge__(self, other):
+    return tf.greater_equal(self, other)
+
+  def __and__(self, other):
+    return tf.logical_and(self, other)
+
+  def __rand__(self, other):
+    return tf.logical_and(other, self)
+
+  def __or__(self, other):
+    return tf.logical_or(self, other)
+
+  def __ror__(self, other):
+    return tf.logical_or(other, self)
+
+  def __xor__(self, other):
+    return tf.logical_xor(self, other)
+
+  def __rxor__(self, other):
+    return tf.logical_xor(other, self)
+
+  def __pow__(self, other):
+    return tf.pow(self, other)
+
+  def __rpow__(self, other):
+    return tf.pow(other, self)
+
+  def __invert__(self):
+    return tf.logical_not(self)
+
+  def __neg__(self):
+    return tf.negative(self)
+
+  def __abs__(self):
+    return tf.abs(self)
+
+  def __hash__(self):
+    return id(self)
+
+  def __eq__(self, other):
+    return id(self) == id(other)
+
   def value(self):
     """Get tensor that the random variable corresponds to."""
     return self._value

--- a/tests/test-models/test_random_variable_operators.py
+++ b/tests/test-models/test_random_variable_operators.py
@@ -1,0 +1,223 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import edward as ed
+import numpy as np
+import tensorflow as tf
+
+from edward.models import Normal
+
+
+class test_random_variable_operators_class(tf.test.TestCase):
+
+  def test_add(self):
+    with self.test_session() as sess:
+      x = Normal(mu=0.0, sigma=1.0)
+      y = 5.0
+      z = x + y
+      z_value = x.value() + y
+      z_eval, z_value_eval = sess.run([z, z_value])
+      assert np.allclose(z_eval, z_value_eval)
+
+  def test_radd(self):
+    with self.test_session() as sess:
+      x = Normal(mu=0.0, sigma=1.0)
+      y = 5.0
+      z = y + x
+      z_value = y + x.value()
+      z_eval, z_value_eval = sess.run([z, z_value])
+      assert np.allclose(z_eval, z_value_eval)
+
+  def test_sub(self):
+    with self.test_session() as sess:
+      x = Normal(mu=0.0, sigma=1.0)
+      y = 5.0
+      z = x - y
+      z_value = x.value() - y
+      z_eval, z_value_eval = sess.run([z, z_value])
+      assert np.allclose(z_eval, z_value_eval)
+
+  def test_rsub(self):
+    with self.test_session() as sess:
+      x = Normal(mu=0.0, sigma=1.0)
+      y = 5.0
+      z = y - x
+      z_value = y - x.value()
+      z_eval, z_value_eval = sess.run([z, z_value])
+      assert np.allclose(z_eval, z_value_eval)
+
+  def test_mul(self):
+    with self.test_session() as sess:
+      x = Normal(mu=0.0, sigma=1.0)
+      y = 5.0
+      z = x * y
+      z_value = x.value() * y
+      z_eval, z_value_eval = sess.run([z, z_value])
+      assert np.allclose(z_eval, z_value_eval)
+
+  def test_rmul(self):
+    with self.test_session() as sess:
+      x = Normal(mu=0.0, sigma=1.0)
+      y = 5.0
+      z = y * x
+      z_value = y * x.value()
+      z_eval, z_value_eval = sess.run([z, z_value])
+      assert np.allclose(z_eval, z_value_eval)
+
+  def test_div(self):
+    with self.test_session() as sess:
+      x = Normal(mu=0.0, sigma=1.0)
+      y = 5.0
+      z = x / y
+      z_value = x.value() / y
+      z_eval, z_value_eval = sess.run([z, z_value])
+      assert np.allclose(z_eval, z_value_eval)
+
+  def test_rdiv(self):
+    with self.test_session() as sess:
+      x = Normal(mu=0.0, sigma=1.0)
+      y = 5.0
+      z = y / x
+      z_value = y / x.value()
+      z_eval, z_value_eval = sess.run([z, z_value])
+      assert np.allclose(z_eval, z_value_eval)
+
+  def test_floordiv(self):
+    with self.test_session() as sess:
+      x = Normal(mu=0.0, sigma=1.0)
+      y = 5.0
+      z = x // y
+      z_value = x.value() // y
+      z_eval, z_value_eval = sess.run([z, z_value])
+      assert np.allclose(z_eval, z_value_eval)
+
+  def test_rfloordiv(self):
+    with self.test_session() as sess:
+      x = Normal(mu=0.0, sigma=1.0)
+      y = 5.0
+      z = y // x
+      z_value = y // x.value()
+      z_eval, z_value_eval = sess.run([z, z_value])
+      assert np.allclose(z_eval, z_value_eval)
+
+  def test_mod(self):
+    with self.test_session() as sess:
+      x = Normal(mu=0.0, sigma=1.0)
+      y = 5.0
+      z = x % y
+      z_value = x.value() % y
+      z_eval, z_value_eval = sess.run([z, z_value])
+      assert np.allclose(z_eval, z_value_eval)
+
+  def test_rmod(self):
+    with self.test_session() as sess:
+      x = Normal(mu=0.0, sigma=1.0)
+      y = 5.0
+      z = y % x
+      z_value = y % x.value()
+      z_eval, z_value_eval = sess.run([z, z_value])
+      assert np.allclose(z_eval, z_value_eval)
+
+  def test_lt(self):
+    with self.test_session() as sess:
+      x = Normal(mu=0.0, sigma=1.0)
+      y = 5.0
+      z = x < y
+      z_value = x.value() < y
+      z_eval, z_value_eval = sess.run([z, z_value])
+      assert np.allclose(z_eval, z_value_eval)
+
+  def test_le(self):
+    with self.test_session() as sess:
+      x = Normal(mu=0.0, sigma=1.0)
+      y = 5.0
+      z = x <= y
+      z_value = x.value() <= y
+      z_eval, z_value_eval = sess.run([z, z_value])
+      assert np.allclose(z_eval, z_value_eval)
+
+  def test_gt(self):
+    with self.test_session() as sess:
+      x = Normal(mu=0.0, sigma=1.0)
+      y = 5.0
+      z = x > y
+      z_value = x.value() > y
+      z_eval, z_value_eval = sess.run([z, z_value])
+      assert np.allclose(z_eval, z_value_eval)
+
+  def test_ge(self):
+    with self.test_session() as sess:
+      x = Normal(mu=0.0, sigma=1.0)
+      y = 5.0
+      z = x >= y
+      z_value = x.value() >= y
+      z_eval, z_value_eval = sess.run([z, z_value])
+      assert np.allclose(z_eval, z_value_eval)
+
+    # need to test with a random variable of boolean
+  # def test_and(self):
+  #   with self.test_session() as sess:
+      # x = tf.cast(Bernoulli(p=0.5), tf.bool)
+      # y = True
+      # z = x & y
+      # z_value = x.value() & y
+      # z_eval, z_value_eval = sess.run([z, z_value])
+      # assert np.allclose(z_eval, z_value_eval)
+
+  # def test_rand(self):
+  # def test_or(self):
+  # def test_ror(self):
+  # def test_xor(self):
+  # def test_rxor(self):
+
+  def test_pow(self):
+    with self.test_session() as sess:
+      x = Normal(mu=0.0, sigma=1.0)
+      y = 5.0
+      z = x ** y
+      z_value = x.value() ** y
+      z_eval, z_value_eval = sess.run([z, z_value])
+      assert np.allclose(z_eval, z_value_eval)
+
+  def test_rpow(self):
+    with self.test_session() as sess:
+      x = Normal(mu=0.0, sigma=1.0)
+      y = 5.0
+      z = y ** x
+      z_value = y ** x.value()
+      z_eval, z_value_eval = sess.run([z, z_value])
+      assert np.allclose(z_eval, z_value_eval)
+
+  # def test_invert(self):
+
+  def test_neg(self):
+    with self.test_session() as sess:
+      x = Normal(mu=0.0, sigma=1.0)
+      z = -x
+      z_value = -x.value()
+      z_eval, z_value_eval = sess.run([z, z_value])
+      assert np.allclose(z_eval, z_value_eval)
+
+  def test_abs(self):
+    with self.test_session() as sess:
+      x = Normal(mu=0.0, sigma=1.0)
+      z = abs(x)
+      z_value = abs(x.value())
+      z_eval, z_value_eval = sess.run([z, z_value])
+      assert np.allclose(z_eval, z_value_eval)
+
+  def test_hash(self):
+    x = Normal(mu=0.0, sigma=1.0)
+    y = 5.0
+    assert not hash(x) == hash(y)
+    assert hash(x) == id(x)
+
+  def test_eq(self):
+    x = Normal(mu=0.0, sigma=1.0)
+    y = 5.0
+    assert not x == y
+    assert x == x
+
+if __name__ == '__main__':
+  tf.test.main()


### PR DESCRIPTION
Many operators are overloaded for RandomVariable, following those available in [`tf.Tensor`](https://github.com/tensorflow/tensorflow/blob/r1.0/tensorflow/python/framework/ops.py#L250). The output is always a `tf.Tensor`. It operates on the sample tensor associated to the RandomVariable.

For example, this lets us do
```python
from edward.models import Normal

x = Normal(mu=0.0, sigma=1.0)
y = Normal(mu=0.0, sigma=1.0)

x + y, x * y, x / y, x // y
x == y
hash(x)
-x
x ** y
````

Remarks
+ An open question is what to do with the `__getitem__` method. That is, should we also return indexing from the sample tensor? Or should `__getitem__` be the only method that returns a subset of the random variable? (If so, how do we do so efficiently?)
+ Should `eval()` be a method? E.g., calling `x.eval()` would be easier than `x.value().eval()` which is almost always what the user intended. I think it should only be a method if we can also do `sess.run(x)` somehow, and not require `sess.run(x.value())`.

todo
+ [x] unit test