### PR TITLE
Miscellaneous improvements to ed.evaluate and ed.ppc

### DIFF
--- a/docs/tex/tutorials/criticism.tex
+++ b/docs/tex/tutorials/criticism.tex
@@ -132,10 +132,7 @@ distribution.
 The \texttt{ed.ppc()} method provides a scaffold for studying
 various discrepancy functions.
 \begin{lstlisting}[language=Python]
-def T(xs, zs):
-  return tf.reduce_mean(xs[x_post])
-
-ed.ppc(T, data={x_post: x_train})
+ed.ppc(lambda xs, zs: tf.reduce_mean(xs[x_post]), data={x_post: x_train})
 \end{lstlisting}
 The discrepancy can also take latent variables as input, which we pass
 into the PPC.

--- a/docs/tex/tutorials/criticism.tex
+++ b/docs/tex/tutorials/criticism.tex
@@ -141,10 +141,10 @@ The discrepancy can also take latent variables as input, which we pass
 into the PPC.
 \begin{lstlisting}[language=Python]
 def T(xs, zs):
-  return tf.reduce_mean(tf.cast(zs['z'], tf.float32))
+  return tf.reduce_mean(tf.cast(zs[z], tf.float32))
 
 ppc(T, data={y_post: y_train, x_ph: x_train},
-    latent_vars={'z': qz, 'beta': qbeta})
+    latent_vars={z: qz, beta: qbeta})
 \end{lstlisting}
 
 See the \href{/api/criticism}{criticism API} for further details.

--- a/edward/criticisms/evaluate.py
+++ b/edward/criticisms/evaluate.py
@@ -11,7 +11,7 @@ from edward.util import logit, get_session
 
 
 def evaluate(metrics, data, latent_vars=None, model_wrapper=None,
-             n_samples=100, output_key='y'):
+             n_samples=100, output_key=None):
   """Evaluate fitted model using a set of metrics.
 
   A metric, or scoring rule (Winkler, 1994), is a function of observed
@@ -62,7 +62,7 @@ def evaluate(metrics, data, latent_vars=None, model_wrapper=None,
     Number of posterior samples for making predictions,
     using the posterior predictive distribution. It is only used if
     the model wrapper is specified.
-  output_key : RandomVariable or str, optional
+  output_key : RandomVariable, optional
     It is the key in ``data`` which corresponds to the model's output.
 
   Returns
@@ -102,16 +102,14 @@ def evaluate(metrics, data, latent_vars=None, model_wrapper=None,
   if isinstance(metrics, str):
     metrics = [metrics]
 
-  # Set default for output_key if not using a model wrapper.
-  if model_wrapper is None:
-    if output_key == 'y':
-      # Try to default to the only one observed random variable.
-      keys = [key for key in six.iterkeys(data)
-              if isinstance(key, RandomVariable)]
-      if len(keys) == 1:
-        output_key = keys[0]
-      else:
-        raise KeyError("User must specify output_key.")
+  # Default output_key to the only one observed random variable.
+  if output_key is None:
+    keys = [key for key in six.iterkeys(data)
+            if isinstance(key, RandomVariable)]
+    if len(keys) == 1:
+      output_key = keys[0]
+    else:
+      raise KeyError("User must specify output_key.")
 
   # Form true data. (It is not required in the specific setting of the
   # log-likelihood metric with a model wrapper.)

--- a/edward/criticisms/evaluate.py
+++ b/edward/criticisms/evaluate.py
@@ -133,7 +133,7 @@ def evaluate(metrics, data, latent_vars=None, model_wrapper=None,
       y_pred = tf.add_n(y_pred) / tf.cast(n_samples, tf.float32)
     else:
       y_pred = []
-      for s in range(n_samples):
+      for _ in range(n_samples):
         zrep = {key: qz.sample(())
                 for key, qz in six.iteritems(latent_vars)}
         y_pred += [model_wrapper.predict(data, zrep)]
@@ -217,7 +217,7 @@ def binary_accuracy(y_true, y_pred):
   Parameters
   ----------
   y_true : tf.Tensor
-    Tensor of 0s and 1s.
+    Tensor of 0s and 1s (most generally, any real values a and b).
   y_pred : tf.Tensor
     Tensor of probabilities.
   """

