### PR TITLE
Memoise beta, the stick breaking proportions of a DP

### DIFF
--- a/edward/models/dirichlet_process.py
+++ b/edward/models/dirichlet_process.py
@@ -54,13 +54,16 @@ class DirichletProcess(RandomVariable, Distribution):
         # Create empty tensor to store future atoms.
         self._theta = tf.zeros(
             [0] +
-            self.get_batch_shape().as_list() +
-            self.get_event_shape().as_list())
+              self.get_batch_shape().as_list() +
+              self.get_event_shape().as_list(),
+            dtype=self._base.dtype)
 
         # Instantiate beta distribution for stick breaking proportions.
         self._betadist = Beta(a=tf.ones_like(self.alpha), b=self.alpha)
         # Create empty tensor to store stick breaking proportions.
-        self._beta = tf.zeros([0] + self.get_batch_shape().as_list())
+        self._beta = tf.zeros(
+            [0] + self.get_batch_shape().as_list(),
+            dtype=self._betadist.dtype)
 
         super(DirichletProcess, self).__init__(
             dtype=tf.int32,
@@ -147,7 +150,7 @@ class DirichletProcess(RandomVariable, Distribution):
     bools = tf.ones([n] + self.get_batch_shape().as_list(), dtype=tf.bool)
 
     # Initialize all samples as zero, they will be overwritten in any case
-    draws = tf.zeros([n] + batch_shape + event_shape)
+    draws = tf.zeros([n] + batch_shape + event_shape, dtype=self._base.dtype)
 
     # Calculate shape invariance conditions for theta and beta as these
     # can change shape between loop iterations.

--- a/edward/models/dirichlet_process.py
+++ b/edward/models/dirichlet_process.py
@@ -38,7 +38,7 @@ class DirichletProcess(RandomVariable, Distribution):
     >>>
     >>> # vector of concentration parameters, matrix of Exponentials
     >>> dp = DirichletProcess(tf.constant([0.1, 0.4]),
-        ...                       Exponential, lam=tf.ones([5, 3]))
+    ...                       Exponential, lam=tf.ones([5, 3]))
     >>> assert dp.get_shape() == (2, 5, 3)
     """
     parameters = locals()
@@ -52,15 +52,15 @@ class DirichletProcess(RandomVariable, Distribution):
 
         # Instantiate base distribution.
         self._base = self._base_cls(*self._base_args, **self._base_kwargs)
-        # Create empty tensor to store future atoms
+        # Create empty tensor to store future atoms.
         self._theta = tf.zeros(
             [0] +
             self.get_batch_shape().as_list() +
             self.get_event_shape().as_list())
 
-        # Instantiate beta distribution for stick breaking proportions
+        # Instantiate beta distribution for stick breaking proportions.
         self._betadist = Beta(a=tf.ones_like(self.alpha), b=self.alpha)
-        # Create empty tensor to store stick breaking proportions
+        # Create empty tensor to store stick breaking proportions.
         self._beta = tf.zeros([0] + self.get_batch_shape().as_list())
 
         super(DirichletProcess, self).__init__(

--- a/edward/models/dirichlet_process.py
+++ b/edward/models/dirichlet_process.py
@@ -10,8 +10,9 @@ from tensorflow.contrib.distributions import Distribution
 
 
 class DirichletProcess(RandomVariable, Distribution):
-  def __init__(self, alpha, base_cls, validate_args=False, allow_nan_stats=True,
-               name="DirichletProcess", value=None, *args, **kwargs):
+  def __init__(
+          self, alpha, base_cls, validate_args=False, allow_nan_stats=True,
+          name="DirichletProcess", value=None, *args, **kwargs):
     """Dirichlet process :math:`\mathcal{DP}(\\alpha, H)`.
 
     It has two parameters: a positive real value :math:`\\alpha`,
@@ -161,7 +162,8 @@ class DirichletProcess(RandomVariable, Distribution):
     _, _, self._theta, self._beta, samples = tf.while_loop(
         self._sample_n_cond, self._sample_n_body,
         loop_vars=[k, bools, self.theta, self.beta, draws],
-        shape_invariants=[k.shape, bools.shape, theta_shape, beta_shape, draws.shape])
+        shape_invariants=[
+            k.shape, bools.shape, theta_shape, beta_shape, draws.shape])
 
     return samples
 
@@ -178,10 +180,10 @@ class DirichletProcess(RandomVariable, Distribution):
         tf.shape(theta)[0] - 1 >= k,
         lambda: (theta, beta),
         lambda: (
-          tf.concat(
-            [theta, tf.expand_dims(self._base.sample(batch_shape), 0)], 0),
-          tf.concat(
-            [beta, tf.expand_dims(self._betadist.sample(), 0)], 0)))
+            tf.concat(
+                [theta, tf.expand_dims(self._base.sample(batch_shape), 0)], 0),
+            tf.concat(
+                [beta, tf.expand_dims(self._betadist.sample(), 0)], 0)))
     theta_k = tf.gather(theta, k)
     beta_k = tf.gather(beta, k)
 
@@ -194,8 +196,8 @@ class DirichletProcess(RandomVariable, Distribution):
       # Therefore we tile ``bools`` to be of shape
       # (n, batch_shape, event_shape) in order to index per-element.
       bools_tile = tf.tile(tf.reshape(
-        bools, [n] + batch_shape + [1] * len(event_shape)),
-        [1] + [1] * len(batch_shape) + event_shape)
+          bools, [n] + batch_shape + [1] * len(event_shape)),
+          [1] + [1] * len(batch_shape) + event_shape)
 
     theta_k_tile = tf.tile(tf.expand_dims(theta_k, 0), [n] + [1] * (rank - 1))
     draws = tf.where(bools_tile, theta_k_tile, draws)

--- a/edward/models/dirichlet_process.py
+++ b/edward/models/dirichlet_process.py
@@ -201,7 +201,7 @@ class DirichletProcess(RandomVariable, Distribution):
     theta_k_tile = tf.tile(tf.expand_dims(theta_k, 0), [n] + [1] * (rank - 1))
     draws = tf.where(bools_tile, theta_k_tile, draws)
 
