### PR TITLE
sess.run() and eval() can work directly on RandomVariable's

### DIFF
--- a/docs/tex/api/model-compositionality.tex
+++ b/docs/tex/api/model-compositionality.tex
@@ -41,9 +41,9 @@ Computational graph for a Beta-Bernoulli program.
 }}
 
 The random variable \texttt{x} ($\mathbf{x}$) is 50-dimensional,
-parameterized by the random tensor $\theta^*$. Fetching the object
-\texttt{x.value()} ($\mathbf{x}^*$) from session runs the graph: it simulates from
-the generative process and outputs a binary vector of $50$ elements.
+parameterized by the random tensor $\theta^*$. Fetching \texttt{x}
+from a session runs the graph: it simulates from the generative process
+and outputs a binary vector ($\mathbf{x}^*$) of $50$ elements.
 
 With computational graphs, it is also natural to build mutable states
 within the probabilistic program. As a typical use of computational
@@ -122,7 +122,7 @@ from edward.models import Bernoulli, Normal
 from keras.layers import Dense
 
 z = Normal(mu=tf.zeros([N, d]), sigma=tf.ones([N, d]))
-h = Dense(256, activation='relu')(z.value())
+h = Dense(256, activation='relu')(z)
 x = Bernoulli(logits=Dense(28 * 28)(h))
 \end{lstlisting}
 

--- a/docs/tex/api/model-development.tex
+++ b/docs/tex/api/model-development.tex
@@ -67,9 +67,9 @@ Poisson._sample_n = _sample_n
 
 sess = ed.get_session()
 x = Poisson(lam=1.0)
-sess.run(x.value())
+sess.run(x)
 ## 1.0
-sess.run(x.value())
+sess.run(x)
 ## 4.0
 \end{lstlisting}
 

--- a/edward/models/random_variable.py
+++ b/edward/models/random_variable.py
@@ -4,6 +4,9 @@ from __future__ import print_function
 
 import tensorflow as tf
 
+from tensorflow.python.client.session import \
+    register_session_run_conversion_functions
+
 RANDOM_VARIABLE_COLLECTION = "_random_variable_collection_"
 
 
@@ -179,6 +182,36 @@ class RandomVariable(object):
   def __eq__(self, other):
     return id(self) == id(other)
 
+  def eval(self, session=None, feed_dict=None):
+    """In a session, computes and returns the value of this random variable.
+
+    This is not a graph construction method, it does not add ops to the graph.
+
+    This convenience method requires a session where the graph
+    containing this variable has been launched. If no session is
+    passed, the default session is used.
+
+    Parameters
+    ----------
+    session : tf.BaseSession, optional
+      The ``tf.Session`` to use to evaluate this random variable. If
+      none, the default session is used.
+    feed_dict : dict, optional
+      A dictionary that maps `Tensor` objects to feed values. See
+      ``tf.Session.run()`` for a description of the valid feed values.
+
+    Examples
+    --------
+    >>> x = Normal(0.0, 1.0)
+    >>> with tf.Session() as sess:
+    >>>   # Usage passing the session explicitly.
+    >>>   print(x.eval(sess))
+    >>>   # Usage with the default session.  The 'with' block
+    >>>   # above makes 'sess' the default session.
+    >>>   print(x.eval())
+    """
+    return self.value().eval(session=session, feed_dict=feed_dict)
+
   def value(self):
     """Get tensor that the random variable corresponds to."""
     return self._value
@@ -217,6 +250,15 @@ class RandomVariable(object):
     """Get shape of random variable."""
     return self._value.get_shape()
 
+  def _session_run_conversion_fetch_function(tensor):
+    return ([tensor.value()], lambda val: val[0])
+
+  def _session_run_conversion_feed_function(feed, feed_val):
+    return [(feed.value(), feed_val)]
+
+  def _session_run_conversion_feed_function_for_partial_run(feed):
+    return [feed.value()]
+
   def _tensor_conversion_function(v, dtype=None, name=None, as_ref=False):
     _ = name
     if dtype and not dtype.is_compatible_with(v.dtype):
@@ -227,6 +269,12 @@ class RandomVariable(object):
       raise ValueError("%s: Ref type is not supported." % v)
     return v.value()
 
+
+register_session_run_conversion_functions(
+    RandomVariable,
+    RandomVariable._session_run_conversion_fetch_function,
+    RandomVariable._session_run_conversion_feed_function,
+    RandomVariable._session_run_conversion_feed_function_for_partial_run)
 
 tf.register_tensor_conversion_function(
     RandomVariable, RandomVariable._tensor_conversion_function)

--- a/examples/factor_analysis.py
+++ b/examples/factor_analysis.py
@@ -88,6 +88,6 @@ for epoch in range(n_epoch):
   print("log p(x) >= {:0.3f}".format(avg_loss))
 
   # Prior predictive check.
