### PR TITLE
Move all tf distribution imports within try/except block

### DIFF
--- a/docs/tex/troubleshooting.tex
+++ b/docs/tex/troubleshooting.tex
@@ -12,11 +12,16 @@ Edward depends on
   \item TensorFlow (>=1.0.0a0)
 \end{itemize}
 
-We recommend using \texttt{pip} to install \texttt{numpy},
-\texttt{six}, and \texttt{tensorflow} as
+Installing \texttt{edward} by default also installs \texttt{numpy} and
+\texttt{six} if they are not available (or are out-of-date in your
+system).
+
+Installing \texttt{edward} does not automatically install TensorFlow
+(or update an existing TensorFlow version). We recommend installing
+it via
 
 \begin{lstlisting}[language=JSON]
-pip install numpy six tensorflow
+pip install tensorflow
 \end{lstlisting}
 
 To use Edward with GPUs, install \texttt{tensorflow-gpu} instead of
@@ -28,7 +33,7 @@ pip install tensorflow-gpu
 
 See TensorFlow's
 \href{https://www.tensorflow.org/install/}{installation instructions}
-for details on how to setup up NVIDIA software for TensorFlow with GPUs.
+for details, including how to setup up NVIDIA software for TensorFlow with GPUs.
 
 \subsubsection{Full Installation}
 

--- a/edward/inferences/hmc.py
+++ b/edward/inferences/hmc.py
@@ -7,8 +7,13 @@ import tensorflow as tf
 
 from collections import OrderedDict
 from edward.inferences.monte_carlo import MonteCarlo
-from edward.models import Normal, RandomVariable, Uniform
+from edward.models import RandomVariable
 from edward.util import copy
+
+try:
+  from edward.models import Normal, Uniform
+except Exception as e:
+  raise ImportError("{0}. Your TensorFlow version is not supported.".format(e))
 
 
 class HMC(MonteCarlo):

--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -6,8 +6,13 @@ import six
 import tensorflow as tf
 
 from edward.inferences.variational_inference import VariationalInference
-from edward.models import RandomVariable, Normal
+from edward.models import RandomVariable
 from edward.util import copy
+
+try:
+  from edward.models import Normal
+except Exception as e:
+  raise ImportError("{0}. Your TensorFlow version is not supported.".format(e))
 
 
 class KLpq(VariationalInference):

--- a/edward/inferences/klqp.py
+++ b/edward/inferences/klqp.py
@@ -6,9 +6,14 @@ import six
 import tensorflow as tf
 
 from edward.inferences.variational_inference import VariationalInference
-from edward.models import RandomVariable, Normal
+from edward.models import RandomVariable
 from edward.util import copy
 from tensorflow.contrib import distributions as ds
+
+try:
+  from edward.models import Normal
+except Exception as e:
+  raise ImportError("{0}. Your TensorFlow version is not supported.".format(e))
 
 
 class KLqp(VariationalInference):

--- a/edward/inferences/laplace.py
+++ b/edward/inferences/laplace.py
@@ -6,10 +6,14 @@ import six
 import tensorflow as tf
 
 from edward.inferences.map import MAP
-from edward.models import \
-    MultivariateNormalCholesky, MultivariateNormalDiag, \
-    MultivariateNormalFull, PointMass, RandomVariable
+from edward.models import PointMass, RandomVariable
 from edward.util import get_session, get_variables
+
+try:
+  from edward.models import \
+      MultivariateNormalCholesky, MultivariateNormalDiag, MultivariateNormalFull
+except Exception as e:
+  raise ImportError("{0}. Your TensorFlow version is not supported.".format(e))
 
 
 class Laplace(MAP):

--- a/edward/inferences/metropolis_hastings.py
+++ b/edward/inferences/metropolis_hastings.py
@@ -7,8 +7,13 @@ import tensorflow as tf
 
 from collections import OrderedDict
 from edward.inferences.monte_carlo import MonteCarlo
-from edward.models import RandomVariable, Uniform
+from edward.models import RandomVariable
 from edward.util import copy
+
+try:
+  from edward.models import Uniform
+except Exception as e:
+  raise ImportError("{0}. Your TensorFlow version is not supported.".format(e))
 
 
 class MetropolisHastings(MonteCarlo):

--- a/edward/inferences/sghmc.py
+++ b/edward/inferences/sghmc.py
@@ -6,8 +6,13 @@ import six
 import tensorflow as tf
 
 from edward.inferences.monte_carlo import MonteCarlo
-from edward.models import Normal, RandomVariable, Empirical
+from edward.models import RandomVariable, Empirical
 from edward.util import copy
+
+try:
+  from edward.models import Normal
+except Exception as e:
+  raise ImportError("{0}. Your TensorFlow version is not supported.".format(e))
 
 
 class SGHMC(MonteCarlo):

--- a/edward/inferences/sgld.py
+++ b/edward/inferences/sgld.py
@@ -6,8 +6,13 @@ import six
 import tensorflow as tf
 
 from edward.inferences.monte_carlo import MonteCarlo
-from edward.models import Normal, RandomVariable
+from edward.models import RandomVariable
 from edward.util import copy
+
+try:
+  from edward.models import Normal
+except Exception as e:
+  raise ImportError("{0}. Your TensorFlow version is not supported.".format(e))
 
 
 class SGLD(MonteCarlo):

--- a/edward/models/dirichlet_process.py
+++ b/edward/models/dirichlet_process.py
@@ -5,8 +5,12 @@ from __future__ import print_function
 import tensorflow as tf
 
 from edward.models.random_variable import RandomVariable
-from edward.models.random_variables import Bernoulli, Beta
 from tensorflow.contrib.distributions import Distribution
+
+try:
+  from edward.models.random_variables import Bernoulli, Beta
+except Exception as e:
+  raise ImportError("{0}. Your TensorFlow version is not supported.".format(e))
 
 
 class DirichletProcess(RandomVariable, Distribution):

--- a/edward/models/random_variable.py
+++ b/edward/models/random_variable.py
@@ -4,8 +4,11 @@ from __future__ import print_function
 
 import tensorflow as tf
 
-from tensorflow.python.client.session import \
-    register_session_run_conversion_functions
+try:
+  from tensorflow.python.client.session import \
+      register_session_run_conversion_functions
+except Exception as e:
+  raise ImportError("{0}. Your TensorFlow version is not supported.".format(e))
 
 RANDOM_VARIABLE_COLLECTION = "_random_variable_collection_"
 


### PR DESCRIPTION
We autogenerate random variables from `tensorflow.contrib.distributions`, thus relying on specific TensorFlow versions. This provides a more informative message if the user does not have a supported TensorFlow version, thus making installation issues (https://github.com/blei-lab/edward/pull/569#issuecomment-288028868, #568) easier to solve.

Remarks
+ Ideally this would be caught during installation of Edward in `setup.py`, but due to the `tensorflow`/`tensorflow-gpu` dichotomy we cannot explicitly depend on a TensorFlow version.
+ This is not testable with Travis unless we use an outdated TensorFlow version just for this test; that's too impractical to have for all integration testing.