-    # Draw new stick probability, then flip coins.
+    # Flip coins according to stick probabilities.
     flips = Bernoulli(p=beta_k).sample(n)
     # If coin lands heads, assign sample's corresponding bool to False
     # (this ends its "while loop").

--- a/edward/models/dirichlet_process.py
+++ b/edward/models/dirichlet_process.py
@@ -8,7 +8,6 @@ from edward.models.random_variable import RandomVariable
 from edward.models.random_variables import Bernoulli, Beta
 from tensorflow.contrib.distributions import Distribution
 
-
 class DirichletProcess(RandomVariable, Distribution):
   def __init__(self, alpha, base_cls, validate_args=False, allow_nan_stats=True,
                name="DirichletProcess", value=None, *args, **kwargs):
@@ -51,17 +50,20 @@ class DirichletProcess(RandomVariable, Distribution):
 
         # Instantiate base distribution.
         self._base = self._base_cls(*self._base_args, **self._base_kwargs)
-        # Define atoms of Dirichlet process, storing only the first as default.
-        self._theta = tf.expand_dims(
-            self._base.sample(self.get_batch_shape()), 0)
+        # Create empty tensor to store future atoms in
+        self._theta = tf.zeros(
+            [0] + self.get_batch_shape().as_list() +
+            self.get_event_shape().as_list())
+        # self._theta = tf.expand_dims(
+            # self._base.sample(self.get_batch_shape()), 0)
 
         # Instantiate beta distribution for stick breaking proportions
         self._betadist = Beta(a=tf.ones_like(self.alpha), b=self.alpha)