-  imgs = x.value().eval()
+  imgs = x.eval()
   for m in range(N):
     imsave(os.path.join(IMG_DIR, '%d.png') % m, imgs[m].reshape(28, 28))

--- a/examples/pp_dynamic_shape.py
+++ b/examples/pp_dynamic_shape.py
@@ -25,8 +25,8 @@ n = 1 + tf.cast(Exponential(lam=0.5), tf.int32)
 p = Dirichlet(alpha=tf.ones([n]) * alpha)
 
 sess = ed.get_session()
-print(sess.run(p.value()))
+print(sess.run(p))
 # [ 0.01012419  0.02939712  0.05036638  0.51287931  0.31020424  0.0485355
 #   0.0384932 ]
-print(sess.run(p.value()))
+print(sess.run(p))
 # [ 0.12836078  0.23335715  0.63828212]

--- a/examples/vae.py
+++ b/examples/vae.py
@@ -77,6 +77,6 @@ for epoch in range(n_epoch):
   print("log p(x) >= {:0.3f}".format(avg_loss))
 
   # Prior predictive check.
-  imgs = sess.run(x.value())
+  imgs = sess.run(x)
   for m in range(M):
     imsave(os.path.join(IMG_DIR, '%d.png') % m, imgs[m].reshape(28, 28))

--- a/examples/vae_convolutional.py
+++ b/examples/vae_convolutional.py
@@ -77,7 +77,7 @@ mnist = input_data.read_data_sets(DATA_DIR, one_hot=True)
 
 # MODEL
 z = Normal(mu=tf.zeros([M, d]), sigma=tf.ones([M, d]))
-logits = generative_network(z.value())
+logits = generative_network(z)
 x = Bernoulli(logits=logits)
 
 # INFERENCE

--- a/examples/vae_convolutional_prettytensor.py
+++ b/examples/vae_convolutional_prettytensor.py
@@ -77,7 +77,7 @@ mnist = input_data.read_data_sets(DATA_DIR, one_hot=True)
 
 # MODEL
 z = Normal(mu=tf.zeros([M, d]), sigma=tf.ones([M, d]))
-logits = generative_network(z.value())
+logits = generative_network(z)
 x = Bernoulli(logits=logits)
 
 # INFERENCE

--- a/tests/test-models/test_random_variable_session.py
+++ b/tests/test-models/test_random_variable_session.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import edward as ed
+import tensorflow as tf
+
+from edward.models import Normal
+
+
+class test_random_variable_session_class(tf.test.TestCase):
+
+  def test_eval(self):
+    with self.test_session() as sess:
+      x = Normal(mu=0.0, sigma=0.1)
+      x_ph = tf.placeholder(tf.float32, [])
+      y = Normal(mu=x_ph, sigma=0.1)
+      self.assertLess(x.eval(), 5.0)
+      self.assertLess(x.eval(sess), 5.0)
+      self.assertLess(x.eval(feed_dict={x_ph: 100.0}), 5.0)
+      self.assertGreater(y.eval(feed_dict={x_ph: 100.0}), 5.0)
+      self.assertGreater(y.eval(sess, feed_dict={x_ph: 100.0}), 5.0)
+      self.assertRaises(tf.errors.InvalidArgumentError, y.eval)
+      self.assertRaises(tf.errors.InvalidArgumentError, y.eval, sess)
+
+  def test_run(self):
+    with self.test_session() as sess:
+      x = Normal(mu=0.0, sigma=0.1)
+      x_ph = tf.placeholder(tf.float32, [])
+      y = Normal(mu=x_ph, sigma=0.1)
+      self.assertLess(sess.run(x), 5.0)
+      self.assertLess(sess.run(x, feed_dict={x_ph: 100.0}), 5.0)
+      self.assertGreater(sess.run(y, feed_dict={x_ph: 100.0}), 5.0)
+      self.assertRaises(tf.errors.InvalidArgumentError, sess.run, y)
+
+if __name__ == '__main__':
+  ed.set_seed(82341)
+  tf.test.main()


### PR DESCRIPTION
Title. The magic comes from TensorFlow's `register_session_run_conversion_functions`. (I found this function out of sheer coincidence after browsing TensorFlow internals. It is not directly exposed in the API.)

For example, you can now do the following:
```python
from edward.models import Normal

x = Normal(0.0, 1.0)

sess = ed.get_session()
sess.run(x)
## 0.088767856
x.eval()
## 1.0179992

x_ph = tf.placeholder(tf.float32, [])
y = Normal(x_ph, 1.0)

sess.run(y, feed_dict={x_ph: 100.0})
## 100.72381
y.eval(feed_dict={x_ph: 100.0})
## 101.87513
```
Previously you had to call `.value()`—a minor nuisance.