### PR TITLE
Let Keras apply neural net layers directly to RandomVariable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
   - pip install python-coveralls pytest-cov
   - pip install numpydoc
   - pip install pymc3
+  - pip install keras
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
       pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.0.0rc0-cp27-none-linux_x86_64.whl;
     elif [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then

--- a/edward/models/random_variable.py
+++ b/edward/models/random_variable.py
@@ -213,6 +213,10 @@ class RandomVariable(object):
     from edward.util.random_variables import get_variables
     return get_variables(self, collection)
 
+  def get_shape(self):
+    """Get shape of random variable."""
+    return self._value.get_shape()
+
   def _tensor_conversion_function(v, dtype=None, name=None, as_ref=False):
     _ = name
     if dtype and not dtype.is_compatible_with(v.dtype):

--- a/examples/vae.py
+++ b/examples/vae.py
@@ -36,7 +36,7 @@ mnist = input_data.read_data_sets(DATA_DIR, one_hot=True)
 # Define a subgraph of the full model, corresponding to a minibatch of
 # size M.
 z = Normal(mu=tf.zeros([M, d]), sigma=tf.ones([M, d]))
-hidden = Dense(256, activation='relu')(z.value())
+hidden = Dense(256, activation='relu')(z)
 x = Bernoulli(logits=Dense(28 * 28)(hidden))
 
 # INFERENCE

--- a/tests/test-models/test_keras_core_layers.py
+++ b/tests/test-models/test_keras_core_layers.py
@@ -1,0 +1,79 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import edward as ed
+import keras.layers as layers
+import tensorflow as tf
+
+from edward.models import Normal
+
+
+class test_keras_core_layers_class(tf.test.TestCase):
+
+  def test_dense(self):
+    x = Normal(mu=tf.zeros([100, 10, 5]), sigma=tf.ones([100, 10, 5]))
+    y = layers.Dense(32)(x)
+
+  def test_activation(self):
+    x = Normal(mu=tf.zeros([100, 10, 5]), sigma=tf.ones([100, 10, 5]))
+    y = layers.Activation('tanh')(x)
+
+  def test_dropout(self):
+    x = Normal(mu=tf.zeros([100, 10, 5]), sigma=tf.ones([100, 10, 5]))
+    y = layers.Dropout(0.5)(x)
+
+  def test_flatten(self):
+    x = Normal(mu=tf.zeros([100, 10, 5]), sigma=tf.ones([100, 10, 5]))
+    y = layers.Flatten()(x)
+    with self.test_session():
+      assert y.eval().shape == (100, 50)
+
+  def test_reshape(self):
+    x = Normal(mu=tf.zeros([100, 10, 5]), sigma=tf.ones([100, 10, 5]))
+    y = layers.Reshape((5, 10))(x)
+    with self.test_session():
+      assert y.eval().shape == (100, 5, 10)
+
+  def test_permute(self):
+    x = Normal(mu=tf.zeros([100, 10, 5]), sigma=tf.ones([100, 10, 5]))
+    y = layers.Permute((2, 1))(x)
+    with self.test_session():
+      assert y.eval().shape == (100, 5, 10)
+
+  def test_repeat_vector(self):
+    x = Normal(mu=tf.zeros([100, 10]), sigma=tf.ones([100, 10]))
+    y = layers.RepeatVector(2)(x)
+    with self.test_session():
+      assert y.eval().shape == (100, 2, 10)
+
+  def test_merge(self):
+    shared_dense = layers.Dense(32)
+    x1 = Normal(mu=tf.zeros([100, 10]), sigma=tf.ones([100, 10]))
+    x2 = Normal(mu=tf.zeros([100, 10]), sigma=tf.ones([100, 10]))
+    encoded1 = shared_dense(x1)
+    encoded2 = shared_dense(x2)
+    merged_vector = layers.merge([encoded1, encoded2], mode='sum')
+
+  def test_lambda(self):
+    x = Normal(mu=tf.zeros([100, 10, 5]), sigma=tf.ones([100, 10, 5]))
+    y = layers.Lambda(lambda x: x ** 2)(x)
+
+  def test_activity_regularization(self):
+    x = Normal(mu=tf.zeros([100, 10, 5]), sigma=tf.ones([100, 10, 5]))
+    y = layers.ActivityRegularization(l1=0.1)(x)
+
+  def test_masking(self):
+    x = Normal(mu=tf.zeros([100, 10, 5]), sigma=tf.ones([100, 10, 5]))
+    y = layers.Masking()(x)
+
+  def test_highway(self):
+    x = Normal(mu=tf.zeros([100, 10]), sigma=tf.ones([100, 10]))
+    y = layers.Highway()(x)
+
+  def test_maxout_dense(self):
+    x = Normal(mu=tf.zeros([100, 10]), sigma=tf.ones([100, 10]))
+    y = layers.MaxoutDense(5)(x)
+
+if __name__ == '__main__':
+  tf.test.main()


### PR DESCRIPTION
This PR lets you apply Keras neural net layers directly on random variables, rather than having to first convert it to a tensor. For example, instead of
```python
z = Normal(mu=tf.zeros([100, 10]), sigma=tf.ones([100, 10]))
hidden = Dense(256, activation='relu')(z.value())
```
you can do
```python
z = Normal(mu=tf.zeros([100, 10]), sigma=tf.ones([100, 10]))
hidden = Dense(256, activation='relu')(z)
```