### PR TITLE
Wasserstein GAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It supports __modeling__ with
 + Neural networks (via libraries such as
     [Keras](http://keras.io) and [TensorFlow
     Slim](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/slim))
-+ Conditionally specified undirected models
++ Intractable likelihoods
 + Bayesian nonparametrics and probabilistic programs
 
 It supports __inference__ with
@@ -25,7 +25,7 @@ It supports __inference__ with
 + Variational inference
   + Black box variational inference
   + Stochastic variational inference
-  + Inclusive KL divergence: KL(p||q)
+  + Generative adversarial networks
   + Maximum a posteriori estimation
 + Monte Carlo
   + Hamiltonian Monte Carlo

--- a/docs/tex/api/inference-classes.tex
+++ b/docs/tex/api/inference-classes.tex
@@ -158,6 +158,9 @@ details.
 .. autoclass:: edward.inferences.GANInference
    :members:
 
+.. autoclass:: edward.inferences.WGANInference
+   :members:
+
 .. autoclass:: edward.inferences.KLpq
    :members:
 

--- a/docs/tex/index.tex
+++ b/docs/tex/index.tex
@@ -17,7 +17,7 @@ It supports \textbf{modeling} with
   \href{http://keras.io}{Keras} and
   \href{https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/slim}{TensorFlow
   Slim})
-\item Conditionally specified undirected models
+\item Intractable likelihoods
 \item Bayesian nonparametrics and probabilistic programs
 \end{itemize}
 
@@ -28,7 +28,7 @@ It supports \textbf{inference} with
   \begin{itemize}
     \item Black box variational inference
     \item Stochastic variational inference
-    \item Inclusive KL divergence: $\text{KL}(p\|q)$
+    \item Generative adversarial networks
     \item Maximum a posteriori estimation
   \end{itemize}
 \item Monte Carlo

--- a/edward/__init__.py
+++ b/edward/__init__.py
@@ -16,7 +16,7 @@ from edward.inferences import Inference, MonteCarlo, VariationalInference, \
     HMC, MetropolisHastings, SGLD, SGHMC, \
     KLpq, KLqp, MFVI, ReparameterizationKLqp, ReparameterizationKLKLqp, \
     ReparameterizationEntropyKLqp, ScoreKLqp, ScoreKLKLqp, ScoreEntropyKLqp, \
-    GANInference, MAP, Laplace
+    GANInference, WGANInference, MAP, Laplace
 from edward.models import PyMC3Model, PythonModel, StanModel, \
     RandomVariable
 from edward.util import copy, dot, get_ancestors, get_children, \

--- a/edward/inferences/__init__.py
+++ b/edward/inferences/__init__.py
@@ -13,3 +13,4 @@ from edward.inferences.monte_carlo import *
 from edward.inferences.sgld import *
 from edward.inferences.sghmc import *
 from edward.inferences.variational_inference import *
+from edward.inferences.wgan_inference import *

--- a/edward/inferences/gan_inference.py
+++ b/edward/inferences/gan_inference.py
@@ -93,11 +93,10 @@ class GANInference(VariationalInference):
     optimizer, global_step = _build_optimizer(optimizer, global_step)
     optimizer_d, global_step_d = _build_optimizer(optimizer_d, global_step_d)
 
-    train = optimizer.apply_gradients(grads_and_vars,
-                                      global_step=global_step)
-    train_d = optimizer_d.apply_gradients(grads_and_vars_d,
-                                          global_step=global_step_d)
-    self.train = tf.group(*[train, train_d])
+    self.train = optimizer.apply_gradients(grads_and_vars,
+                                           global_step=global_step)
+    self.train_d = optimizer_d.apply_gradients(grads_and_vars_d,
+                                               global_step=global_step_d)
 
   def build_loss_and_gradients(self, var_list):
     x_true = list(six.itervalues(self.data))[0]
@@ -131,20 +130,29 @@ class GANInference(VariationalInference):
     grads_and_vars_g = list(zip(grads_g, var_list_g))
     return loss_g, grads_and_vars_g, loss_d, grads_and_vars_d
 