--- a/edward/criticisms/evaluate.py
+++ b/edward/criticisms/evaluate.py
@@ -102,7 +102,7 @@ def evaluate(metrics, data, latent_vars=None, model_wrapper=None,
 
   # Default output_key to the only data key that isn't a placeholder.
   if output_key is None:
-    keys = [key for key in six.iterkeys(data) if not \
+    keys = [key for key in six.iterkeys(data) if not
             isinstance(key, tf.Tensor) or "Placeholder" not in key.op.type]
     if len(keys) == 1:
       output_key = keys[0]

--- a/edward/criticisms/ppc.py
+++ b/edward/criticisms/ppc.py
@@ -35,10 +35,10 @@ def ppc(T, data, latent_vars=None, model_wrapper=None, n_samples=100):
     ``RandomVariable``) to their realizations (of type ``tf.Tensor``). It
     can also bind placeholders (of type ``tf.Tensor``) used in the model
     to their realizations.
-  latent_vars : dict of str to RandomVariable, optional
+  latent_vars : dict of RandomVariable to RandomVariable, optional
     Collection of random variables binded to their inferred posterior.
-    It is an optional argument, necessary for when the discrepancy is
-    a function of latent variables.
+    This argument is used when the discrepancy is a function of latent
+    variables.
   model_wrapper : ed.Model, optional
     An optional wrapper for the probability model. It must have a
     ``sample_likelihood`` method. If ``latent_vars`` is not specified,
@@ -81,9 +81,9 @@ def ppc(T, data, latent_vars=None, model_wrapper=None, n_samples=100):
   >>>
   >>> # in general T is a discrepancy function of the data (both response and
   >>> # covariates) and latent variables, T(data, latent_vars)
-  >>> T = lambda xs, zs: tf.reduce_mean(zs['z'])
+  >>> T = lambda xs, zs: tf.reduce_mean(zs[z])
   >>> ppc(T, data={y_post: y_train, x_ph: x_train},
-  ...     latent_vars={'z': qz, 'beta': qbeta})
+  ...     latent_vars={z: qz, beta: qbeta})
   >>>
   >>> # prior predictive check
   >>> # running ppc on original x

--- a/edward/criticisms/ppc.py
+++ b/edward/criticisms/ppc.py
@@ -71,8 +71,8 @@ def ppc(T, data, latent_vars=None, model_wrapper=None, n_samples=100):
   Examples
   --------
   >>> # build posterior predictive after inference: it is
-  >>> # parameterized by posterior means
-  >>> x_post = copy(x, {z: qz.mean(), beta: qbeta.mean()})
+  >>> # parameterized by a posterior sample
+  >>> x_post = copy(x, {z: qz, beta: qbeta})
   >>>
   >>> # posterior predictive check
   >>> # T is a user-defined function of data, T(data)
@@ -126,12 +126,12 @@ def ppc(T, data, latent_vars=None, model_wrapper=None, n_samples=100):
   Tobs = T(data, zrep)
   Treps = []
   Ts = []
-  for s in range(n_samples):
+  for _ in range(n_samples):
     # Take a forward pass (session run) to get new samples for
     # each calculation of the discrepancy.
-    # Note that alternatively we can unroll the graph by registering
-    # this operation ``n_samples`` times, each for different parent
-    # nodes representing ``xrep`` and ``zrep``.
+    # Alternatively, we could unroll the graph by registering this
+    # operation ``n_samples`` times, each for different parent nodes
+    # representing ``xrep`` and ``zrep``. But it's expensive.
     Treps += [sess.run(Trep, feed_dict)]
     Ts += [sess.run(Tobs, feed_dict)]
 

