### PR TITLE
A due reshape of y_train and y_test to avoid errors in the inference …

### DIFF
--- a/examples/mixture_density_network.py
+++ b/examples/mixture_density_network.py
@@ -82,6 +82,8 @@ K = 20  # number of mixture components
 
 # DATA
 X_train, X_test, y_train, y_test = build_toy_dataset(N)
+y_train = y_train.reshape(-1)
+y_test = y_test.reshape(-1)
 print("Size of features in training data: {}".format(X_train.shape))
 print("Size of output in training data: {}".format(y_train.shape))
 print("Size of features in test data: {}".format(X_test.shape))


### PR DESCRIPTION
Without reshaping y_train and y_test the following error arises:
```
File "MixtureDensityNetwork.py", line 120, in <module>
    info_dict = inference.update(feed_dict={X_ph: X_train, y_ph: y_train})
[...]
ValueError: Cannot feed value of shape (4000, 1) for Tensor 'Placeholder_1:0', which has shape '(?,)'
```