### PR TITLE
Use pytest instead of py.test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
     fi
   - python setup.py install
 script:
-  - PYTHONPATH=$PWD:$PYTHONPATH py.test --cov=./ --pep8;
+  - PYTHONPATH=$PWD:$PYTHONPATH pytest --cov=./ --pep8;
 
 after_success:
   - coveralls

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -28,7 +28,7 @@ notebook: build
 	$(DOCKER) run -it -v $(SRC):/src -v $(DATA):/data --net=host edward
 
 test: build
-	$(DOCKER) run -it -v $(SRC):/src -v $(DATA):/data edward py.test $(TEST)
+	$(DOCKER) run -it -v $(SRC):/src -v $(DATA):/data edward pytest $(TEST)
 
 # GPU environment
 
@@ -53,5 +53,5 @@ notebook-gpu: build-gpu
 test-gpu: build-gpu
 	$(DOCKER_GPU) run -it -v $(SRC):/src -v $(DATA):/data --env CUDA_HOME=${CUDA} \
 	                                                  --env LD_LIBRARY_PATH=${LD_LIBRARY} \
-	                                                  edward-gpu py.test $(TEST)
+	                                                  edward-gpu pytest $(TEST)
 

--- a/docs/tex/contributing.tex
+++ b/docs/tex/contributing.tex
@@ -85,9 +85,10 @@ Follow
 \href{https://www.tensorflow.org/versions/master/api_docs/python/test.html}
 {TensorFlow's testing guide}.
 To run the unit tests, we use
-\href{http://doc.pytest.org/}{py.test}:
-run \texttt{py.test tests/}.
-To run specific unit tests, call \texttt{py.test} individually, e.g., \texttt{py.test tests/test_metrics.py}.
+\href{http://doc.pytest.org/}{pytest}:
+run \texttt{pytest tests/} in command line.
+To run specific unit tests, call \texttt{pytest} individually, e.g.,
+\texttt{pytest tests/test_metrics.py}.
 
 Submit the pull request whenever you're ready. You can also submit an
 incomplete pull request to get intermediate feedback.

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
                     'tensorflow with gpu': ['tensorflow-gpu>=1.0.0a0'],
                     'neural networks': ['keras>=1.0.0', 'prettytensor>=0.7.4'],
                     'visualization': ['progressbar>=2.0', 'pillow>=3.4.2']},
+    tests_require=['pytest', 'pytest-pep8'],
     url='http://edwardlib.org',
     license='Apache License 2.0',
     classifiers=['License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
Since pytest 3.0, `pytest` is the recommended command over `py.test`. See https://github.com/pytest-dev/pytest/issues/1629#issue-161422224.