### PR TITLE
Let Inference work with tf.Tensor latent variables and observed variables

### DIFF
--- a/edward/inferences/inference.py
+++ b/edward/inferences/inference.py
@@ -24,12 +24,15 @@ class Inference(object):
 
   Attributes
   ----------
-  latent_vars : dict of RandomVariable to RandomVariable
-    Collection of random variables to perform inference on. Each
-    random variable is binded to another random variable; the latter
-    will infer the former conditional on data.
+  latent_vars : dict
+    Collection of latent variables (of type ``RandomVariable`` or
+    ``tf.Tensor``) to perform inference on. Each random variable is
+    binded to another random variable; the latter will infer the
+    former conditional on data.
   data : dict
-    Data dictionary whose values may vary at each session run.
+    Data dictionary which binds observed variables (of type
+    ``RandomVariable`` or ``tf.Tensor``) to their realizations (of
+    type ``tf.Tensor``).
   model_wrapper : ed.Model or None
     An optional wrapper for the probability model. If specified, the
     random variables in ``latent_vars``' dictionary keys are strings
@@ -40,10 +43,11 @@ class Inference(object):
 
     Parameters
     ----------
-    latent_vars : dict of RandomVariable to RandomVariable, optional
-      Collection of random variables to perform inference on. Each
-      random variable is binded to another random variable; the latter
-      will infer the former conditional on data.
+    latent_vars : dict, optional
+      Collection of latent variables (of type ``RandomVariable`` or
+      ``tf.Tensor``) to perform inference on. Each random variable is
+      binded to another random variable; the latter will infer the
+      former conditional on data.
     data : dict, optional
       Data dictionary which binds observed variables (of type
       ``RandomVariable`` or ``tf.Tensor``) to their realizations (of
@@ -92,10 +96,9 @@ class Inference(object):
       raise TypeError()
 
     for key, value in six.iteritems(latent_vars):
-      if isinstance(value, RandomVariable):
-        if isinstance(key, RandomVariable):
-          if not key.value().get_shape().is_compatible_with(
-                  value.value().get_shape()):
+      if isinstance(value, RandomVariable) or isinstance(value, tf.Tensor):
+        if isinstance(key, RandomVariable) or isinstance(key, tf.Tensor):
+          if not key.get_shape().is_compatible_with(value.get_shape()):
             raise TypeError("Latent variable bindings do not have same shape.")
         elif not isinstance(key, str):
           raise TypeError("Latent variable key has an invalid type.")
@@ -119,16 +122,15 @@ class Inference(object):
     else:
       self.data = {}
       for key, value in six.iteritems(data):
-        if isinstance(key, RandomVariable):
+        if isinstance(key, RandomVariable) or isinstance(key, tf.Tensor):
           if isinstance(value, tf.Tensor):
-            if not key.value().get_shape().is_compatible_with(
-                    value.get_shape()):
+            if not key.get_shape().is_compatible_with(value.get_shape()):
               raise TypeError("Observed variable bindings do not have same "
                               "shape.")
 
             self.data[key] = tf.cast(value, tf.float32)
           elif isinstance(value, np.ndarray):
-            if not key.value().get_shape().is_compatible_with(value.shape):
+            if not key.get_shape().is_compatible_with(value.shape):
               raise TypeError("Observed variable bindings do not have same "
                               "shape.")
 
@@ -145,8 +147,7 @@ class Inference(object):
             self.data[key] = var
             sess.run(var.initializer, {ph: value})
           elif isinstance(value, RandomVariable):
-            if not key.value().get_shape().is_compatible_with(
-                    value.value().get_shape()):
+            if not key.get_shape().is_compatible_with(value.get_shape()):
               raise TypeError("Observed variable bindings do not have same "
                               "shape.")
 
@@ -190,7 +191,7 @@ class Inference(object):
         elif (have_theano and
                 isinstance(key, theano.tensor.sharedvar.TensorSharedVariable)):
           self.data[key] = value
-        elif isinstance(key, tf.Tensor):
+        elif isinstance(key, tf.Tensor) and "Placeholder" in key.op.type:
           if isinstance(value, RandomVariable):
             raise TypeError("Data placeholder cannot be bound to a "
                             "RandomVariable.")

--- a/edward/inferences/map.py
+++ b/edward/inferences/map.py
@@ -55,7 +55,7 @@ class MAP(VariationalInference):
       list, each random variable will be implictly optimized
       using a ``PointMass`` random variable that is defined
       internally (with unconstrained support). If dictionary, each
-      random variable must be a ``PointMass`` random variable.
+      value in the dictionary must be a ``PointMass`` random variable.
 
     Examples
     --------

--- a/edward/inferences/monte_carlo.py
+++ b/edward/inferences/monte_carlo.py
@@ -19,13 +19,13 @@ class MonteCarlo(Inference):
 
     Parameters
     ----------
-    latent_vars : list of RandomVariable or
-                  dict of RandomVariable to RandomVariable
-      Collection of random variables to perform inference on. If
-      list, each random variable will be implictly approximated
-      using a ``Empirical`` random variable that is defined
-      internally (with unconstrained support). If dictionary, each
-      random variable must be a ``Empirical`` random variable.
+    latent_vars : list or dict, optional
+      Collection of random variables (of type ``RandomVariable`` or
+      ``tf.Tensor``) to perform inference on. If list, each random
+      variable will be approximated using a ``Empirical`` random
+      variable that is defined internally (with unconstrained
+      support). If dictionary, each value in the dictionary must be a
+      ``Empirical`` random variable.
     data : dict, optional
       Data dictionary which binds observed variables (of type
       ``RandomVariable`` or ``tf.Tensor``) to their realizations (of

--- a/examples/gan_wasserstein.py
+++ b/examples/gan_wasserstein.py
@@ -77,7 +77,7 @@ inference = ed.WGANInference(
     data={x: x_ph}, discriminator=discriminative_network)
 inference.initialize(
     optimizer=optimizer, optimizer_d=optimizer,
-    n_iter=15000 * 6, n_print=1000 * 6)
+    n_iter=15000, n_print=1000)
 
 sess = ed.get_session()
 tf.global_variables_initializer().run()
@@ -85,7 +85,7 @@ tf.global_variables_initializer().run()
 idx = np.random.randint(M, size=16)
 i = 0
 for t in range(inference.n_iter):
-  if (t * 6) % inference.n_print == 0:
+  if t % inference.n_print == 0:
     samples = sess.run(x)
     samples = samples[idx, ]
 
@@ -102,4 +102,5 @@ for t in range(inference.n_iter):
   info_dict = inference.update(feed_dict={x_ph: x_batch}, variables="Gen")
   # note: not printing discriminative objective; ``info_dict`` above
   # does not store it since updating only "Gen"
+  info_dict['t'] = info_dict['t'] // 6  # say set of 6 updates is 1 iteration
   inference.print_progress(info_dict)

--- a/tests/test-inferences/test_inference.py
+++ b/tests/test-inferences/test_inference.py
@@ -27,9 +27,9 @@ class test_inference_class(tf.test.TestCase):
     qmu_misshape = Normal(mu=tf.constant([0.0]), sigma=tf.constant([1.0]))
 
     ed.Inference({mu: qmu})
+    ed.Inference({mu: tf.constant(0.0)})
+    ed.Inference({tf.constant(0.0): qmu})
     self.assertRaises(TypeError, ed.Inference, {mu: '5'})
-    self.assertRaises(TypeError, ed.Inference, {mu: tf.constant(0.0)})
-    self.assertRaises(TypeError, ed.Inference, {tf.constant(0.0): qmu})
     self.assertRaises(TypeError, ed.Inference, {mu: qmu_misshape})
 
   def test_data(self):
@@ -49,6 +49,7 @@ class test_inference_class(tf.test.TestCase):
     ed.Inference(data={x: False})  # converted to `int`
     ed.Inference(data={x: x_ph})
     ed.Inference(data={x: qx})
+    ed.Inference(data={2.0 * x: tf.constant(0.0)})
     self.assertRaises(TypeError, ed.Inference, data={5: tf.constant(0.0)})
     self.assertRaises(TypeError, ed.Inference, data={x: tf.zeros(5)})
     self.assertRaises(TypeError, ed.Inference, data={x_ph: x})


### PR DESCRIPTION
+ issues | fixes #444 

This is part of the move to fully support implicit probabilistic models. In implicit models, the output is a `tf.Tensor`, based on some function of noise (a `RandomVariable`).  To do this, `Inference` should support use of `tf.Tensor` types both for data (as in `GANInference`) as well as for latent variables (as in research I'm doing now).