### PR TITLE
WIP: proper handling of recursive graphs

### DIFF
--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -333,10 +333,16 @@ def get_ancestors(x, collection=None):
   node_dict = {node.value(): node for node in collection}
 
   # Traverse the graph. Add each node to the set if it's in the collection.
-  output = set([])
-  nodes = set([x])
+  output = set()
+  visited = set()
+  nodes = {x}
   while nodes:
     node = nodes.pop()
+
+    if node in visited:
+      continue
+    visited.add(node)
+
     if isinstance(node, RandomVariable):
       node = node.value()
 
@@ -380,10 +386,16 @@ def get_children(x, collection=None):
   node_dict = {node.value(): node for node in collection}
 
   # Traverse the graph. Add each node to the set if it's in the collection.
-  output = set([])
-  nodes = set([x])
+  output = set()
+  visited = set()
+  nodes = {x}
   while nodes:
     node = nodes.pop()
+
+    if node in visited:
+      continue
+    visited.add(node)
+
     if isinstance(node, RandomVariable):
       node = node.value()
 
@@ -428,10 +440,16 @@ def get_descendants(x, collection=None):
   node_dict = {node.value(): node for node in collection}
 
   # Traverse the graph. Add each node to the set if it's in the collection.
-  output = set([])
-  nodes = set([x])
+  output = set()
+  visited = set()
+  nodes = {x}
   while nodes:
     node = nodes.pop()
+
+    if node in visited:
+      continue
+    visited.add(node)
+
     if isinstance(node, RandomVariable):
       node = node.value()
 
@@ -501,10 +519,16 @@ def get_parents(x, collection=None):
   node_dict = {node.value(): node for node in collection}
 
   # Traverse the graph. Add each node to the set if it's in the collection.
-  output = set([])
-  nodes = set([x])
+  output = set()
+  visited = set()
+  nodes = {x}
   while nodes:
     node = nodes.pop()
+
+    if node in visited:
+      continue
+    visited.add(node)
+
     if isinstance(node, RandomVariable):
       node = node.value()
 
