### PR TITLE
fix missing case to feed np.float variables

### DIFF
--- a/edward/inferences/inference.py
+++ b/edward/inferences/inference.py
@@ -151,6 +151,30 @@ class Inference(object):
                               "shape.")
 
             self.data[key] = value
+          elif isinstance(value, np.number):
+            if np.issubdtype(value.dtype, np.float):
+              ph_type = tf.float32
+            elif np.issubdtype(value.dtype, np.int):
+              ph_type = tf.int32
+            else:
+                raise TypeError("Data value as an invalid type.")
+            ph = tf.placeholder(ph_type, value.shape)
+            var = tf.Variable(ph, trainable=False, collections=[])
+            self.data[key] = var
+            sess.run(var.initializer, {ph: value})
+          elif isinstance(value, float):
+            ph_type = tf.float32
+            ph = tf.placeholder(ph_type, ())
+            var = tf.Variable(ph, trainable=False, collections=[])
+            self.data[key] = var
+            sess.run(var.initializer, {ph: value})
+          elif isinstance(value, int):
+            ph_type = tf.int32
+            ph = tf.placeholder(ph_type, ())
+            var = tf.Variable(ph, trainable=False, collections=[])
+            self.data[key] = var
+            # handle if value is `bool` which this case catches
+            sess.run(var.initializer, {ph: int(value)})
           else:
             raise TypeError("Data value has an invalid type.")
         elif isinstance(key, str):

--- a/tests/test-inferences/test_inference.py
+++ b/tests/test-inferences/test_inference.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import edward as ed
+import numpy as np
 import tensorflow as tf
 
 from edward.models import Normal
@@ -20,6 +21,7 @@ class NormalNormal:
 class test_inference_class(tf.test.TestCase):
 
   def test_latent_vars(self):
+    tf.InteractiveSession()
     mu = Normal(mu=0.0, sigma=1.0)
     qmu = Normal(mu=tf.Variable(0.0), sigma=tf.constant(1.0))
     qmu_misshape = Normal(mu=tf.constant([0.0]), sigma=tf.constant([1.0]))
@@ -31,6 +33,7 @@ class test_inference_class(tf.test.TestCase):
     self.assertRaises(TypeError, ed.Inference, {mu: qmu_misshape})
 
   def test_data(self):
+    tf.InteractiveSession()
     x = Normal(mu=0.0, sigma=1.0)
     qx = Normal(mu=0.0, sigma=1.0)
     qx_misshape = Normal(mu=tf.constant([0.0]), sigma=tf.constant([1.0]))
@@ -39,6 +42,11 @@ class test_inference_class(tf.test.TestCase):
     ed.Inference()
     ed.Inference(data={x: tf.constant(0.0)})
     ed.Inference(data={x_ph: tf.constant(0.0)})
+    ed.Inference(data={x: np.float64(0.0)})
+    ed.Inference(data={x: np.int64(0)})
+    ed.Inference(data={x: 0.0})
+    ed.Inference(data={x: 0})
+    ed.Inference(data={x: False})  # converted to `int`
     ed.Inference(data={x: x_ph})
     ed.Inference(data={x: qx})
     self.assertRaises(TypeError, ed.Inference, data={5: tf.constant(0.0)})
@@ -47,6 +55,7 @@ class test_inference_class(tf.test.TestCase):
     self.assertRaises(TypeError, ed.Inference, data={x: qx_misshape})
 
   def test_model_wrapper(self):
+    tf.InteractiveSession()
     model = NormalNormal()
     qmu = Normal(mu=tf.Variable(0.0), sigma=tf.constant(1.0))
 


### PR DESCRIPTION
Creates a new path in `inference.py` to handle the case where we feed in `np.float` variables to nodes in the computation graph.