### PR TITLE
Make miscellaneous updates to custom random variables in Edward

### DIFF
--- a/edward/inferences/monte_carlo.py
+++ b/edward/inferences/monte_carlo.py
@@ -79,7 +79,7 @@ class MonteCarlo(Inference):
     super(MonteCarlo, self).__init__(latent_vars, data)
 
   def initialize(self, *args, **kwargs):
-    kwargs['n_iter'] = np.amin([qz.n for
+    kwargs['n_iter'] = np.amin([qz.params.get_shape().as_list()[0] for
                                 qz in six.itervalues(self.latent_vars)])
     super(MonteCarlo, self).initialize(*args, **kwargs)
 

--- a/edward/models/dirichlet_process.py
+++ b/edward/models/dirichlet_process.py
@@ -40,6 +40,8 @@ class DirichletProcess(RandomVariable, Distribution):
     ...                       Exponential, lam=tf.ones([5, 3]))
     >>> assert dp.get_shape() == (2, 5, 3)
     """
+    parameters = locals()
+    parameters.pop("self")
     with tf.name_scope(name, values=[alpha]) as ns:
       with tf.control_dependencies([]):
         self._alpha = tf.identity(alpha, name="alpha")
@@ -55,14 +57,12 @@ class DirichletProcess(RandomVariable, Distribution):
 
         super(DirichletProcess, self).__init__(
             dtype=tf.int32,
-            parameters={"alpha": self._alpha,
-                        "base_cls": self._base_cls,
-                        "args": self._base_args,
-                        "kwargs": self._base_kwargs},
             is_continuous=False,
             is_reparameterized=False,
             validate_args=validate_args,
             allow_nan_stats=allow_nan_stats,
+            parameters=parameters,
+            graph_parents=[self._alpha, self._theta],
             name=ns,
             value=value)
 

--- a/edward/models/dirichlet_process.py
+++ b/edward/models/dirichlet_process.py
@@ -82,7 +82,7 @@ class DirichletProcess(RandomVariable, Distribution):
     return tf.convert_to_tensor(self.get_batch_shape())
 
   def _get_batch_shape(self):
-    return self._alpha.get_shape()
+    return self.alpha.get_shape()
 
   def _event_shape(self):
     return tf.convert_to_tensor(self.get_event_shape())

--- a/edward/models/dirichlet_process.py
+++ b/edward/models/dirichlet_process.py
@@ -79,13 +79,13 @@ class DirichletProcess(RandomVariable, Distribution):
     return self._theta
 
   def _batch_shape(self):
-    return tf.convert_to_tensor(self.get_batch_shape())
+    return tf.shape(self.alpha)
 
   def _get_batch_shape(self):
     return self.alpha.get_shape()
 
   def _event_shape(self):
-    return tf.convert_to_tensor(self.get_event_shape())
+    return tf.shape(self._base)
 
   def _get_event_shape(self):
     return self._base.get_shape()

--- a/edward/models/empirical.py
+++ b/edward/models/empirical.py
@@ -48,13 +48,13 @@ class Empirical(RandomVariable, Distribution):
     return self._n
 
   def _batch_shape(self):
-    return tf.convert_to_tensor(self.get_batch_shape())
+    return tf.constant([], dtype=tf.int32)
 
   def _get_batch_shape(self):
     return tf.TensorShape([])
 
   def _event_shape(self):
-    return tf.convert_to_tensor(self.get_event_shape())
+    return tf.shape(self.params)[1:]
 
   def _get_event_shape(self):
     return self.params.get_shape()[1:]

--- a/edward/models/empirical.py
+++ b/edward/models/empirical.py
@@ -57,21 +57,21 @@ class Empirical(RandomVariable, Distribution):
     return tf.convert_to_tensor(self.get_event_shape())
 
   def _get_event_shape(self):
-    return self._params.get_shape()[1:]
+    return self.params.get_shape()[1:]
 
   def _mean(self):
-    return tf.reduce_mean(self._params, 0)
+    return tf.reduce_mean(self.params, 0)
 
   def _std(self):
-    # broadcasting T x shape - shape = T x shape
-    r = self._params - self.mean()
+    # broadcasting n x shape - shape = n x shape
+    r = self.params - self.mean()
     return tf.sqrt(tf.reduce_mean(tf.square(r), 0))
 
   def _variance(self):
     return tf.square(self.std())
 
   def _sample_n(self, n, seed=None):
-    input_tensor = self._params
+    input_tensor = self.params
     if len(input_tensor.get_shape()) == 0:
       input_tensor = tf.expand_dims(input_tensor, 0)
       multiples = tf.concat(

--- a/edward/models/point_mass.py
+++ b/edward/models/point_mass.py
@@ -43,13 +43,13 @@ class PointMass(RandomVariable, Distribution):
     return self._params
 
   def _batch_shape(self):
-    return tf.convert_to_tensor(self.get_batch_shape())
+    return tf.constant([], dtype=tf.int32)
 
   def _get_batch_shape(self):
     return tf.TensorShape([])
 
   def _event_shape(self):
-    return tf.convert_to_tensor(self.get_event_shape())
+    return tf.shape(self.params)
 
   def _get_event_shape(self):
     return self.params.get_shape()

--- a/edward/models/point_mass.py
+++ b/edward/models/point_mass.py
@@ -16,16 +16,19 @@ class PointMass(RandomVariable, Distribution):
   """
   def __init__(self, params, validate_args=False, allow_nan_stats=True,
                name="PointMass", *args, **kwargs):
+    parameters = locals()
+    parameters.pop("self")
     with tf.name_scope(name, values=[params]) as ns:
       with tf.control_dependencies([]):
         self._params = tf.identity(params, name="params")
         super(PointMass, self).__init__(
             dtype=self._params.dtype,
-            parameters={"params": self._params},
             is_continuous=False,
             is_reparameterized=True,
             validate_args=validate_args,
             allow_nan_stats=allow_nan_stats,
+            parameters=parameters,
+            graph_parents=[self._params],
             name=ns,
             *args, **kwargs)
 

--- a/edward/models/point_mass.py
+++ b/edward/models/point_mass.py
@@ -52,19 +52,19 @@ class PointMass(RandomVariable, Distribution):
     return tf.convert_to_tensor(self.get_event_shape())
 
   def _get_event_shape(self):
-    return self._params.get_shape()
+    return self.params.get_shape()
 
   def _mean(self):
-    return self._params
+    return self.params
 
   def _std(self):
-    return 0.0 * tf.ones_like(self._params)
+    return 0.0 * tf.ones_like(self.params)
 
   def _variance(self):
     return tf.square(self.std())
 
   def _sample_n(self, n, seed=None):
-    input_tensor = self._params
+    input_tensor = self.params
     input_tensor = tf.expand_dims(input_tensor, 0)
     multiples = tf.concat(
         [tf.expand_dims(n, 0), [1] * len(self.get_event_shape())], 0)


### PR DESCRIPTION
This
+ makes `n` in Empirical a `tf.Tensor` rather than an `int`;
+ properly defines `parameters` and `graph_parents` in `__init__`;
+ allows for dynamic shapes when calling `event_shape()` and `batch_shape()`;
+ uses class properties instead of hidden members to access elements.