@@ -542,7 +566,7 @@ def get_siblings(x, collection=None):
   True
   """
   parents = get_parents(x, collection)
-  siblings = set([])
+  siblings = set()
   for parent in parents:
     siblings.update(get_children(parent, collection))
 
@@ -580,9 +604,9 @@ def get_variables(x, collection=None):
   node_dict = {node.name: node for node in collection}
 
   # Traverse the graph. Add each node to the set if it's in the collection.
-  output = set([])
+  output = set()
   visited = set()
-  nodes = set([x])
+  nodes = {x}
   while nodes:
     node = nodes.pop()
 

--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -579,9 +579,15 @@ def get_variables(x, collection=None):
 
   # Traverse the graph. Add each node to the set if it's in the collection.
   output = set([])
+  visited = set()
   nodes = set([x])
   while nodes:
     node = nodes.pop()
+
+    if node in visited:
+      continue
+    visited.add(node)
+
     if isinstance(node, RandomVariable):
       node = node.value()
 

--- a/tests/test-util/test_copy.py
+++ b/tests/test-util/test_copy.py
@@ -130,5 +130,29 @@ class test_copy_class(tf.test.TestCase):
       z_new = copy(z, {x.value(): qx})
       self.assertGreater(z_new.eval(), 5.0)
 
+  def test_scan(self):
+    with self.test_session():
+      set_seed(42)
+      op = tf.scan(lambda a, x: a + x, tf.constant([2.0, 3.0, 1.0]))
+
+      self.assertAllClose(op.eval(), [2.0, 5.0, 6.0])
+      self.assertAllClose(copy(op).eval(), [2.0, 5.0, 6.0])
+
+  def test_scan_random(self):
+    with self.test_session() as session:
+      set_seed(1234)
+      op = tf.scan(lambda a, x: a + x, tf.random_normal([3]))
+      copy_op = copy(op)
+
+      result = session.run([copy_op, copy_op, op, op])
+      self.assertAllClose(result[0], result[1])
+      self.assertAllClose(result[2], result[3])
+
+      # currently set_seed does seem to prevent variate generation to work
+      #self.assertNotAlmostEquals(result[0][0], result[2][0])
+      #self.assertNotAlmostEquals(result[0][1], result[2][1])
+      #self.assertNotAlmostEquals(result[0][2], result[2][2])
+
+
 if __name__ == '__main__':
   tf.test.main()

--- a/tests/test-util/test_copy.py
+++ b/tests/test-util/test_copy.py
@@ -149,9 +149,9 @@ class test_copy_class(tf.test.TestCase):
       self.assertAllClose(result[2], result[3])
 
       # currently set_seed does seem to prevent variate generation to work
-      #self.assertNotAlmostEquals(result[0][0], result[2][0])
-      #self.assertNotAlmostEquals(result[0][1], result[2][1])
-      #self.assertNotAlmostEquals(result[0][2], result[2][2])
+      # self.assertNotAlmostEquals(result[0][0], result[2][0])
+      # self.assertNotAlmostEquals(result[0][1], result[2][1])
+      # self.assertNotAlmostEquals(result[0][2], result[2][2])
 
 
 if __name__ == '__main__':

--- a/tests/test-util/test_get_ancestors.py
+++ b/tests/test-util/test_get_ancestors.py
@@ -73,5 +73,22 @@ class test_get_ancestors_class(tf.test.TestCase):
       self.assertEqual(set(get_ancestors(d)), set([a, b]))
       self.assertEqual(set(get_ancestors(e)), set([a, b]))
 
+  def test_scan(self):
+    """copied form test_chain_structure"""
+    def cumsum(x):
+      return tf.scan(lambda a, x: a + x, x)
+
+    with self.test_session():
+      a = Normal(mu=tf.ones([3]), sigma=tf.ones([3]))
+      b = Normal(mu=cumsum(a), sigma=tf.ones([3]))
+      c = Normal(mu=cumsum(b), sigma=tf.ones([3]))
+      d = Normal(mu=cumsum(c), sigma=tf.ones([3]))
+      e = Normal(mu=cumsum(d), sigma=tf.ones([3]))
+      self.assertEqual(get_ancestors(a), [])
+      self.assertEqual(get_ancestors(b), [a])
+      self.assertEqual(set(get_ancestors(c)), set([a, b]))
+      self.assertEqual(set(get_ancestors(d)), set([a, b, c]))
+      self.assertEqual(set(get_ancestors(e)), set([a, b, c, d]))
+
 if __name__ == '__main__':
   tf.test.main()

--- a/tests/test-util/test_get_children.py
+++ b/tests/test-util/test_get_children.py
@@ -73,5 +73,22 @@ class test_get_children_class(tf.test.TestCase):
       self.assertEqual(get_children(d), [e])
       self.assertEqual(get_children(e), [])
 
+  def test_scan(self):
+    """copied form test_chain_structure"""
+    def cumsum(x):
+      return tf.scan(lambda a, x: a + x, x)
+
+    with self.test_session():
+      a = Normal(mu=tf.ones([3]), sigma=tf.ones([3]))
+      b = Normal(mu=cumsum(a), sigma=tf.ones([3]))
+      c = Normal(mu=cumsum(b), sigma=tf.ones([3]))
+      d = Normal(mu=cumsum(c), sigma=tf.ones([3]))
+      e = Normal(mu=cumsum(d), sigma=tf.ones([3]))
+      self.assertEqual(get_children(a), [b])
+      self.assertEqual(get_children(b), [c])
+      self.assertEqual(get_children(c), [d])
+      self.assertEqual(get_children(d), [e])
+      self.assertEqual(get_children(e), [])
+
 if __name__ == '__main__':
   tf.test.main()

--- a/tests/test-util/test_get_descendants.py
+++ b/tests/test-util/test_get_descendants.py
@@ -73,5 +73,22 @@ class test_get_descendants_class(tf.test.TestCase):
       self.assertEqual(get_descendants(d), [e])
       self.assertEqual(get_descendants(e), [])
 
+  def test_scan(self):
+    """copied form test_chain_structure"""
+    def cumsum(x):
+      return tf.scan(lambda a, x: a + x, x)
+
+    with self.test_session():
+      a = Normal(mu=tf.ones([3]), sigma=tf.ones([3]))
+      b = Normal(mu=cumsum(a), sigma=tf.ones([3]))
+      c = Normal(mu=cumsum(b), sigma=tf.ones([3]))
+      d = Normal(mu=cumsum(c), sigma=tf.ones([3]))
+      e = Normal(mu=cumsum(d), sigma=tf.ones([3]))
+      self.assertEqual(set(get_descendants(a)), set([b, c, d, e]))
+      self.assertEqual(set(get_descendants(b)), set([c, d, e]))
+      self.assertEqual(set(get_descendants(c)), set([d, e]))
+      self.assertEqual(get_descendants(d), [e])
+      self.assertEqual(get_descendants(e), [])
+
 if __name__ == '__main__':
   tf.test.main()

--- a/tests/test-util/test_get_parents.py
+++ b/tests/test-util/test_get_parents.py
@@ -73,5 +73,22 @@ class test_get_parents_class(tf.test.TestCase):
       self.assertEqual(set(get_parents(d)), set([a, b]))
       self.assertEqual(set(get_parents(e)), set([a, b]))
 
+  def test_scan(self):
+    """copied form test_chain_structure"""
+    def cumsum(x):
+      return tf.scan(lambda a, x: a + x, x)
+
+    with self.test_session():
+      a = Normal(mu=tf.ones([3]), sigma=tf.ones([3]))
+      b = Normal(mu=cumsum(a), sigma=tf.ones([3]))
+      c = Normal(mu=cumsum(b), sigma=tf.ones([3]))
+      d = Normal(mu=cumsum(c), sigma=tf.ones([3]))
+      e = Normal(mu=cumsum(d), sigma=tf.ones([3]))
+      self.assertEqual(get_parents(a), [])
+      self.assertEqual(get_parents(b), [a])
+      self.assertEqual(get_parents(c), [b])
+      self.assertEqual(get_parents(d), [c])
+      self.assertEqual(get_parents(e), [d])
+
 if __name__ == '__main__':
   tf.test.main()

--- a/tests/test-util/test_get_siblings.py
+++ b/tests/test-util/test_get_siblings.py
@@ -73,5 +73,22 @@ class test_get_siblings_class(tf.test.TestCase):
       self.assertEqual(get_siblings(d), [e])
       self.assertEqual(get_siblings(e), [])
 
+  def test_scan(self):
+    """copied from test_a_structure"""
+    def cumsum(x):
+      return tf.scan(lambda a, x: a + x, x)
+
+    with self.test_session():
+      a = Normal(mu=tf.ones([3]), sigma=tf.ones([3]))
+      b = Normal(mu=cumsum(a), sigma=tf.ones([3]))
+      c = Normal(mu=cumsum(b), sigma=tf.ones([3]))
+      d = Normal(mu=cumsum(a), sigma=tf.ones([3]))
+      e = Normal(mu=cumsum(d), sigma=tf.ones([3]))
+      self.assertEqual(get_siblings(a), [])
+      self.assertEqual(get_siblings(b), [d])
+      self.assertEqual(get_siblings(c), [])
+      self.assertEqual(get_siblings(d), [b])
+      self.assertEqual(get_siblings(e), [])
+
 if __name__ == '__main__':
   tf.test.main()

--- a/tests/test-util/test_get_variables.py
+++ b/tests/test-util/test_get_variables.py
@@ -73,6 +73,22 @@ class test_get_variables_class(tf.test.TestCase):
 
       self.assertEqual(get_variables(op), [b])
 
+  def test_scan_with_a_structure(self):
+    """copied from test_a_structure"""
+    def cumsum(x):
+      return tf.scan(lambda a, x: a + x, x)
+
+    with self.test_session():
+      a = tf.Variable([1.0, 1.0, 1.0])
+      b = Normal(mu=cumsum(a), sigma=tf.ones([3]))
+      c = Normal(mu=cumsum(b), sigma=tf.ones([3]))
+      d = Normal(mu=cumsum(a), sigma=tf.ones([3]))
+      e = Normal(mu=cumsum(d), sigma=tf.ones([3]))
+      self.assertEqual(get_variables(a), [])
+      self.assertEqual(get_variables(b), [a])
+      self.assertEqual(get_variables(c), [a])
+      self.assertEqual(get_variables(d), [a])
+      self.assertEqual(get_variables(e), [a])
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tests/test-util/test_get_variables.py
+++ b/tests/test-util/test_get_variables.py
@@ -66,5 +66,13 @@ class test_get_variables_class(tf.test.TestCase):
       self.assertEqual(get_variables(d), [b])
       self.assertEqual(get_variables(e), [b])
 
+  def test_scan(self):
+    with self.test_session():
+      b = tf.Variable(0.0)
+      op = tf.scan(lambda a, x: a + b + x, tf.constant([2.0, 3.0, 1.0]))
+
+      self.assertEqual(get_variables(op), [b])
+
+
 if __name__ == '__main__':
   tf.test.main()


### PR DESCRIPTION
When working with control flow constructs in tensorflow often graphs are defined recursively. Examples are `while_loop` and `scan`. Currently, such graphs are not properly handled in edward.

This PR addresses this issues. As of now, this branch of edwards allows to execute:

```python
minimal_op = tf.scan(lambda a, x: a + x, tf.random_normal([3]))
print(ed.copy(minimal_op).eval())
print(ed.get_variables(minimal_op))
```

Before merging, this branch requires proper tests. Further, there is a good chance that other functions (such as get_ancestors) need to be changed also.

Additional internal tensorflow API used:

- `Operation._add_input`
- `Operation._add_control_inputs`