### PR TITLE
WIP: examples of simple time series models

### DIFF
--- a/examples/time-series/example_ar-p.ipynb
+++ b/examples/time-series/example_ar-p.ipynb
@@ -1,0 +1,285 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-24T10:29:35.964814",
+     "start_time": "2017-02-24T10:29:35.600359"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "from __future__ import absolute_import\n",
+    "from __future__ import division\n",
+    "from __future__ import print_function\n",
+    "\n",
+    "import edward as ed\n",
+    "import numpy as np\n",
+    "import tensorflow as tf\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Generate data from stable AR(2) process\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-24T10:29:36.820467",
+     "start_time": "2017-02-24T10:29:36.814343"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "# Parameters\n",
+    "\n",
+    "mu = 0.\n",
+    "beta_true = np.array([0.7, 0.25])\n",
+    "\n",
+    "noise_obs = 0.1\n",
+    "T = 128\n",
+    "p = 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-24T10:29:37.788903",
+     "start_time": "2017-02-24T10:29:37.781328"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "# Generate synthetic data\n",
+    "x_true = np.random.randn(T+1)*noise_obs\n",
+    "for t in xrange(p, T):\n",
+    "    x_true[t] += beta_true.dot(x_true[t-p:t][::-1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-24T10:29:39.165765",
+     "start_time": "2017-02-24T10:29:38.873426"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "plt.plot(x_true);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Edward model\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-24T10:38:57.184835",
+     "start_time": "2017-02-24T10:38:52.252252"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "from edward.models import Normal, InverseGamma, PointMass\n",
+    "\n",
+    "mu = Normal(mu=0., sigma=10.)\n",
+    "beta = [Normal(mu=0., sigma=2.) for i in xrange(p)]\n",
+    "\n",
+    "noise_proc = tf.constant(0.1) #InverseGamma(alpha=1.0, beta=1.0)\n",
+    "noise_obs = tf.constant(0.1) #InverseGamma(alpha=1.0, beta=1.0)\n",
+    "\n",
+    "x = [0] * T\n",
+    "for n in xrange(p):\n",
+    "    x[n] = Normal(mu=mu, sigma=10.0)  # fat prior on x\n",
+    "for n in xrange(p, T):\n",
+    "    mu_ = mu\n",
+    "    for j in xrange(p):\n",
+    "        mu_ += beta[j] * x[n-j-1]\n",
+    "    x[n] = Normal(mu=mu_, sigma=noise_proc)\n",
+    "\n",
+    "# use variance as zero to convert the list of x's to something Inference\n",
+    "# will understand\n",
+    "#y = Normal(mu=x, sigma=tf.constant(0.))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### MAP Inference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-24T10:44:03.932152",
+     "start_time": "2017-02-24T10:38:58.889492"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "print(\"setting up distributions\")\n",
+    "qmu = PointMass(params=tf.Variable(0.))\n",
+    "qbeta = [PointMass(params=tf.Variable(0.)) for i in xrange(p)]\n",
+    "print(\"constructing inference object\")\n",
+    "vdict = {mu: qmu}\n",
+    "vdict.update({b: qb for b, qb in zip(beta, qbeta)}) inference = ed.MAP(vdict, data={xt: xt_true for xt, xt_true in zip(x, x_true)})\n",
+    "print(\"running inference\")\n",
+    "inference.run()\n",
+    "\n",
+    "print(\"parameter estimates:\")\n",
+    "print(\"beta: \", [qb.value().eval() for qb in qbeta])\n",
+    "print(\"mu: \", qmu.value().eval())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Variational inference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-24T11:24:40.939490",
+     "start_time": "2017-02-24T11:17:58.456562"
+    },
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(\"setting up variational distributions\")\n",
+    "qmu = Normal(mu=tf.Variable(0.), sigma=tf.nn.softplus(tf.Variable(0.)))\n",
+    "qbeta = [Normal(mu=tf.Variable(0.), sigma=tf.nn.softplus(tf.Variable(0.))) for i in xrange(p)]\n",
+    "print(\"constructing inference object\")\n",
+    "vdict = {mu: qmu}\n",
+    "vdict.update({b: qb for b, qb in zip(beta, qbeta)})\n",
+    "inference_vb = ed.KLqp(vdict, data={xt: xt_true for xt, xt_true in zip(x, x_true)})\n",
+    "print(\"running inference\")\n",
+    "inference_vb.run()\n",
+    "\n",
+    "print(\"parameter estimates:\")\n",
+    "for j in xrange(p):\n",
+    "    print(\"beta[%d]: \" % j, qbeta[j].mean().eval(), \" +- \", qbeta[j].std().eval())\n",
+    "print(\"mu: \", qmu.variance().eval(), qmu.std().eval())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Compare with estimate from statsmodels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-24T10:38:17.895247",
+     "start_time": "2017-02-24T10:38:17.883803"
+    },
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from statsmodels.tsa import ar_model\n",
+    "\n",
+    "ar2_sm = ar_model.AR(x_true)\n",
+    "res = ar2_sm.fit(maxlag=2, ic=None, trend='c')\n",
+    "\n",
+    "print(\"statsmodels AR(2) params: \", res.params)"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernel_info": {
+   "name": "python2"
+  },
+  "kernelspec": {
+   "display_name": "Python [conda env:py2]",
+   "language": "python",
+   "name": "conda-env-py2-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  },
+  "latex_envs": {
+   "bibliofile": "biblio.bib",
+   "cite_by": "apalike",
+   "current_citInitial": 1,
+   "eqLabelWithNumbers": true,
+   "eqNumInitial": 0
+  },
+  "toc": {
+   "nav_menu": {
+    "height": "105px",
+    "width": "252px"
+   },
+   "navigate_menu": true,
+   "number_sections": true,
+   "sideBar": true,
+   "threshold": 4,
+   "toc_cell": false,
+   "toc_section_display": "block",
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/time-series/example_ar-p_replicates.ipynb
+++ b/examples/time-series/example_ar-p_replicates.ipynb
@@ -1,0 +1,295 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-25T20:19:18.814387",
+     "start_time": "2017-02-25T20:19:16.217460"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "from __future__ import absolute_import\n",
+    "from __future__ import division\n",
+    "from __future__ import print_function\n",
+    "\n",
+    "import edward as ed\n",
+    "import numpy as np\n",
+    "import tensorflow as tf\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Generate data from stable AR(2) process\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-25T20:21:31.422870",
+     "start_time": "2017-02-25T20:21:31.415073"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "# Parameters\n",
+    "\n",
+    "mu = 0.\n",
+    "beta_true = np.array([0.7, 0.25])\n",
+    "\n",
+    "noise_obs = 0.1\n",
+    "T = 128\n",
+    "N= 50\n",
+    "p = 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-25T20:21:31.937504",
+     "start_time": "2017-02-25T20:21:31.929251"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "# Generate synthetic data\n",
+    "x_true = np.random.randn(T+1,N)*noise_obs\n",
+    "for t in xrange(p, T):\n",
+    "    x_true[t] += beta_true.dot(x_true[t-p:t][::-1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-25T20:21:35.448535",
+     "start_time": "2017-02-25T20:21:34.990083"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "plt.plot(x_true);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Edward model\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-25T20:28:29.958929",
+     "start_time": "2017-02-25T20:28:24.025371"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "from edward.models import Normal, InverseGamma, PointMass\n",
+    "\n",
+    "mu = Normal(mu=0., sigma=10.)\n",
+    "beta = [Normal(mu=0., sigma=2.) for i in xrange(p)]\n",
+    "\n",
+    "noise_proc = tf.constant(0.1) #InverseGamma(alpha=1.0, beta=1.0)\n",
+    "noise_obs = tf.constant(0.1) #InverseGamma(alpha=1.0, beta=1.0)\n",
+    "\n",
+    "x = [0] * T\n",
+    "for n in xrange(p):\n",
+    "    x[n] = Normal(mu=mu*tf.ones([N]), sigma=10.0*tf.ones([N]))  # fat prior on x\n",
+    "for n in xrange(p, T):\n",
+    "    mu_ = mu\n",
+    "    for j in xrange(p):\n",
+    "        mu_ += beta[j] * x[n-j-1]\n",
+    "    x[n] = Normal(mu=mu_*tf.ones([N]), sigma=noise_proc*tf.ones([N]))\n",
+    "\n",
+    "# use variance as zero to convert the list of x's to something Inference\n",
+    "# will understand\n",
+    "#y = Normal(mu=x, sigma=tf.constant(0.))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### MAP Inference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-25T20:32:48.976811",
+     "start_time": "2017-02-25T20:28:32.987558"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "print(\"setting up distributions\")\n",
+    "qmu = PointMass(params=tf.Variable(0.))\n",
+    "qbeta = [PointMass(params=tf.Variable(0.)) for i in xrange(p)]\n",
+    "print(\"constructing inference object\")\n",
+    "vdict = {mu: qmu}\n",
+    "vdict.update({b: qb for b, qb in zip(beta, qbeta)})\n",
+    "inference = ed.MAP(vdict, data={xt: xt_true for xt, xt_true in zip(x, x_true)})\n",
+    "print(\"running inference\")\n",
+    "inference.run()\n",
+    "\n",
+    "print(\"parameter estimates:\")\n",
+    "print(\"beta: \", [qb.value().eval() for qb in qbeta])\n",
+    "print(\"mu: \", qmu.value().eval())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Variational inference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-25T20:38:21.878610",
+     "start_time": "2017-02-25T20:33:07.986214"
+    },
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(\"setting up variational distributions\")\n",
+    "qmu = Normal(mu=tf.Variable(0.), sigma=tf.nn.softplus(tf.Variable(0.)))\n",
+    "qbeta = [Normal(mu=tf.Variable(0.), sigma=tf.nn.softplus(tf.Variable(0.))) for i in xrange(p)]\n",
+    "print(\"constructing inference object\")\n",
+    "vdict = {mu: qmu}\n",
+    "vdict.update({b: qb for b, qb in zip(beta, qbeta)})\n",
+    "inference_vb = ed.KLqp(vdict, data={xt: xt_true for xt, xt_true in zip(x, x_true)})\n",
+    "print(\"running inference\")\n",
+    "inference_vb.run()\n",
+    "\n",
+    "print(\"parameter estimates:\")\n",
+    "for j in xrange(p):\n",
+    "    print(\"beta[%d]: \" % j, qbeta[j].mean().eval(), \" +- \", qbeta[j].std().eval())\n",
+    "print(\"mu: \", qmu.variance().eval(), qmu.std().eval())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Compare with estimate from statsmodels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-25T20:40:48.698792",
+     "start_time": "2017-02-25T20:40:48.650248"
+    },
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from statsmodels.tsa import ar_model\n",
+    "\n",
+    "mu_res = np.empty(N)\n",
+    "beta_res = np.empty((N, p))\n",
+    "for n in xrange(N):\n",
+    "    ar2_sm = ar_model.AR(x_true[:,n])\n",
+    "    res = ar2_sm.fit(maxlag=2, ic=None, trend='c')\n",
+    "    mu_res[n] = res.params[0]\n",
+    "    beta_res[n] = res.params[1:]\n",
+    "\n",
+    "\n",
+    "print(\"statsmodels AR(2) params:\")\n",
+    "print(\"mu: \", np.mean(mu_res))\n",
+    "print(\"beta: \", np.mean(beta_res, axis=0))"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernel_info": {
+   "name": "python2"
+  },
+  "kernelspec": {
+   "display_name": "Python [conda env:py2]",
+   "language": "python",
+   "name": "conda-env-py2-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  },
+  "latex_envs": {
+   "bibliofile": "biblio.bib",
+   "cite_by": "apalike",
+   "current_citInitial": 1,
+   "eqLabelWithNumbers": true,
+   "eqNumInitial": 0
+  },
+  "toc": {
+   "nav_menu": {
+    "height": "105px",
+    "width": "252px"
+   },
+   "navigate_menu": true,
+   "number_sections": true,
+   "sideBar": true,
+   "threshold": 4,
+   "toc_cell": false,
+   "toc_section_display": "block",
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/time-series/example_ar.ipynb
+++ b/examples/time-series/example_ar.ipynb
@@ -1,0 +1,291 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-21T14:13:41.094831",
+     "start_time": "2017-02-21T14:13:37.654479"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "from __future__ import absolute_import\n",
+    "from __future__ import division\n",
+    "from __future__ import print_function\n",
+    "\n",
+    "import edward as ed\n",
+    "import numpy as np\n",
+    "import tensorflow as tf\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Generate data from stable AR(1) process\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-21T14:13:41.101854",
+     "start_time": "2017-02-21T14:13:41.097094"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "# Parameters\n",
+    "\n",
+    "mu = 0.\n",
+    "beta_true = 0.9\n",
+    "\n",
+    "noise_obs = 0.1\n",
+    "T = 128"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-21T14:13:41.788955",
+     "start_time": "2017-02-21T14:13:41.782206"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "# Generate synthetic data\n",
+    "x_true = np.random.randn(T)*noise_obs\n",
+    "for t in range(1, T):\n",
+    "    x_true[t] += beta_true*x_true[t-1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-21T14:13:43.085027",
+     "start_time": "2017-02-21T14:13:42.785135"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "plt.plot(x_true);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Edward model\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-21T14:17:47.513764",
+     "start_time": "2017-02-21T14:17:42.272915"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "from edward.models import Normal, InverseGamma, PointMass\n",
+    "\n",
+    "mu = Normal(mu=0., sigma=10.0)\n",
+    "beta = Normal(mu=0., sigma=2.0)\n",
+    "\n",
+    "noise_proc = tf.constant(0.1) #InverseGamma(alpha=1.0, beta=1.0)\n",
+    "noise_obs = tf.constant(0.1) #InverseGamma(alpha=1.0, beta=1.0)\n",
+    "\n",
+    "x = [0] * T\n",
+    "x[0] = Normal(mu=mu, sigma=10.0)  # fat prior on x\n",
+    "for n in range(1, T):\n",
+    "    x[n] = Normal(mu=mu + beta * x[n-1], sigma=noise_proc)\n",
+    "\n",
+    "# use variance as zero to convert the list of x's to something Inference\n",
+    "# will understand\n",
+    "#y = Normal(mu=x, sigma=tf.constant(0.))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### MAP Inference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-21T14:19:13.526123",
+     "start_time": "2017-02-21T14:17:52.477122"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "print(\"setting up distributions\")\n",
+    "qmu = PointMass(params=tf.Variable(0.))\n",
+    "qbeta = PointMass(params=tf.Variable(0.))\n",
+    "print(\"constructing inference object\")\n",
+    "inference = ed.MAP({beta: qbeta, mu: qmu}, data={xt: xt_true for xt, xt_true in zip(x, x_true)})\n",
+    "print(\"running inference\")\n",
+    "inference.run()\n",
+    "\n",
+    "print(\"parameter estimates:\")\n",
+    "print(\"beta: \", qbeta.value().eval())\n",
+    "print(\"mu: \", qmu.value().eval())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Variational inference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-22T20:56:22.817912",
+     "start_time": "2017-02-22T20:50:59.564908"
+    },
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(\"setting up variational distributions\")\n",
+    "qmu = Normal(mu=tf.Variable(tf.random_normal([])), sigma=tf.nn.softplus(tf.Variable(tf.random_normal([]))))\n",
+    "qbeta = Normal(mu=tf.Variable(tf.random_normal([])), sigma=tf.nn.softplus(tf.Variable(tf.random_normal([]))))\n",
+    "#qmu = Normal(mu=tf.Variable(0.), sigma=tf.nn.softplus(tf.Variable(0.)))\n",
+    "#qbeta = Normal(mu=tf.Variable(0.), sigma=tf.nn.softplus(tf.Variable(0.)))\n",
+    "print(\"constructing inference object\")\n",
+    "inference_vb = ed.KLqp({beta: qbeta, mu:qmu}, data={xt: xt_true for xt, xt_true in zip(x, x_true)})\n",
+    "print(\"running inference\")\n",
+    "inference_vb.run()\n",
+    "\n",
+    "print(\"parameter estimates:\")\n",
+    "print(\"beta: \", qbeta.mean().eval(), qbeta.std().eval())\n",
+    "print(\"mu: \", qbeta.variance().eval(), qmu.std().eval())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Compare with estimate from statsmodels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-21T14:21:06.970194",
+     "start_time": "2017-02-21T14:21:06.963652"
+    },
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from statsmodels.tsa import ar_model\n",
+    "\n",
+    "ar1_sm = ar_model.AR(x_true)\n",
+    "res = ar1_sm.fit(maxlag=1, ic=None, trend='c')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-21T14:21:06.980148",
+     "start_time": "2017-02-21T14:21:06.973252"
+    },
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "res.params"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernel_info": {
+   "name": "python2"
+  },
+  "kernelspec": {
+   "display_name": "Python [conda env:py2]",
+   "language": "python",
+   "name": "conda-env-py2-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  },
+  "latex_envs": {
+   "bibliofile": "biblio.bib",
+   "cite_by": "apalike",
+   "current_citInitial": 1,
+   "eqLabelWithNumbers": true,
+   "eqNumInitial": 0
+  },
+  "toc": {
+   "nav_menu": {
+    "height": "105px",
+    "width": "252px"
+   },
+   "navigate_menu": true,
+   "number_sections": true,
+   "sideBar": true,
+   "threshold": 4,
+   "toc_cell": false,
+   "toc_section_display": "block",
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/time-series/example_ar_replicates.ipynb
+++ b/examples/time-series/example_ar_replicates.ipynb
@@ -1,0 +1,277 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-25T19:44:41.827195",
+     "start_time": "2017-02-25T19:44:37.204384"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "from __future__ import absolute_import\n",
+    "from __future__ import division\n",
+    "from __future__ import print_function\n",
+    "\n",
+    "import edward as ed\n",
+    "import numpy as np\n",
+    "import tensorflow as tf\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Generate data from stable AR(1) process\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-25T20:14:32.190269",
+     "start_time": "2017-02-25T20:14:32.184963"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "# Parameters\n",
+    "\n",
+    "mu = 0.\n",
+    "beta_true = 0.9\n",
+    "\n",
+    "noise_obs = 0.1\n",
+    "T = 32\n",
+    "N = 50"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-25T20:14:32.561995",
+     "start_time": "2017-02-25T20:14:32.554936"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "# Generate synthetic data\n",
+    "x_true = np.random.randn(T,N)*noise_obs\n",
+    "for t in range(1, T):\n",
+    "    x_true[t] += beta_true*x_true[t-1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-25T20:14:33.438957",
+     "start_time": "2017-02-25T20:14:33.004023"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "plt.plot(x_true);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Edward model\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-25T20:14:37.958214",
+     "start_time": "2017-02-25T20:14:36.464753"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "from edward.models import Normal, InverseGamma, PointMass\n",
+    "\n",
+    "mu = Normal(mu=0., sigma=10.0)\n",
+    "beta = Normal(mu=0., sigma=2.0)\n",
+    "\n",
+    "noise_proc = tf.constant(0.1) #InverseGamma(alpha=1.0, beta=1.0)\n",
+    "noise_obs = tf.constant(0.1) #InverseGamma(alpha=1.0, beta=1.0)\n",
+    "\n",
+    "x = [0] * T\n",
+    "x[0] = Normal(mu=tf.ones([N])*mu, sigma=tf.ones([N])*10.0)  # fat prior on x\n",
+    "for n in range(1, T):\n",
+    "    x[n] = Normal(mu=tf.ones([N])*mu + beta * x[n-1], sigma=tf.ones([N])*noise_proc)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### MAP Inference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-25T20:15:42.241446",
+     "start_time": "2017-02-25T20:14:37.960419"
+    },
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "print(\"setting up distributions\")\n",
+    "qmu = PointMass(params=tf.Variable(0.))\n",
+    "qbeta = PointMass(params=tf.Variable(0.))\n",
+    "print(\"constructing inference object\")\n",
+    "inference = ed.MAP({beta: qbeta, mu: qmu}, data={xt: xt_true for xt, xt_true in zip(x, x_true)})\n",
+    "print(\"running inference\")\n",
+    "inference.run()\n",
+    "\n",
+    "print(\"parameter estimates:\")\n",
+    "print(\"beta: \", qbeta.value().eval())\n",
+    "print(\"mu: \", qmu.value().eval())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Variational inference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-25T20:17:04.344888",
+     "start_time": "2017-02-25T20:15:52.454033"
+    },
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(\"setting up variational distributions\")\n",
+    "qmu = Normal(mu=tf.Variable(tf.random_normal([])), sigma=tf.nn.softplus(tf.Variable(tf.random_normal([]))))\n",
+    "qbeta = Normal(mu=tf.Variable(tf.random_normal([])), sigma=tf.nn.softplus(tf.Variable(tf.random_normal([]))))\n",
+    "print(\"constructing inference object\")\n",
+    "inference_vb = ed.KLqp({beta: qbeta, mu:qmu}, data={xt: xt_true for xt, xt_true in zip(x, x_true)})\n",
+    "print(\"running inference\")\n",
+    "inference_vb.run()\n",
+    "\n",
+    "print(\"parameter estimates:\")\n",
+    "print(\"beta: \", qbeta.mean().eval(), qbeta.std().eval())\n",
+    "print(\"mu: \", qbeta.variance().eval(), qmu.std().eval())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Compare with estimate from statsmodels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-25T20:11:07.312470",
+     "start_time": "2017-02-25T20:11:06.600927"
+    },
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from statsmodels.tsa import ar_model\n",
+    "\n",
+    "mu_res = np.empty(N)\n",
+    "beta_res = np.empty(N)\n",
+    "for n in xrange(N):\n",
+    "    ar1_sm = ar_model.AR(x_true[:,n])\n",
+    "    res = ar1_sm.fit(maxlag=1, ic=None, trend='c')\n",
+    "    mu_res[n], beta_res[n] = res.params\n",
+    "print(\"sm mu: \", np.mean(mu_res))\n",
+    "print(\"sm beta: \", np.mean(beta_res))"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernel_info": {
+   "name": "python2"
+  },
+  "kernelspec": {
+   "display_name": "Python [conda env:py2]",
+   "language": "python",
+   "name": "conda-env-py2-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  },
+  "latex_envs": {
+   "bibliofile": "biblio.bib",
+   "cite_by": "apalike",
+   "current_citInitial": 1,
+   "eqLabelWithNumbers": true,
+   "eqNumInitial": 0
+  },
+  "toc": {
+   "nav_menu": {
+    "height": "105px",
+    "width": "252px"
+   },
+   "navigate_menu": true,
+   "number_sections": true,
+   "sideBar": true,
+   "threshold": 4,
+   "toc_cell": false,
+   "toc_section_display": "block",
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/time-series/example_var.ipynb
+++ b/examples/time-series/example_var.ipynb
@@ -1,0 +1,308 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Vector autoregressive model\n",
+    "==="
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-26T14:12:54.160524",
+     "start_time": "2017-02-26T14:12:50.210457"
+    },
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from __future__ import absolute_import\n",
+    "from __future__ import division\n",
+    "from __future__ import print_function\n",
+    "\n",
+    "import edward as ed\n",
+    "import numpy as np\n",
+    "import tensorflow as tf\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-26T14:15:07.138394",
+     "start_time": "2017-02-26T14:15:07.132332"
+    }
+   },
+   "source": [
+    "Generate data from stable three dimensional VAR(1) process\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-26T14:43:58.118052",
+     "start_time": "2017-02-26T14:43:58.112160"
+    },
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# parameters\n",
+    "# this example comes from Lutkepohl, \"New Introduction fo Multiple Time Series Analysis\"\n",
+    "\n",
+    "d = 3\n",
+    "mu = np.zeros(d)\n",
+    "beta_true = np.array([[0.5, 0., 0.],[0.1, 0.1, 0.3],[0., 0.2, 0.3]])\n",
+    "\n",
+    "noise_obs = 0.1\n",
+    "T = 128"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-26T14:44:00.582316",
+     "start_time": "2017-02-26T14:44:00.575021"
+    },
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# generate synthetic data from true model\n",
+    "x_true = np.random.randn(T,d)*noise_obs\n",
+    "for t in xrange(1, T):\n",
+    "    x_true[t] += beta_true.dot(x_true[t-1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-26T14:44:01.469943",
+     "start_time": "2017-02-26T14:44:01.163022"
+    },
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "plt.plot(x_true);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Edward model\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-26T14:46:59.717808",
+     "start_time": "2017-02-26T14:46:44.535277"
+    },
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from edward.models import Normal, InverseGamma, PointMass\n",
+    "\n",
+    "mu = Normal(mu=tf.zeros([d]), sigma=10.*tf.ones([d]))\n",
+    "beta = Normal(mu=tf.zeros([d, d]), sigma=2.*tf.ones([d,d]))\n",
+    "\n",
+    "noise_proc = tf.constant(0.1)  # InverseGamma(alpha=1.0, beta=1.0)\n",
+    "noise_obs = tf.constant(0.1)  # InverseGamma(alpha=1.0, beta=1.0)\n",
+    "\n",
+    "x = [0] * T\n",
+    "x[0] = Normal(mu=mu, sigma=10.*tf.ones([d]))\n",
+    "for n in xrange(1, T):\n",
+    "    x[n] = Normal(mu=mu + tf.tensordot(beta, x[n-1], axes=[[1],[0]]),\n",
+    "                  sigma=noise_proc*tf.ones([d]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "MAP inference\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-26T15:01:35.989050",
+     "start_time": "2017-02-26T14:52:27.698901"
+    },
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from itertools import izip\n",
+    "\n",
+    "print(\"setting up distributions\")\n",
+    "qmu = PointMass(params=tf.Variable(tf.zeros([d])))\n",
+    "qbeta = PointMass(params=tf.Variable(tf.zeros([d,d])))\n",
+    "print(\"constructing inference object\")\n",
+    "inference = ed.MAP({beta: qbeta, mu: qmu}, data={xt: xt_true for xt, xt_true in izip(x, x_true)})\n",
+    "print(\"running inference\")\n",
+    "inference.run()\n",
+    "\n",
+    "print(\"parameter estimates:\")\n",
+    "print(\"mu: \", qmu.value().eval())\n",
+    "print(\"beta:\\n\", qbeta.value().eval())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-26T14:34:10.138001",
+     "start_time": "2017-02-26T14:34:10.132720"
+    }
+   },
+   "source": [
+    "Variational inference\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-26T14:52:18.725384",
+     "start_time": "2017-02-26T22:47:04.817Z"
+    },
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(\"setting up variational distributions\")\n",
+    "qmu = Normal(mu=tf.Variable(tf.random_normal([d])), sigma=tf.nn.softplus(tf.Variable(tf.random_normal([d]))))\n",
+    "qbeta = Normal(mu=tf.Variable(tf.random_normal([d, d])), sigma=tf.nn.softplus(tf.Variable(tf.random_normal([d,d]))))\n",
+    "print(\"constructing inference object\")\n",
+    "inference_vb = ed.KLqp({beta: qbeta, mu: qmu}, data={xt: xt_true for xt, xt_true in zip(x, x_true)})\n",
+    "print(\"running VB inference\")\n",
+    "inference_vb.run()\n",
+    "\n",
+    "print(\"parameter estimates:\")\n",
+    "print(\"mu: \", qmu.mean().eval())\n",
+    "print(\"beta:\\n\", qbeta.mean().eval())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compare with `statsmodels`\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-26T15:08:57.966230",
+     "start_time": "2017-02-26T15:08:57.958732"
+    },
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from statsmodels.tsa.vector_ar.var_model import VAR\n",
+    "\n",
+    "var1 = VAR(x_true)\n",
+    "res = var1.fit(1, ic=None, trend='c')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-02-26T15:09:48.647095",
+     "start_time": "2017-02-26T15:09:48.638609"
+    },
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "mu_sm = res.params[0]\n",
+    "beta_sm = res.params[1:].T\n",
+    "print(\"mu_sm: \", mu_sm)\n",
+    "print(\"beta_sm:\\n\", beta_sm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [conda env:py2]",
+   "language": "python",
+   "name": "conda-env-py2-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  },
+  "latex_envs": {
+   "bibliofile": "biblio.bib",
+   "cite_by": "apalike",
+   "current_citInitial": 1,
+   "eqLabelWithNumbers": true,
+   "eqNumInitial": 0
+  },
+  "toc": {
+   "nav_menu": {
+    "height": "124px",
+    "width": "252px"
+   },
+   "navigate_menu": true,
+   "number_sections": true,
+   "sideBar": true,
+   "threshold": 4,
+   "toc_cell": false,
+   "toc_section_display": "block",
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
I have written a few examples of using edward to fit some simple time series models. They are in Jupyter notebook form right now, but I'm happy to convert them to scripts if that's easier (though I think having them as notebooks with some annotations can also be useful for learning edward). Any suggestions for improvement are welcome. I am planning on adding at least two more examples, one that uses a VAR(1) model for multiple replicates of a series and another example demonstrating a VAR(p) process (p > 1).

One point to notice is that constructing the `Inference` objects takes a very long time. I haven't dug into why this is happening, but I'm guessing that there is a lot of copying going when when I connect the training data to the corresponding nodes in the computation graph. Now that ICML is over I should have some time to dig into what's actually happening during construction and ways that we could potentially speed it up.