-  def update(self, feed_dict=None):
-    """Run one iteration of optimizer for variational inference.
+  def update(self, feed_dict=None, variables=None):
+    """Run one iteration of optimization.
 
     Parameters
     ----------
     feed_dict : dict, optional
       Feed dictionary for a TensorFlow session run. It is used to feed
       placeholders that are not fed during initialization.
+    variables : str, optional
+      Which set of variables to optimize. Either "Disc" or "Gen".
+      Default is both.
 
     Returns
     -------
     dict
       Dictionary of algorithm-specific information. In this case, the
-      loss function value after one iteration.
+      iteration number and generative and discriminative losses.
+
+    Notes
+    -----
+    The outputted iteration number is the total number of calls to
+    ``update``. Each update may include updating only a subset of
+    parameters.
     """
     if feed_dict is None:
       feed_dict = {}
@@ -155,8 +163,20 @@ class GANInference(VariationalInference):
           feed_dict[key] = value
 
     sess = get_session()
-    _, t, loss, loss_d = sess.run(
-        [self.train, self.increment_t, self.loss, self.loss_d], feed_dict)
+    if variables is None:
+      _, _, t, loss, loss_d = sess.run(
+          [self.train, self.train_d, self.increment_t, self.loss, self.loss_d],
+          feed_dict)
+    elif variables == "Gen":
+      _, t, loss = sess.run(
+          [self.train, self.increment_t, self.loss], feed_dict)
+      loss_d = 0.0
+    elif variables == "Disc":
+      _, t, loss_d = sess.run(
+          [self.train_d, self.increment_t, self.loss_d], feed_dict)
+      loss = 0.0
+    else:
+      raise NotImplementedError()
 
     if self.debug:
       sess.run(self.op_check)

--- a/edward/inferences/gan_inference.py
+++ b/edward/inferences/gan_inference.py
@@ -103,17 +103,17 @@ class GANInference(VariationalInference):
     x_true = list(six.itervalues(self.data))[0]
     x_fake = list(six.iterkeys(self.data))[0]
     with tf.variable_scope("Disc"):
-      logits_true = self.discriminator(x_true)
+      d_true = self.discriminator(x_true)
 
     with tf.variable_scope("Disc", reuse=True):
-      logits_fake = self.discriminator(x_fake)
+      d_fake = self.discriminator(x_fake)
 
     loss_d = tf.nn.sigmoid_cross_entropy_with_logits(
-        labels=tf.ones_like(logits_true), logits=logits_true) + \
+        labels=tf.ones_like(d_true), logits=d_true) + \
         tf.nn.sigmoid_cross_entropy_with_logits(
-            labels=tf.zeros_like(logits_fake), logits=logits_fake)
+            labels=tf.zeros_like(d_fake), logits=d_fake)
     loss_g = tf.nn.sigmoid_cross_entropy_with_logits(
-        labels=tf.ones_like(logits_fake), logits=logits_fake)
+        labels=tf.ones_like(d_fake), logits=d_fake)
     loss_d = tf.reduce_mean(loss_d)
     loss_g = tf.reduce_mean(loss_g)
 

--- a/edward/inferences/wgan_inference.py
+++ b/edward/inferences/wgan_inference.py
@@ -47,7 +47,7 @@ class WGANInference(GANInference):
 
     clip_d = [w.assign(tf.clip_by_value(w, -0.01, 0.01))
               for w in var_list_d]
-    self.train = tf.group(*[self.train, clip_d])
+    self.train_d = tf.group(*([self.train_d] + clip_d))
 
   def build_loss_and_gradients(self, var_list):
     x_true = list(six.itervalues(self.data))[0]

--- a/edward/inferences/wgan_inference.py
+++ b/edward/inferences/wgan_inference.py
@@ -1,0 +1,78 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import six
+import tensorflow as tf
+
+from edward.inferences.gan_inference import GANInference
+from edward.util import get_session
+
+
+class WGANInference(GANInference):
+  """Parameter estimation with GAN-style training (Goodfellow et al.,
+  2014), using the Wasserstein distance (Arjovsky et al., 2017).
+
+  Works for the class of implicit (and differentiable) probabilistic
+  models. These models do not require a tractable density and assume
+  only a program that generates samples.
+  """
+  def __init__(self, *args, **kwargs):
+    """
+    Examples
+    --------
+    >>> z = Normal(mu=tf.zeros([100, 10]), sigma=tf.ones([100, 10]))
+    >>> x = generative_network(z)
+    >>>
+    >>> inference = ed.WGANInference({x: x_data}, discriminator)
+
+    Notes
+    -----
+    The only difference in arguments from ``GANInference`` is
+    conceptual: the ``discriminator`` argument is technically better
+    described as a test function from statistics. ``WGANInference``
+    continues to use ``discriminator`` only to share methods and
+    attributes with ``GANInference``.
+    """
+    super(WGANInference, self).__init__(*args, **kwargs)
+
+  def initialize(self, *args, **kwargs):
+    super(WGANInference, self).initialize(*args, **kwargs)
+
+    var_list = kwargs.get('var_list', None)
+    var_list_d = tf.get_collection(
+        tf.GraphKeys.TRAINABLE_VARIABLES, scope="Disc")
+    if var_list is not None:
+      var_list_d = list(set(var_list_d) & set(var_list))
+
+    clip_d = [w.assign(tf.clip_by_value(w, -0.01, 0.01))
+              for w in var_list_d]
+    self.train = tf.group(*[self.train, clip_d])
+
+  def build_loss_and_gradients(self, var_list):
+    x_true = list(six.itervalues(self.data))[0]
+    x_fake = list(six.iterkeys(self.data))[0]
+    with tf.variable_scope("Disc"):
+      d_true = self.discriminator(x_true)
+
+    with tf.variable_scope("Disc", reuse=True):
+      d_fake = self.discriminator(x_fake)
+
+    mean_true = tf.reduce_mean(d_true)
+    mean_fake = tf.reduce_mean(d_fake)
+    loss_d = -mean_true + mean_fake
+    loss_g = -mean_fake
+
+    var_list_d = tf.get_collection(
+        tf.GraphKeys.TRAINABLE_VARIABLES, scope="Disc")
+    var_list_g = tf.get_collection(
+        tf.GraphKeys.TRAINABLE_VARIABLES, scope="Gen")
+    if var_list is not None:
+      var_list_d = list(set(var_list_d) & set(var_list))
+      var_list_g = list(set(var_list_g) & set(var_list))
+
+    grads_d = tf.gradients(loss_d, var_list_d)
+    grads_g = tf.gradients(loss_g, var_list_g)
+    grads_and_vars_d = list(zip(grads_d, var_list_d))
+    grads_and_vars_g = list(zip(grads_g, var_list_g))
+    return loss_g, grads_and_vars_g, loss_d, grads_and_vars_d

--- a/examples/gan_wasserstein.py
+++ b/examples/gan_wasserstein.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+"""Wasserstein generative adversarial network for MNIST (Arjovsky et
+al., 2017). It modifies GANs (Goodfellow et al., 2014) to optimize
+under the Wasserstein distance.
+"""
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+
+import edward as ed
+import matplotlib.pyplot as plt
+import matplotlib.gridspec as gridspec
+import numpy as np
+import os
+import tensorflow as tf
+
+from edward.models import Uniform
+from tensorflow.contrib import slim
+from tensorflow.examples.tutorials.mnist import input_data
+
+
+def generative_network(z):
+  h1 = slim.fully_connected(z, 128, activation_fn=tf.nn.relu)
+  x = slim.fully_connected(h1, 784, activation_fn=tf.sigmoid)
+  return x
+
+
+def discriminative_network(x):
+  """Outputs probability in logits."""
+  h1 = slim.fully_connected(x, 128, activation_fn=tf.nn.relu)
+  logit = slim.fully_connected(h1, 1, activation_fn=None)
+  return logit
+
+
+def plot(samples):
+  fig = plt.figure(figsize=(4, 4))
+  gs = gridspec.GridSpec(4, 4)
+  gs.update(wspace=0.05, hspace=0.05)
+
+  for i, sample in enumerate(samples):
+    ax = plt.subplot(gs[i])
+    plt.axis('off')
+    ax.set_xticklabels([])
+    ax.set_yticklabels([])
+    ax.set_aspect('equal')
+    plt.imshow(sample.reshape(28, 28), cmap='Greys_r')
+
+  return fig
+
+
+ed.set_seed(42)
+
+M = 128  # batch size during training
+d = 10  # latent dimension
+
+DATA_DIR = "data/mnist"
+IMG_DIR = "img"
+
+if not os.path.exists(DATA_DIR):
+  os.makedirs(DATA_DIR)
+if not os.path.exists(IMG_DIR):
+  os.makedirs(IMG_DIR)
+
+# DATA. MNIST batches are fed at training time.
+mnist = input_data.read_data_sets(DATA_DIR, one_hot=True)
+x_ph = tf.placeholder(tf.float32, [M, 784])
+
+# MODEL
+with tf.variable_scope("Gen"):
+  z = Uniform(a=tf.zeros([M, d]) - 1.0, b=tf.ones([M, d]))
+  x = generative_network(z)
+
+# INFERENCE
+optimizer = tf.train.RMSPropOptimizer(learning_rate=5e-5)
+optimizer_d = tf.train.RMSPropOptimizer(learning_rate=5e-5)
+
+inference = ed.WGANInference(
+    data={x: x_ph}, discriminator=discriminative_network)
+inference.initialize(
+    optimizer=optimizer, optimizer_d=optimizer,
+    n_iter=15000 * 6, n_print=1000 * 6)
+
+sess = ed.get_session()
+tf.global_variables_initializer().run()
+
+idx = np.random.randint(M, size=16)
+i = 0
+for t in range(inference.n_iter):
+  if (t * 6) % inference.n_print == 0:
+    samples = sess.run(x)
+    samples = samples[idx, ]
+
+    fig = plot(samples)
+    plt.savefig(os.path.join(IMG_DIR, '{}.png').format(
+        str(i).zfill(3)), bbox_inches='tight')
+    plt.close(fig)
+    i += 1
+
+  x_batch, _ = mnist.train.next_batch(M)
+  for _ in range(5):
+    inference.update(feed_dict={x_ph: x_batch}, variables="Disc")
+
+  info_dict = inference.update(feed_dict={x_ph: x_batch}, variables="Gen")
+  # note: not printing discriminative objective
+  inference.print_progress(info_dict)

--- a/tests/test-inferences/test_bayesian_nn.py
+++ b/tests/test-inferences/test_bayesian_nn.py
@@ -57,6 +57,22 @@ class test_inference_bayesian_nn_class(tf.test.TestCase):
         discriminator=discriminator)
     inference.run(n_iter=1)
 
+  def test_wgan_inference(self):
+    N, D, W_1, W_2, W_3, b_1, b_2, x_ph, y, X_train, y_train = self._test()
+
+    with tf.variable_scope("Gen"):
+      theta = tf.get_variable("theta", [1])
+      y = tf.cast(y, tf.float32) * theta
+
+    def discriminator(x):
+      w = tf.get_variable("w", [1])
+      return w * tf.cast(x, tf.float32)
+
+    inference = ed.WGANInference(
+        data={y: tf.cast(y_train, tf.float32), x_ph: X_train},
+        discriminator=discriminator)
+    inference.run(n_iter=1)
+
   def test_hmc(self):
     N, D, W_1, W_2, W_3, b_1, b_2, x_ph, y, X_train, y_train = self._test()
 


### PR DESCRIPTION
+ issues | fixes #431 

Wasserstein GAN is implemented (Arjovsky et al., 2017). As an aside, I love the simplicity of `wgan_inference.py`—it really showcases the power of Edward for developing inference methods.

An example with MNIST is added. The images are actually blurrier than the vanilla GAN experiment. One might hope this is true because it supposedly drops less modes, or so says [the week-old preprint](https://arxiv.org/abs/1701.07875).

`GANInference` can now perform separate updates on the generator or the discriminator (this was necessary to get WGANs to work).