--- a/examples/bayesian_linear_regression.py
+++ b/examples/bayesian_linear_regression.py
@@ -44,9 +44,9 @@ inference = ed.KLqp({w: qw, b: qb}, data={X: X_train, y: y_train})
 inference.run(n_samples=5, n_iter=250)
 
 # CRITICISM
-y_post = ed.copy(y, {w: qw.mean(), b: qb.mean()})
+y_post = ed.copy(y, {w: qw, b: qb})
 # This is equivalent to
-# y_post = Normal(mu=ed.dot(X, qw.mean()) + qb.mean(), sigma=tf.ones(N))
+# y_post = Normal(mu=ed.dot(X, qw) + qb, sigma=tf.ones(N))
 
 print("Mean squared error on test data:")
 print(ed.evaluate('mean_squared_error', data={X: X_test, y_post: y_test}))

--- a/examples/bayesian_linear_regression_ppc.py
+++ b/examples/bayesian_linear_regression_ppc.py
@@ -49,9 +49,9 @@ inference = ed.KLqp({w: qw, b: qb}, data={X: X_train, y: y_train})
 inference.run()
 
 # CRITICISM
-y_post = ed.copy(y, {w: qw.mean(), b: qb.mean()})
+y_post = ed.copy(y, {w: qw, b: qb})
 # This is equivalent to
-# y_post = Normal(mu=ed.dot(X, qw.mean()) + qb.mean(), sigma=tf.ones(N))
+# y_post = Normal(mu=ed.dot(X, qw) + qb, sigma=tf.ones(N))
 
 print("Mean squared error on test data:")
 print(ed.evaluate('mean_squared_error', data={X: X_test, y_post: y_test}))

