### PR TITLE
Added sample_shape parameter to RandomVariable

### DIFF
--- a/edward/inferences/monte_carlo.py
+++ b/edward/inferences/monte_carlo.py
@@ -82,6 +82,9 @@ class MonteCarlo(Inference):
         if not isinstance(qz, Empirical):
           raise TypeError("Posterior approximation must consist of only "
                           "Empirical random variables.")
+        elif len(qz.get_sample_shape()) != 0:
+          raise ValueError("Empirical posterior approximations must have "
+                           "a scalar sample shape.")
 
     super(MonteCarlo, self).__init__(latent_vars, data)
 

--- a/tests/test-models/test_random_variable_shape.py
+++ b/tests/test-models/test_random_variable_shape.py
@@ -1,0 +1,34 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+
+from edward.models import Bernoulli, Dirichlet
+
+
+class test_random_variable_shape_class(tf.test.TestCase):
+
+  def _test_sample(self, rv, sample_shape, batch_shape, event_shape):
+    self.assertEqual(rv.shape, sample_shape + batch_shape + event_shape)
+    self.assertEqual(rv.get_sample_shape(), sample_shape)
+    self.assertEqual(rv.get_batch_shape(), batch_shape)
+    self.assertEqual(rv.get_event_shape(), event_shape)
+
+  def test_bernoulli(self):
+    with self.test_session():
+      self._test_sample(Bernoulli(0.5), [], [], [])
+      self._test_sample(Bernoulli(tf.zeros([2, 3])), [], [2, 3], [])
+      self._test_sample(Bernoulli(0.5, sample_shape=2), [2], [], [])
+      self._test_sample(Bernoulli(0.5, sample_shape=[2, 1]), [2, 1], [], [])
+
+  def test_dirichlet(self):
+    with self.test_session():
+      self._test_sample(Dirichlet(tf.zeros(3)), [], [], [3])
+      self._test_sample(Dirichlet(tf.zeros([2, 3])), [], [2], [3])
+      self._test_sample(Dirichlet(tf.zeros(3), sample_shape=1), [1], [], [3])
+      self._test_sample(Dirichlet(tf.zeros(3), sample_shape=[2, 1]),
+                        [2, 1], [], [3])
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tests/test-models/test_random_variable_value.py
+++ b/tests/test-models/test_random_variable_value.py
@@ -14,8 +14,9 @@ class test_random_variable_value_class(tf.test.TestCase):
   def _test_sample(self, RV, value, *args, **kwargs):
     rv = RV(*args, value=value, **kwargs)
     value_shape = rv.value().shape
-    expected_shape = rv.get_batch_shape().concatenate(rv.get_event_shape())
-    self.assertEqual(value_shape[-len(expected_shape):], expected_shape)
+    expected_shape = rv.get_sample_shape().concatenate(
+        rv.get_batch_shape()).concatenate(rv.get_event_shape())
+    self.assertEqual(value_shape, expected_shape)
     self.assertEqual(rv.dtype, rv.value().dtype)
 
   def _test_copy(self, RV, value, *args, **kwargs):

--- a/tests/test-models/test_random_variable_value.py
+++ b/tests/test-models/test_random_variable_value.py
@@ -39,8 +39,7 @@ class test_random_variable_value_class(tf.test.TestCase):
       self.assertRaises(ValueError, self._test_sample, Normal, 2,
                         mu=[0.5], sigma=[1.0])
       self.assertRaises(ValueError, self._test_sample, Normal,
-                        np.zeros([10, 3], np.float32),
-                        mu=[0.5, 0.5], sigma=1.)
+                        np.zeros([10, 3]), mu=[0.5, 0.5], sigma=[1.0, 1.0])
 
   def test_copy(self):
     with self.test_session():

--- a/tests/test-models/test_random_variable_value.py
+++ b/tests/test-models/test_random_variable_value.py
@@ -15,7 +15,7 @@ class test_random_variable_value_class(tf.test.TestCase):
     rv = RV(*args, value=value, **kwargs)
     value_shape = rv.value().shape
     expected_shape = rv.get_batch_shape().concatenate(rv.get_event_shape())
-    self.assertEqual(value_shape, expected_shape)
+    self.assertEqual(value_shape[-len(expected_shape):], expected_shape)
     self.assertEqual(rv.dtype, rv.value().dtype)
 
   def _test_copy(self, RV, value, *args, **kwargs):
@@ -37,8 +37,9 @@ class test_random_variable_value_class(tf.test.TestCase):
                         mu=[0.5, 0.5], sigma=1.0)
       self.assertRaises(ValueError, self._test_sample, Normal, 2,
                         mu=[0.5], sigma=[1.0])
-      self.assertRaises(ValueError, self._test_sample, Normal, [2],
-                        mu=0.5, sigma=1.0)
+      self.assertRaises(ValueError, self._test_sample, Normal,
+                        np.zeros([10, 3], np.float32),
+                        mu=[0.5, 0.5], sigma=1.)
 
   def test_copy(self):
     with self.test_session():


### PR DESCRIPTION
This is a small PR that adds a keyword argument `sample_shape` to Edward `RandomVariable`s that gets passed to the underlying `tf.contrib.distributions` `Distribution`'s [sample function](https://www.tensorflow.org/versions/r0.10/api_docs/python/contrib.distributions/classes_for_statistical_distributions_#Distribution.sample). This lets us replace syntax like ed.Normal(mu=tf.ones([10, 1])*mu_vec, sigma=1.) with ed.Normal(mu=mu_vec, sigma=1., n=10).

IMO, this is clearer, since it explicitly says that some slices are i.i.d., some are independent, and dependent. (`Distribution` keeps track of these with `batch_size` and `event_size`.) It's also (very marginally) more efficient, and it makes doing algebra on the graph a little easier in some cases.