-        # Define atoms of Dirichlet process, storing only the first as default.
-        self._beta = tf.expand_dims(self._betadist.sample(), 0)
+        # Create empty tensor to store stick breaking proportions
+        self._beta = tf.zeros([0] + self.get_batch_shape().as_list())
 
         super(DirichletProcess, self).__init__(
-            dtype=tf.int32,
+            dtype=tf.float32,
             is_continuous=False,
             is_reparameterized=False,
             validate_args=validate_args,
@@ -135,50 +137,52 @@ class DirichletProcess(RandomVariable, Distribution):
     # Note this is for scoping within the while loop's body function.
     self._temp_scope = [n, batch_shape, event_shape, rank]
 
+    # Start at the beginning of the stick, i.e. the k'th index
     k = tf.constant(0)
 
-    # Draw stick probability, then flip coin; perform this for each
-    # sample and each DP in the batch shape. It has shape (n, batch_shape).
-    beta_k = Beta(a=tf.ones_like(self.alpha), b=self.alpha).sample(n)
-    flips = Bernoulli(p=beta_k)
     # Define boolean tensor. It is True for samples that require continuing
     # the while loop and False for samples that can receive their base
     # distribution (coin lands heads).
-    bools = tf.cast(1 - flips, tf.bool)
+    bools = tf.ones([n] + self.get_batch_shape().as_list(), dtype=tf.bool)
 
-    # Extract base distribution. It has shape (batch_shape, event_shape).
-    theta = self.theta
-    theta_k = tf.gather(theta, k)
+    # Initialize all samples as zero, they will be overwritten in any case
+    draws = tf.zeros([n] + batch_shape + event_shape)
 
-    # Initialize all samples as the first base distribution.
-    draws = tf.tile(tf.expand_dims(theta_k, 0), [n] + [1] * (rank - 1))
-
+    # Calculate shape invariance conditions for theta and beta as these
+    # can change shape between loop iterations.
     theta_shape = tf.TensorShape([None])
-    if len(theta.shape) > 1:
-      theta_shape = theta_shape.concatenate(theta.shape[1:])
+    beta_shape = tf.TensorShape([None])
+    if len(self.theta.shape) > 1:
+      theta_shape = theta_shape.concatenate(self.theta.shape[1:])
+      beta_shape = beta_shape.concatenate(self.beta.shape[1:])
 
-    _, _, self._theta, samples = tf.while_loop(
+    # While we have not broken enough sticks, keep sampling.
+    _, _, self._theta, self._beta, samples = tf.while_loop(
         self._sample_n_cond, self._sample_n_body,
-        loop_vars=[k, bools, theta, draws],
-        shape_invariants=[k.shape, bools.shape, theta_shape, draws.shape])
+        loop_vars=[k, bools, self.theta, self.beta, draws],
+        shape_invariants=[k.shape, bools.shape, theta_shape, beta_shape, draws.shape])
 
     return samples
 
-  def _sample_n_cond(self, k, bools, theta, draws):
+  def _sample_n_cond(self, k, bools, theta, beta, draws):
     # Proceed if at least one bool is True.
     return tf.reduce_any(bools)
 
-  def _sample_n_body(self, k, bools, theta, draws):
+  def _sample_n_body(self, k, bools, theta, beta, draws):
     n, batch_shape, event_shape, rank = self._temp_scope
-    k += 1
 
-    # If necessary, add a new persistent state to theta.
-    theta = tf.cond(
+    # If necessary, break a new piece of stick, i.e.
+    # add a new persistent atom to theta and sample another beta
+    theta, beta = tf.cond(
         tf.shape(theta)[0] - 1 >= k,
-        lambda: theta,
-        lambda: tf.concat(
-            [theta, tf.expand_dims(self._base.sample(batch_shape), 0)], 0))
+        lambda: (theta, beta),
+        lambda: (
+            tf.concat(
+                [theta, tf.expand_dims(self._base.sample(batch_shape), 0)], 0),
+            tf.concat(
+                [beta, tf.expand_dims(self._betadist.sample(), 0)], 0)))
     theta_k = tf.gather(theta, k)
+    beta_k = tf.gather(beta, k)
 
     # Assign True samples to the new theta_k.
     if len(bools.get_shape()) <= 1:
@@ -195,10 +199,9 @@ class DirichletProcess(RandomVariable, Distribution):
     theta_k_tile = tf.tile(tf.expand_dims(theta_k, 0), [n] + [1] * (rank - 1))
     draws = tf.where(bools_tile, theta_k_tile, draws)
 
-    # Draw new stick probability, then flip coin.
-    beta_k = Beta(a=tf.ones_like(self.alpha), b=self.alpha).sample(n)
-    flips = Bernoulli(p=beta_k)
+    # Draw new stick probability, then flip coins.
+    flips = Bernoulli(p=beta_k).sample(n)
     # If coin lands heads, assign sample's corresponding bool to False
     # (this ends its "while loop").
     bools = tf.where(tf.cast(flips, tf.bool), tf.zeros_like(bools), bools)
-    return k, bools, theta, draws
+    return k+1, bools, theta, beta, draws

--- a/edward/models/dirichlet_process.py
+++ b/edward/models/dirichlet_process.py
@@ -55,6 +55,11 @@ class DirichletProcess(RandomVariable, Distribution):
         self._theta = tf.expand_dims(
             self._base.sample(self.get_batch_shape()), 0)
 
+        # Instantiate beta distribution for stick breaking proportions
+        self._betadist = Beta(a=tf.ones_like(self.alpha), b=self.alpha)
+        # Define atoms of Dirichlet process, storing only the first as default.
+        self._beta = tf.expand_dims(self._betadist.sample(), 0)
+
         super(DirichletProcess, self).__init__(
             dtype=tf.int32,
             is_continuous=False,
@@ -62,7 +67,7 @@ class DirichletProcess(RandomVariable, Distribution):
             validate_args=validate_args,
             allow_nan_stats=allow_nan_stats,
             parameters=parameters,
-            graph_parents=[self._alpha, self._theta],
+            graph_parents=[self._alpha, self._theta, self._beta],
             name=ns,
             value=value)
 
@@ -70,6 +75,13 @@ class DirichletProcess(RandomVariable, Distribution):
   def alpha(self):
     """Concentration parameter."""
     return self._alpha
+
+  @property
+  def beta(self):
+    """Stick breaking proportions. It has shape [None] + batch_shape, where
+    the first dimension is the number of atoms, instantiated only as
+    needed."""
+    return self._beta
 
   @property
   def theta(self):

--- a/edward/models/dirichlet_process.py
+++ b/edward/models/dirichlet_process.py
@@ -10,9 +10,8 @@ from tensorflow.contrib.distributions import Distribution
 
 
 class DirichletProcess(RandomVariable, Distribution):
-  def __init__(
-          self, alpha, base_cls, validate_args=False, allow_nan_stats=True,
-          name="DirichletProcess", value=None, *args, **kwargs):
+  def __init__(self, alpha, base_cls, validate_args=False, allow_nan_stats=True,
+               name="DirichletProcess", value=None, *args, **kwargs):
     """Dirichlet process :math:`\mathcal{DP}(\\alpha, H)`.
 
     It has two parameters: a positive real value :math:`\\alpha`,
@@ -64,7 +63,7 @@ class DirichletProcess(RandomVariable, Distribution):
         self._beta = tf.zeros([0] + self.get_batch_shape().as_list())
 
         super(DirichletProcess, self).__init__(
-            dtype=tf.float32,
+            dtype=tf.int32,
             is_continuous=False,
             is_reparameterized=False,
             validate_args=validate_args,

--- a/edward/models/dirichlet_process.py
+++ b/edward/models/dirichlet_process.py
@@ -54,8 +54,8 @@ class DirichletProcess(RandomVariable, Distribution):
         # Create empty tensor to store future atoms.
         self._theta = tf.zeros(
             [0] +
-              self.get_batch_shape().as_list() +
-              self.get_event_shape().as_list(),
+            self.get_batch_shape().as_list() +
+            self.get_event_shape().as_list(),
             dtype=self._base.dtype)
 
         # Instantiate beta distribution for stick breaking proportions.

--- a/edward/models/dirichlet_process.py
+++ b/edward/models/dirichlet_process.py
@@ -10,202 +10,199 @@ from tensorflow.contrib.distributions import Distribution
 
 
 class DirichletProcess(RandomVariable, Distribution):
+  def __init__(self, alpha, base_cls, validate_args=False, allow_nan_stats=True,
+               name="DirichletProcess", value=None, *args, **kwargs):
+    """Dirichlet process :math:`\mathcal{DP}(\\alpha, H)`.
 
-    def __init__(
-        self, alpha, base_cls, validate_args=False, allow_nan_stats=True,
-                 name="DirichletProcess", value=None, *args, **kwargs):
-        """Dirichlet process :math:`\mathcal{DP}(\\alpha, H)`.
+    It has two parameters: a positive real value :math:`\\alpha`,
+    known as the concentration parameter (``alpha``), and a base
+    distribution :math:`H` (``base_cls(*args, **kwargs)``).
 
-        It has two parameters: a positive real value :math:`\\alpha`,
-        known as the concentration parameter (``alpha``), and a base
-        distribution :math:`H` (``base_cls(*args, **kwargs)``).
+    Parameters
+    ----------
+    alpha : tf.Tensor
+      Concentration parameter. Must be positive real-valued. Its shape
+      determines the number of independent DPs (batch shape).
+    base_cls : RandomVariable
+      Class of base distribution. Its shape (when instantiated)
+      determines the shape of an individual DP (event shape).
+    *args, **kwargs : optional
+      Arguments passed into ``base_cls``.
 
-        Parameters
-        ----------
-        alpha : tf.Tensor
-          Concentration parameter. Must be positive real-valued. Its shape
-          determines the number of independent DPs (batch shape).
-        base_cls : RandomVariable
-          Class of base distribution. Its shape (when instantiated)
-          determines the shape of an individual DP (event shape).
-        *args, **kwargs : optional
-          Arguments passed into ``base_cls``.
-
-        Examples
-        --------
-        >>> # scalar concentration parameter, scalar base distribution
-        >>> dp = DirichletProcess(0.1, Normal, mu=0.0, sigma=1.0)
-        >>> assert dp.get_shape() == ()
-        >>>
-        >>> # vector of concentration parameters, matrix of Exponentials
-        >>> dp = DirichletProcess(tf.constant([0.1, 0.4]),
+    Examples
+    --------
+    >>> # scalar concentration parameter, scalar base distribution
+    >>> dp = DirichletProcess(0.1, Normal, mu=0.0, sigma=1.0)
+    >>> assert dp.get_shape() == ()
+    >>>
+    >>> # vector of concentration parameters, matrix of Exponentials
+    >>> dp = DirichletProcess(tf.constant([0.1, 0.4]),
         ...                       Exponential, lam=tf.ones([5, 3]))
-        >>> assert dp.get_shape() == (2, 5, 3)
-        """
-        parameters = locals()
-        parameters.pop("self")
-        with tf.name_scope(name, values=[alpha]) as ns:
-            with tf.control_dependencies([]):
-                self._alpha = tf.identity(alpha, name="alpha")
-                self._base_cls = base_cls
-                self._base_args = args
-                self._base_kwargs = kwargs
+    >>> assert dp.get_shape() == (2, 5, 3)
+    """
+    parameters = locals()
+    parameters.pop("self")
+    with tf.name_scope(name, values=[alpha]) as ns:
+      with tf.control_dependencies([]):
+        self._alpha = tf.identity(alpha, name="alpha")
+        self._base_cls = base_cls
+        self._base_args = args
+        self._base_kwargs = kwargs
 
-                # Instantiate base distribution.
-                self._base = self._base_cls(
-                    *self._base_args, **self._base_kwargs)
-                # Create empty tensor to store future atoms in
-                self._theta = tf.zeros(
-                    [0] + self.get_batch_shape().as_list() +
-                    self.get_event_shape().as_list())
-                # self._theta = tf.expand_dims(
-                    # self._base.sample(self.get_batch_shape()), 0)
+        # Instantiate base distribution.
+        self._base = self._base_cls(*self._base_args, **self._base_kwargs)
+        # Create empty tensor to store future atoms
+        self._theta = tf.zeros(
+            [0] +
+            self.get_batch_shape().as_list() +
+            self.get_event_shape().as_list())
 
-                # Instantiate beta distribution for stick breaking proportions
-                self._betadist = Beta(a=tf.ones_like(self.alpha), b=self.alpha)
-                # Create empty tensor to store stick breaking proportions
-                self._beta = tf.zeros([0] + self.get_batch_shape().as_list())
+        # Instantiate beta distribution for stick breaking proportions
+        self._betadist = Beta(a=tf.ones_like(self.alpha), b=self.alpha)
+        # Create empty tensor to store stick breaking proportions
+        self._beta = tf.zeros([0] + self.get_batch_shape().as_list())
 
-                super(DirichletProcess, self).__init__(
-                    dtype=tf.float32,
-                    is_continuous=False,
-                    is_reparameterized=False,
-                    validate_args=validate_args,
-                    allow_nan_stats=allow_nan_stats,
-                    parameters=parameters,
-                    graph_parents=[self._alpha, self._theta, self._beta],
-                    name=ns,
-                    value=value)
+        super(DirichletProcess, self).__init__(
+            dtype=tf.float32,
+            is_continuous=False,
+            is_reparameterized=False,
+            validate_args=validate_args,
+            allow_nan_stats=allow_nan_stats,
+            parameters=parameters,
+            graph_parents=[self._alpha, self._theta, self._beta],
+            name=ns,
+            value=value)
 
-    @property
-    def alpha(self):
-        """Concentration parameter."""
-        return self._alpha
+  @property
+  def alpha(self):
+    """Concentration parameter."""
+    return self._alpha
 
-    @property
-    def beta(self):
-        """Stick breaking proportions. It has shape [None] + batch_shape, where
-        the first dimension is the number of atoms, instantiated only as
-        needed."""
-        return self._beta
+  @property
+  def beta(self):
+    """Stick breaking proportions. It has shape [None] + batch_shape, where
+    the first dimension is the number of atoms, instantiated only as
+    needed."""
+    return self._beta
 
-    @property
-    def theta(self):
-        """Atoms. It has shape [None] + batch_shape + event_shape, where
-        the first dimension is the number of atoms, instantiated only as
-        needed."""
-        return self._theta
+  @property
+  def theta(self):
+    """Atoms. It has shape [None] + batch_shape + event_shape, where
+    the first dimension is the number of atoms, instantiated only as
+    needed."""
+    return self._theta
 
-    def _batch_shape(self):
-        return tf.shape(self.alpha)
+  def _batch_shape(self):
+    return tf.shape(self.alpha)
 
-    def _get_batch_shape(self):
-        return self.alpha.get_shape()
+  def _get_batch_shape(self):
+    return self.alpha.get_shape()
 
-    def _event_shape(self):
-        return tf.shape(self._base)
+  def _event_shape(self):
+    return tf.shape(self._base)
 
-    def _get_event_shape(self):
-        return self._base.get_shape()
+  def _get_event_shape(self):
+    return self._base.get_shape()
 
-    def _sample_n(self, n, seed=None):
-        """Sample ``n`` draws from the DP. Draws from the base
-        distribution are memoized across ``n`` and across calls to
-        ``sample()``.
+  def _sample_n(self, n, seed=None):
+    """Sample ``n`` draws from the DP. Draws from the base
+    distribution are memoized across ``n`` and across calls to
+    ``sample()``.
 
-        Draws from the base distribution are not memoized across the batch
-        shape, i.e., each independent DP in the batch shape has its own
-        memoized samples.
+    Draws from the base distribution are not memoized across the batch
+    shape, i.e., each independent DP in the batch shape has its own
+    memoized samples.
 
-        Returns
-        -------
-        tf.Tensor
-          A ``tf.Tensor`` of shape ``[n] + batch_shape + event_shape``,
-          where ``n`` is the number of samples for each DP,
-          ``batch_shape`` is the number of independent DPs, and
-          ``event_shape`` is the shape of the base distribution.
+    Returns
+    -------
+    tf.Tensor
+      A ``tf.Tensor`` of shape ``[n] + batch_shape + event_shape``,
+      where ``n`` is the number of samples for each DP,
+      ``batch_shape`` is the number of independent DPs, and
+      ``event_shape`` is the shape of the base distribution.
 
-        Notes
-        -----
-        The implementation has one inefficiency, which is that it draws
-        (batch_shape,) samples from the base distribution when adding a
-        new persistent state. Ideally, we would only draw new samples for
-        those in the loop which require it.
-        """
-        if seed is not None:
-            raise NotImplementedError("seed is not implemented.")
+    Notes
+    -----
+    The implementation has one inefficiency, which is that it draws
+    (batch_shape,) samples from the base distribution when adding a
+    new persistent state. Ideally, we would only draw new samples for
+    those in the loop which require it.
+    """
+    if seed is not None:
+      raise NotImplementedError("seed is not implemented.")
 
-        batch_shape = self.get_batch_shape().as_list()
-        event_shape = self.get_event_shape().as_list()
-        rank = 1 + len(batch_shape) + len(event_shape)
+    batch_shape = self.get_batch_shape().as_list()
+    event_shape = self.get_event_shape().as_list()
+    rank = 1 + len(batch_shape) + len(event_shape)
+    # Note this is for scoping within the while loop's body function.
+    self._temp_scope = [n, batch_shape, event_shape, rank]
 
-        def _sample_n_cond(k, bools, theta, beta, draws):
-                # Proceed if at least one bool is True.
-            return tf.reduce_any(bools)
+    # Start at the beginning of the stick, i.e. the k'th index
+    k = tf.constant(0)
 
-        def _sample_n_body(k, bools, theta, beta, draws):
-            # If necessary, break a new piece of stick, i.e.
-            # add a new persistent atom to theta and sample another beta
-            theta, beta = tf.cond(
-                tf.shape(theta)[0] - 1 >= k,
-                lambda: (theta, beta),
-                lambda: (
-                    tf.concat(
-                        [theta, tf.expand_dims(
-                            self._base.sample(batch_shape), 0)], 0),
-                    tf.concat(
-                        [beta, tf.expand_dims(self._betadist.sample(), 0)], 0)))
-            theta_k = tf.gather(theta, k)
-            beta_k = tf.gather(beta, k)
+    # Define boolean tensor. It is True for samples that require continuing
+    # the while loop and False for samples that can receive their base
+    # distribution (coin lands heads). Also note that we need one bool for
+    # each sample
+    bools = tf.ones([n] + self.get_batch_shape().as_list(), dtype=tf.bool)
 
-            # Assign True samples to the new theta_k.
-            if len(bools.get_shape()) <= 1:
-                bools_tile = bools
-            else:
-                # ``tf.where`` only index subsets when ``bools`` is at most a
-                # vector. In general, ``bools`` has shape (n, batch_shape).
-                # Therefore we tile ``bools`` to be of shape
-                # (n, batch_shape, event_shape) in order to index per-element.
-                bools_tile = tf.tile(tf.reshape(
-                    bools, [n] + batch_shape + [1] * len(event_shape)),
-                    [1] + [1] * len(batch_shape) + event_shape)
+    # Initialize all samples as zero, they will be overwritten in any case
+    draws = tf.zeros([n] + batch_shape + event_shape)
 
-            theta_k_tile = tf.tile(
-                tf.expand_dims(theta_k, 0), [n] + [1] * (rank - 1))
-            draws = tf.where(bools_tile, theta_k_tile, draws)
+    # Calculate shape invariance conditions for theta and beta as these
+    # can change shape between loop iterations.
+    theta_shape = tf.TensorShape([None])
+    beta_shape = tf.TensorShape([None])
+    if len(self.theta.shape) > 1:
+      theta_shape = theta_shape.concatenate(self.theta.shape[1:])
+      beta_shape = beta_shape.concatenate(self.beta.shape[1:])
 
-            # Draw new stick probability, then flip coins.
-            flips = Bernoulli(p=beta_k).sample(n)
-            # If coin lands heads, assign sample's corresponding bool to False
-            # (this ends its "while loop").
-            bools = tf.where(
-                tf.cast(flips, tf.bool), tf.zeros_like(bools), bools)
-            return k + 1, bools, theta, beta, draws
+    # While we have not broken enough sticks, keep sampling.
+    _, _, self._theta, self._beta, samples = tf.while_loop(
+        self._sample_n_cond, self._sample_n_body,
+        loop_vars=[k, bools, self.theta, self.beta, draws],
+        shape_invariants=[k.shape, bools.shape, theta_shape, beta_shape, draws.shape])
 
-        # Start at the beginning of the stick, i.e. the k'th index
-        k = tf.constant(0)
+    return samples
 
-        # Define boolean tensor. It is True for samples that require continuing
-        # the while loop and False for samples that can receive their base
-        # distribution (coin lands heads).
-        bools = tf.ones([n] + self.get_batch_shape().as_list(), dtype=tf.bool)
+  def _sample_n_cond(self, k, bools, theta, beta, draws):
+    # Proceed if at least one bool is True.
+    return tf.reduce_any(bools)
 
-        # Initialize all samples as zero, they will be overwritten in any case
-        draws = tf.zeros([n] + batch_shape + event_shape)
+  def _sample_n_body(self, k, bools, theta, beta, draws):
+    n, batch_shape, event_shape, rank = self._temp_scope
 
-        # Calculate shape invariance conditions for theta and beta as these
-        # can change shape between loop iterations.
-        theta_shape = tf.TensorShape([None])
-        beta_shape = tf.TensorShape([None])
-        if len(self.theta.shape) > 1:
-            theta_shape = theta_shape.concatenate(self.theta.shape[1:])
-            beta_shape = beta_shape.concatenate(self.beta.shape[1:])
+    # If necessary, break a new piece of stick, i.e.
+    # add a new persistent atom to theta and sample another beta
+    theta, beta = tf.cond(
+        tf.shape(theta)[0] - 1 >= k,
+        lambda: (theta, beta),
+        lambda: (
+          tf.concat(
+            [theta, tf.expand_dims(self._base.sample(batch_shape), 0)], 0),
+          tf.concat(
+            [beta, tf.expand_dims(self._betadist.sample(), 0)], 0)))
+    theta_k = tf.gather(theta, k)
+    beta_k = tf.gather(beta, k)
 
-        # While we have not broken enough sticks, keep sampling.
-        _, _, self._theta, self._beta, samples = tf.while_loop(
-            _sample_n_cond,
-            _sample_n_body,
-            loop_vars=[k, bools, self.theta, self.beta, draws],
-            shape_invariants=[k.shape, bools.shape, theta_shape, beta_shape, draws.shape])
+    # Assign True samples to the new theta_k.
+    if len(bools.get_shape()) <= 1:
+      bools_tile = bools
+    else:
+      # ``tf.where`` only index subsets when ``bools`` is at most a
+      # vector. In general, ``bools`` has shape (n, batch_shape).
+      # Therefore we tile ``bools`` to be of shape
+      # (n, batch_shape, event_shape) in order to index per-element.
+      bools_tile = tf.tile(tf.reshape(
+        bools, [n] + batch_shape + [1] * len(event_shape)),
+        [1] + [1] * len(batch_shape) + event_shape)
 
-        return samples
+    theta_k_tile = tf.tile(tf.expand_dims(theta_k, 0), [n] + [1] * (rank - 1))
+    draws = tf.where(bools_tile, theta_k_tile, draws)
+
+    # Draw new stick probability, then flip coins.
+    flips = Bernoulli(p=beta_k).sample(n)
+    # If coin lands heads, assign sample's corresponding bool to False
+    # (this ends its "while loop").
+    bools = tf.where(tf.cast(flips, tf.bool), tf.zeros_like(bools), bools)
+    return k + 1, bools, theta, beta, draws

--- a/edward/models/dirichlet_process.py
+++ b/edward/models/dirichlet_process.py
@@ -8,200 +8,204 @@ from edward.models.random_variable import RandomVariable
 from edward.models.random_variables import Bernoulli, Beta
 from tensorflow.contrib.distributions import Distribution
 
+
 class DirichletProcess(RandomVariable, Distribution):
-  def __init__(self, alpha, base_cls, validate_args=False, allow_nan_stats=True,
-               name="DirichletProcess", value=None, *args, **kwargs):
-    """Dirichlet process :math:`\mathcal{DP}(\\alpha, H)`.
 
-    It has two parameters: a positive real value :math:`\\alpha`,
-    known as the concentration parameter (``alpha``), and a base
-    distribution :math:`H` (``base_cls(*args, **kwargs)``).
+    def __init__(
+        self, alpha, base_cls, validate_args=False, allow_nan_stats=True,
+                 name="DirichletProcess", value=None, *args, **kwargs):
+        """Dirichlet process :math:`\mathcal{DP}(\\alpha, H)`.
 
-    Parameters
-    ----------
-    alpha : tf.Tensor
-      Concentration parameter. Must be positive real-valued. Its shape
-      determines the number of independent DPs (batch shape).
-    base_cls : RandomVariable
-      Class of base distribution. Its shape (when instantiated)
-      determines the shape of an individual DP (event shape).
-    *args, **kwargs : optional
-      Arguments passed into ``base_cls``.
+        It has two parameters: a positive real value :math:`\\alpha`,
+        known as the concentration parameter (``alpha``), and a base
+        distribution :math:`H` (``base_cls(*args, **kwargs)``).
 
-    Examples
-    --------
-    >>> # scalar concentration parameter, scalar base distribution
-    >>> dp = DirichletProcess(0.1, Normal, mu=0.0, sigma=1.0)
-    >>> assert dp.get_shape() == ()
-    >>>
-    >>> # vector of concentration parameters, matrix of Exponentials
-    >>> dp = DirichletProcess(tf.constant([0.1, 0.4]),
-    ...                       Exponential, lam=tf.ones([5, 3]))
-    >>> assert dp.get_shape() == (2, 5, 3)
-    """
-    parameters = locals()
-    parameters.pop("self")
-    with tf.name_scope(name, values=[alpha]) as ns:
-      with tf.control_dependencies([]):
-        self._alpha = tf.identity(alpha, name="alpha")
-        self._base_cls = base_cls
-        self._base_args = args
-        self._base_kwargs = kwargs
+        Parameters
+        ----------
+        alpha : tf.Tensor
+          Concentration parameter. Must be positive real-valued. Its shape
+          determines the number of independent DPs (batch shape).
+        base_cls : RandomVariable
+          Class of base distribution. Its shape (when instantiated)
+          determines the shape of an individual DP (event shape).
+        *args, **kwargs : optional
+          Arguments passed into ``base_cls``.
 
-        # Instantiate base distribution.
-        self._base = self._base_cls(*self._base_args, **self._base_kwargs)
-        # Create empty tensor to store future atoms in
-        self._theta = tf.zeros(
-            [0] + self.get_batch_shape().as_list() +
-            self.get_event_shape().as_list())
-        # self._theta = tf.expand_dims(
-            # self._base.sample(self.get_batch_shape()), 0)
+        Examples
+        --------
+        >>> # scalar concentration parameter, scalar base distribution
+        >>> dp = DirichletProcess(0.1, Normal, mu=0.0, sigma=1.0)
+        >>> assert dp.get_shape() == ()
+        >>>
+        >>> # vector of concentration parameters, matrix of Exponentials
+        >>> dp = DirichletProcess(tf.constant([0.1, 0.4]),
+        ...                       Exponential, lam=tf.ones([5, 3]))
+        >>> assert dp.get_shape() == (2, 5, 3)
+        """
+        parameters = locals()
+        parameters.pop("self")
+        with tf.name_scope(name, values=[alpha]) as ns:
+            with tf.control_dependencies([]):
+                self._alpha = tf.identity(alpha, name="alpha")
+                self._base_cls = base_cls
+                self._base_args = args
+                self._base_kwargs = kwargs
 
-        # Instantiate beta distribution for stick breaking proportions
-        self._betadist = Beta(a=tf.ones_like(self.alpha), b=self.alpha)
-        # Create empty tensor to store stick breaking proportions
-        self._beta = tf.zeros([0] + self.get_batch_shape().as_list())
+                # Instantiate base distribution.
+                self._base = self._base_cls(
+                    *self._base_args, **self._base_kwargs)
+                # Create empty tensor to store future atoms in
+                self._theta = tf.zeros(
+                    [0] + self.get_batch_shape().as_list() +
+                    self.get_event_shape().as_list())
+                # self._theta = tf.expand_dims(
+                    # self._base.sample(self.get_batch_shape()), 0)
 
-        super(DirichletProcess, self).__init__(
-            dtype=tf.float32,
-            is_continuous=False,
-            is_reparameterized=False,
-            validate_args=validate_args,
-            allow_nan_stats=allow_nan_stats,
-            parameters=parameters,
-            graph_parents=[self._alpha, self._theta, self._beta],
-            name=ns,
-            value=value)
+                # Instantiate beta distribution for stick breaking proportions
+                self._betadist = Beta(a=tf.ones_like(self.alpha), b=self.alpha)
+                # Create empty tensor to store stick breaking proportions
+                self._beta = tf.zeros([0] + self.get_batch_shape().as_list())
 
-  @property
-  def alpha(self):
-    """Concentration parameter."""
-    return self._alpha
+                super(DirichletProcess, self).__init__(
+                    dtype=tf.float32,
+                    is_continuous=False,
+                    is_reparameterized=False,
+                    validate_args=validate_args,
+                    allow_nan_stats=allow_nan_stats,
+                    parameters=parameters,
+                    graph_parents=[self._alpha, self._theta, self._beta],
+                    name=ns,
+                    value=value)
 
-  @property
-  def beta(self):
-    """Stick breaking proportions. It has shape [None] + batch_shape, where
-    the first dimension is the number of atoms, instantiated only as
-    needed."""
-    return self._beta
+    @property
+    def alpha(self):
+        """Concentration parameter."""
+        return self._alpha
 
-  @property
-  def theta(self):
-    """Atoms. It has shape [None] + batch_shape + event_shape, where
-    the first dimension is the number of atoms, instantiated only as
-    needed."""
-    return self._theta
+    @property
+    def beta(self):
+        """Stick breaking proportions. It has shape [None] + batch_shape, where
+        the first dimension is the number of atoms, instantiated only as
+        needed."""
+        return self._beta
 
-  def _batch_shape(self):
-    return tf.shape(self.alpha)
+    @property
+    def theta(self):
+        """Atoms. It has shape [None] + batch_shape + event_shape, where
+        the first dimension is the number of atoms, instantiated only as
+        needed."""
+        return self._theta
 
-  def _get_batch_shape(self):
-    return self.alpha.get_shape()
+    def _batch_shape(self):
+        return tf.shape(self.alpha)
 
-  def _event_shape(self):
-    return tf.shape(self._base)
+    def _get_batch_shape(self):
+        return self.alpha.get_shape()
 
-  def _get_event_shape(self):
-    return self._base.get_shape()
+    def _event_shape(self):
+        return tf.shape(self._base)
 
-  def _sample_n(self, n, seed=None):
-    """Sample ``n`` draws from the DP. Draws from the base
-    distribution are memoized across ``n`` and across calls to
-    ``sample()``.
+    def _get_event_shape(self):
+        return self._base.get_shape()
 
-    Draws from the base distribution are not memoized across the batch
-    shape, i.e., each independent DP in the batch shape has its own
-    memoized samples.
+    def _sample_n(self, n, seed=None):
+        """Sample ``n`` draws from the DP. Draws from the base
+        distribution are memoized across ``n`` and across calls to
+        ``sample()``.
 
-    Returns
-    -------
-    tf.Tensor
-      A ``tf.Tensor`` of shape ``[n] + batch_shape + event_shape``,
-      where ``n`` is the number of samples for each DP,
-      ``batch_shape`` is the number of independent DPs, and
-      ``event_shape`` is the shape of the base distribution.
+        Draws from the base distribution are not memoized across the batch
+        shape, i.e., each independent DP in the batch shape has its own
+        memoized samples.
 
-    Notes
-    -----
-    The implementation has one inefficiency, which is that it draws
-    (batch_shape,) samples from the base distribution when adding a
-    new persistent state. Ideally, we would only draw new samples for
-    those in the loop which require it.
-    """
-    if seed is not None:
-      raise NotImplementedError("seed is not implemented.")
+        Returns
+        -------
+        tf.Tensor
+          A ``tf.Tensor`` of shape ``[n] + batch_shape + event_shape``,
+          where ``n`` is the number of samples for each DP,
+          ``batch_shape`` is the number of independent DPs, and
+          ``event_shape`` is the shape of the base distribution.
 
-    batch_shape = self.get_batch_shape().as_list()
-    event_shape = self.get_event_shape().as_list()
-    rank = 1 + len(batch_shape) + len(event_shape)
-    # Note this is for scoping within the while loop's body function.
-    self._temp_scope = [n, batch_shape, event_shape, rank]
+        Notes
+        -----
+        The implementation has one inefficiency, which is that it draws
+        (batch_shape,) samples from the base distribution when adding a
+        new persistent state. Ideally, we would only draw new samples for
+        those in the loop which require it.
+        """
+        if seed is not None:
+            raise NotImplementedError("seed is not implemented.")
 
-    # Start at the beginning of the stick, i.e. the k'th index
-    k = tf.constant(0)
+        batch_shape = self.get_batch_shape().as_list()
+        event_shape = self.get_event_shape().as_list()
+        rank = 1 + len(batch_shape) + len(event_shape)
 
-    # Define boolean tensor. It is True for samples that require continuing
-    # the while loop and False for samples that can receive their base
-    # distribution (coin lands heads).
-    bools = tf.ones([n] + self.get_batch_shape().as_list(), dtype=tf.bool)
+        def _sample_n_cond(k, bools, theta, beta, draws):
+                # Proceed if at least one bool is True.
+            return tf.reduce_any(bools)
 
-    # Initialize all samples as zero, they will be overwritten in any case
-    draws = tf.zeros([n] + batch_shape + event_shape)
+        def _sample_n_body(k, bools, theta, beta, draws):
+            # If necessary, break a new piece of stick, i.e.
+            # add a new persistent atom to theta and sample another beta
+            theta, beta = tf.cond(
+                tf.shape(theta)[0] - 1 >= k,
+                lambda: (theta, beta),
+                lambda: (
+                    tf.concat(
+                        [theta, tf.expand_dims(
+                            self._base.sample(batch_shape), 0)], 0),
+                    tf.concat(
+                        [beta, tf.expand_dims(self._betadist.sample(), 0)], 0)))
+            theta_k = tf.gather(theta, k)
+            beta_k = tf.gather(beta, k)
 
-    # Calculate shape invariance conditions for theta and beta as these
-    # can change shape between loop iterations.
-    theta_shape = tf.TensorShape([None])
-    beta_shape = tf.TensorShape([None])
-    if len(self.theta.shape) > 1:
-      theta_shape = theta_shape.concatenate(self.theta.shape[1:])
-      beta_shape = beta_shape.concatenate(self.beta.shape[1:])
+            # Assign True samples to the new theta_k.
+            if len(bools.get_shape()) <= 1:
+                bools_tile = bools
+            else:
+                # ``tf.where`` only index subsets when ``bools`` is at most a
+                # vector. In general, ``bools`` has shape (n, batch_shape).
+                # Therefore we tile ``bools`` to be of shape
+                # (n, batch_shape, event_shape) in order to index per-element.
+                bools_tile = tf.tile(tf.reshape(
+                    bools, [n] + batch_shape + [1] * len(event_shape)),
+                    [1] + [1] * len(batch_shape) + event_shape)
 
-    # While we have not broken enough sticks, keep sampling.
-    _, _, self._theta, self._beta, samples = tf.while_loop(
-        self._sample_n_cond, self._sample_n_body,
-        loop_vars=[k, bools, self.theta, self.beta, draws],
-        shape_invariants=[k.shape, bools.shape, theta_shape, beta_shape, draws.shape])
+            theta_k_tile = tf.tile(
+                tf.expand_dims(theta_k, 0), [n] + [1] * (rank - 1))
+            draws = tf.where(bools_tile, theta_k_tile, draws)
 
-    return samples
+            # Draw new stick probability, then flip coins.
+            flips = Bernoulli(p=beta_k).sample(n)
+            # If coin lands heads, assign sample's corresponding bool to False
+            # (this ends its "while loop").
+            bools = tf.where(
+                tf.cast(flips, tf.bool), tf.zeros_like(bools), bools)
+            return k + 1, bools, theta, beta, draws
 
-  def _sample_n_cond(self, k, bools, theta, beta, draws):
-    # Proceed if at least one bool is True.
-    return tf.reduce_any(bools)
+        # Start at the beginning of the stick, i.e. the k'th index
+        k = tf.constant(0)
 
-  def _sample_n_body(self, k, bools, theta, beta, draws):
-    n, batch_shape, event_shape, rank = self._temp_scope
+        # Define boolean tensor. It is True for samples that require continuing
+        # the while loop and False for samples that can receive their base
+        # distribution (coin lands heads).
+        bools = tf.ones([n] + self.get_batch_shape().as_list(), dtype=tf.bool)
 
-    # If necessary, break a new piece of stick, i.e.
-    # add a new persistent atom to theta and sample another beta
-    theta, beta = tf.cond(
-        tf.shape(theta)[0] - 1 >= k,
-        lambda: (theta, beta),
-        lambda: (
-            tf.concat(
-                [theta, tf.expand_dims(self._base.sample(batch_shape), 0)], 0),
-            tf.concat(
-                [beta, tf.expand_dims(self._betadist.sample(), 0)], 0)))
-    theta_k = tf.gather(theta, k)
-    beta_k = tf.gather(beta, k)
+        # Initialize all samples as zero, they will be overwritten in any case
+        draws = tf.zeros([n] + batch_shape + event_shape)
 
-    # Assign True samples to the new theta_k.
-    if len(bools.get_shape()) <= 1:
-      bools_tile = bools
-    else:
-      # ``tf.where`` only index subsets when ``bools`` is at most a
-      # vector. In general, ``bools`` has shape (n, batch_shape).
-      # Therefore we tile ``bools`` to be of shape
-      # (n, batch_shape, event_shape) in order to index per-element.
-      bools_tile = tf.tile(tf.reshape(
-          bools, [n] + batch_shape + [1] * len(event_shape)),
-          [1] + [1] * len(batch_shape) + event_shape)
+        # Calculate shape invariance conditions for theta and beta as these
+        # can change shape between loop iterations.
+        theta_shape = tf.TensorShape([None])
+        beta_shape = tf.TensorShape([None])
+        if len(self.theta.shape) > 1:
+            theta_shape = theta_shape.concatenate(self.theta.shape[1:])
+            beta_shape = beta_shape.concatenate(self.beta.shape[1:])
 
-    theta_k_tile = tf.tile(tf.expand_dims(theta_k, 0), [n] + [1] * (rank - 1))
-    draws = tf.where(bools_tile, theta_k_tile, draws)
+        # While we have not broken enough sticks, keep sampling.
+        _, _, self._theta, self._beta, samples = tf.while_loop(
+            _sample_n_cond,
+            _sample_n_body,
+            loop_vars=[k, bools, self.theta, self.beta, draws],
+            shape_invariants=[k.shape, bools.shape, theta_shape, beta_shape, draws.shape])
 
-    # Draw new stick probability, then flip coins.
-    flips = Bernoulli(p=beta_k).sample(n)
-    # If coin lands heads, assign sample's corresponding bool to False
-    # (this ends its "while loop").
-    bools = tf.where(tf.cast(flips, tf.bool), tf.zeros_like(bools), bools)
-    return k+1, bools, theta, beta, draws
+        return samples


### PR DESCRIPTION
A `DirichletProcess` should retain its beta parameters across calls to sample. I've implemented this in the same way as @dustinvtran did for the theta parameters in issue #564. Also I simplified the code somewhat. Now the body and condition functions for the `tf.while_loop` are defined in `sample()` so that the scoping is easier. The theta and beta tensors are added to as needed and don't need to be sampled in `__init__`, rather they are initialised as empty. Also I ran the code through AutoPep8, I hope that is OK. I'm not sure what edward's standards are re. indentation.