--- a/examples/bayesian_linear_regression_sghmc.py
+++ b/examples/bayesian_linear_regression_sghmc.py
@@ -59,9 +59,9 @@ sns.jointplot(qb.params.eval()[nburn:T:stride],
 plt.show()
 
 # Posterior predictive checks.
-y_post = ed.copy(y, {w: qw.mean(), b: qb.mean()})
+y_post = ed.copy(y, {w: qw, b: qb})
 # This is equivalent to
-# y_post = Normal(mu=ed.dot(X, qw.mean()) + qb.mean(), sigma=tf.ones(N))
+# y_post = Normal(mu=ed.dot(X, qw) + qb, sigma=tf.ones(N))
 
 print("Mean squared error on test data:")
 print(ed.evaluate('mean_squared_error', data={X: X_test, y_post: y_test}))

--- a/examples/beta_bernoulli_ppc.py
+++ b/examples/beta_bernoulli_ppc.py
@@ -31,9 +31,5 @@ inference.run(n_iter=500)
 # CRITICISM
 x_post = ed.copy(x, {p: qp})
 
-
-def T(xs, zs):
-  return tf.reduce_mean(tf.cast(xs[x_post], tf.float32))
-
-
-print(ed.ppc(T, data={x_post: x_data}))
+print(ed.ppc(lambda xs, zs: tf.reduce_mean(tf.cast(xs[x_post], tf.float32)),
+             data={x_post: x_data}))

--- a/examples/linear_mixed_effects_model.py
+++ b/examples/linear_mixed_effects_model.py
@@ -127,12 +127,6 @@ qdept_mean = q_eta_dept.mean()
 qmu_mean = qmu.mean()
 qservice_mean = qservice.mean()
 
-y_post = ed.copy(y, {mu: qmu_mean,
-                 service: qservice_mean,
-                 eta_s: qs_mean,
-                 eta_d: qd_mean,
-                 eta_dept: qdept_mean})
-
 service_X_test = tf.placeholder(tf.float32, [n_obs_test, 1])
 yhat_test = tf.gather(qs_mean, s_test) + \
     tf.gather(qd_mean, d_test) + \

--- a/examples/tf_beta_bernoulli_ppc.py
+++ b/examples/tf_beta_bernoulli_ppc.py
@@ -27,10 +27,6 @@ class BetaBernoulli:
     return {'x': bernoulli.sample(p=tf.ones(10) * zs['p'])}
 
 
-def T(xs, zs):
-  return tf.reduce_mean(tf.cast(xs['x'], tf.float32))
-
-
 ed.set_seed(42)
 data = {'x': np.array([0, 1, 0, 0, 0, 0, 0, 0, 0, 1])}
 
@@ -43,4 +39,5 @@ qp = Beta(a=qp_a, b=qp_b)
 inference = ed.KLqp({'p': qp}, data, model)
 inference.run(n_iter=200)
 
-print(ed.ppc(T, data, latent_vars={'p': qp}, model_wrapper=model))
+print(ed.ppc(lambda xs, zs: tf.reduce_mean(tf.cast(xs['x'], tf.float32)),
+             data, latent_vars={'p': qp}, model_wrapper=model))

--- a/examples/tf_beta_bernoulli_prior_predictive_check.py
+++ b/examples/tf_beta_bernoulli_prior_predictive_check.py
@@ -31,10 +31,6 @@ class BetaBernoulli:
     return {'x': bernoulli.sample(p=tf.ones(10) * zs['p'])}
 
 
-def T(xs, zs):
-  return tf.reduce_mean(tf.cast(xs['x'], tf.float32))
-
-
 ed.set_seed(42)
 data = {'x': np.array([0, 1, 0, 0, 0, 0, 0, 0, 0, 1])}
 
@@ -47,4 +43,5 @@ qp = Beta(a=qp_a, b=qp_b)
 inference = ed.KLqp({'p': qp}, data, model)
 inference.run(n_iter=200)
 
-print(ed.ppc(T, data, model_wrapper=model))
+print(ed.ppc(lambda xs, zs: tf.reduce_mean(tf.cast(xs['x'], tf.float32)),
+             data, model_wrapper=model))

--- a/tests/test-criticisms/test_evaluate.py
+++ b/tests/test-criticisms/test_evaluate.py
@@ -1,0 +1,62 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import edward as ed
+import numpy as np
+import tensorflow as tf
+
+from edward.models import Normal
+
+
+class test_evaluate_class(tf.test.TestCase):
+
+  def test_metrics(self):
+    tf.InteractiveSession()
+    x = Normal(mu=0.0, sigma=1.0)
+    x_data = tf.constant(0.0)
+    ed.evaluate('mean_squared_error', {x: x_data}, n_samples=1)
+    ed.evaluate(['mean_squared_error'], {x: x_data}, n_samples=1)
+    ed.evaluate(['mean_squared_error', 'mean_absolute_error'],
+                {x: x_data}, n_samples=1)
+    self.assertRaises(NotImplementedError, ed.evaluate, 'hello world',
+                      {x: x_data}, n_samples=1)
+
+  def test_data(self):
+    tf.InteractiveSession()
+    x_ph = tf.placeholder(tf.float32, [])
+    x = Normal(mu=x_ph, sigma=1.0)
+    y = 2.0 * Normal(mu=0.0, sigma=1.0)
+    x_data = tf.constant(0.0)
+    x_ph_data = np.array(0.0)
+    y_data = tf.constant(20.0)
+    ed.evaluate('mean_squared_error', {x: x_data, x_ph: x_ph_data},
+                n_samples=1)
+    ed.evaluate('mean_squared_error', {y: y_data}, n_samples=1)
+
+  def test_n_samples(self):
+    tf.InteractiveSession()
+    x = Normal(mu=0.0, sigma=1.0)
+    x_data = tf.constant(0.0)
+    ed.evaluate('mean_squared_error', {x: x_data}, n_samples=1)
+    ed.evaluate('mean_squared_error', {x: x_data}, n_samples=50)
+
+  def test_output_key(self):
+    tf.InteractiveSession()
+    x_ph = tf.placeholder(tf.float32, [])
+    x = Normal(mu=x_ph, sigma=1.0)
+    y = 2.0 * x
+    x_data = tf.constant(0.0)
+    x_ph_data = np.array(0.0)
+    y_data = tf.constant(20.0)
+    ed.evaluate('mean_squared_error', {x: x_data, x_ph: x_ph_data},
+                n_samples=1)
+    ed.evaluate('mean_squared_error', {y: y_data, x_ph: x_ph_data},
+                n_samples=1)
+    ed.evaluate('mean_squared_error', {x: x_data, y: y_data, x_ph: x_ph_data},
+                n_samples=1, output_key=x)
+    self.assertRaises(KeyError, ed.evaluate, 'mean_squared_error',
+                      {x: x_data, y: y_data, x_ph: x_ph_data}, n_samples=1)
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tests/test-criticisms/test_ppc.py
+++ b/tests/test-criticisms/test_ppc.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import edward as ed
+import tensorflow as tf
+
+from edward.models import Normal
+
+
+class test_ppc_class(tf.test.TestCase):
+
+  def test_data(self):
+    tf.InteractiveSession()
+    x = Normal(mu=0.0, sigma=1.0)
+    y = 2.0 * x
+    x_data = tf.constant(0.0)
+    y_data = tf.constant(0.0)
+    ed.ppc(lambda xs, zs: tf.reduce_mean(xs[x]), {x: x_data}, n_samples=1)
+    ed.ppc(lambda xs, zs: tf.reduce_mean(xs[y]), {y: y_data}, n_samples=1)
+
+  def test_latent_vars(self):
+    tf.InteractiveSession()
+    x = Normal(mu=0.0, sigma=1.0)
+    y = 2.0 * x
+    z = Normal(mu=0.0, sigma=1.0)
+    x_data = tf.constant(0.0)
+    y_data = tf.constant(0.0)
+    ed.ppc(lambda xs, zs: tf.reduce_mean(xs[x]) + tf.reduce_mean(zs[z]),
+           {x: x_data}, {z: z}, n_samples=1)
+    ed.ppc(lambda xs, zs: tf.reduce_mean(xs[x]) + tf.reduce_mean(zs[z]),
+           {x: x_data}, {z: y}, n_samples=1)
+    ed.ppc(lambda xs, zs: tf.reduce_mean(xs[x]) + tf.reduce_mean(zs[y]),
+           {x: x_data}, {y: y}, n_samples=1)
+    ed.ppc(lambda xs, zs: tf.reduce_mean(xs[x]) + tf.reduce_mean(zs[y]),
+           {x: x_data}, {y: z}, n_samples=1)
+
+  def test_n_samples(self):
+    tf.InteractiveSession()
+    x = Normal(mu=0.0, sigma=1.0)
+    x_data = tf.constant(0.0)
+    ed.ppc(lambda xs, zs: tf.reduce_mean(xs[x]), {x: x_data}, n_samples=1)
+    ed.ppc(lambda xs, zs: tf.reduce_mean(xs[x]), {x: x_data}, n_samples=10)
+
+if __name__ == '__main__':
+  tf.test.main()


### PR DESCRIPTION
A number of miscellaneous but fundamental improvements are made to Edward's criticism module.

1. `ed.evaluate` now does proper Monte Carlo for estimating posterior predictive means and (log) posterior predictive densities. To make this somewhat accurate, the default number of samples is now `n_samples=500`. In this move, I encourage using `copy()` to swap prior and posterior latent variables, but never to swap the prior with _just_ the posterior mean.

2. Both `ed.evaluate` and `ed.ppc` can work with implicit latent variables and implicit observed variables. This is done as part of the move to fully support implicit probabilistic models.

3. The key to the `latent_vars` argument in `ed.ppc` are now random variables and not strings.

4. I added unit tests.