### PR TITLE
Change {{sphinx to {%sphinx, {tensor... to {{tensor... in docs

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -196,7 +196,7 @@ def generate_docstrings(page_data):
   page_name = page_data['page'][:-4]
   path = os.path.join('build/html/', page_name + '.html')
   document = open(path).read()
-  docstrings = re.findall(r'(?<=<p>{{sphinx</p>)(.*?)(?=<p>}}</p>)',
+  docstrings = re.findall(r'(?<=<p>{%sphinx</p>)(.*?)(?=<p>%}</p>)',
                           document, flags=re.DOTALL)
   if docstrings is None:
     docstrings = []
@@ -273,14 +273,14 @@ for page_data in PAGES:
   document = document.replace('{{navbar}}', navbar)
 
   for i in range(len(docstrings)):
-    document = re.sub(r'(?<={{sphinx)(.*?)(?=}})', "",
+    document = re.sub(r'(?<={%sphinx)(.*?)(?=%})', "",
                       document, count=1, flags=re.DOTALL)
-    document = document.replace('{{sphinx}}', docstrings[i])
+    document = document.replace('{%sphinx%}', docstrings[i])
 
   # note: this tag is part of the sphinx section,
   #       use single quotes to avoid clash
-  if '{tensorflow_distributions}' in document:
-    document = document.replace('{tensorflow_distributions}',
+  if '{{tensorflow_distributions}}' in document:
+    document = document.replace('{{tensorflow_distributions}}',
                                 generate_tensorflow_distributions())
 
   if '{{tensorflow_version}}' in document:

--- a/docs/tex/api/criticism.tex
+++ b/docs/tex/api/criticism.tex
@@ -37,12 +37,12 @@ Edward explores model criticism using
 
 \begin{center}\rule{3in}{0.4pt}\end{center}
 
-{{sphinx
+{%sphinx
 
 .. automodule:: edward.criticisms
    :members: evaluate,
              ppc
 
-}}
+%}
 
 \subsubsection{References}\label{references}

--- a/docs/tex/api/inference-classes.tex
+++ b/docs/tex/api/inference-classes.tex
@@ -135,7 +135,7 @@ The classes below inherit methods from base inference classes;
 see the \href{/api/inference-development}{development page} for more
 details.
 
-{{sphinx
+{%sphinx
 
 .. autoclass:: edward.inferences.VariationalInference
    :members:
@@ -188,6 +188,6 @@ details.
 .. autoclass:: edward.inferences.SGHMC
    :members:
 
-}}
+%}
 
 \subsubsection{References}\label{references}

--- a/docs/tex/api/inference.tex
+++ b/docs/tex/api/inference.tex
@@ -149,9 +149,9 @@ the latent variables; it uses samples from the prior.
 
 \begin{center}\rule{3in}{0.4pt}\end{center}
 
-{{sphinx
+{%sphinx
 
 .. autoclass:: edward.inferences.Inference
    :members:
 
-}}
+%}

--- a/docs/tex/api/model.tex
+++ b/docs/tex/api/model.tex
@@ -78,7 +78,7 @@ Edward random variables build on top of them, inheriting the same
 arguments and class methods. Additional methods are also available,
 detailed below.
 
-{{sphinx
+{%sphinx
 
 .. autoclass:: edward.models.RandomVariable
    :members:
@@ -87,4 +87,4 @@ detailed below.
 
 .. class:: edward.models.PointMass
 
-}}
+%}

--- a/docs/tex/api/reference.tex
+++ b/docs/tex/api/reference.tex
@@ -9,18 +9,18 @@ Therefore the list of available models depends on the TensorFlow version
 installed. For TensorFlow {{tensorflow_version}}, the following models are
 available:
 
-{{sphinx
+{%sphinx
 
 * :class:`edward.models.RandomVariable`
 * :class:`edward.models.Empirical`
 * :class:`edward.models.PointMass`
-* {tensorflow_distributions}
+* {{tensorflow_distributions}}
 
-}}
+%}
 
 \subsubsection{Inference}
 
-{{sphinx
+{%sphinx
 
 * :class:`edward.inferences.Inference`
 * :class:`edward.inferences.VariationalInference`
@@ -53,13 +53,13 @@ available:
   * :class:`edward.inferences.SGLD`
   * :class:`edward.inferences.SGHMC`
 
-}}
+%}
 
 \subsubsection{Criticism}
 
-{{sphinx
+{%sphinx
 
 * :func:`edward.criticisms.evaluate`
 * :func:`edward.criticisms.ppc`
 
-}}
+%}


### PR DESCRIPTION
As discussed in #536, this PR changes `{{sphinx` into `{%sphinx`.  By using `{%sphinx` as the marker for sphinx sections, variables inside the these sections can use double braces. Currently this change only affects the `{{tensorflow_distributions}}`` variable. However, it should make it easier to move code between sphinx and latex blocks in the future.

Possible side effects could be caused by the fact that `%` is the latex comment character. However, since all `{%sphinx` occurrences are replaced before the docs are passed to pandoc this shouldn't be an issue.