### PR TITLE
Fix broken reading-data link in data.tex

### DIFF
--- a/docs/tex/api/data.tex
+++ b/docs/tex/api/data.tex
@@ -6,7 +6,7 @@
 
 Data defines a set of observations. There are three ways
 to read data in Edward. They follow the
-\href{https://www.tensorflow.org/versions/master/how_tos/reading_data/index.html}
+\href{https://www.tensorflow.org/programmers_guide/reading_data}
 {three ways to read data in TensorFlow}.
 
 \textbf{Preloaded data.}

--- a/docs/tex/api/data.tex
+++ b/docs/tex/api/data.tex
@@ -31,7 +31,7 @@ This setting provides the most fine control which is useful for
 experimentation.
 
 Represent the data as
-\href{https://www.tensorflow.org/versions/master/how_tos/reading_data/index.html#feeding}{TensorFlow placeholders},
+\href{https://www.tensorflow.org/programmers_guide/reading_data#feeding}{TensorFlow placeholders},
 which are nodes in the graph that are fed at runtime.
 
 \begin{lstlisting}[language=Python]


### PR DESCRIPTION
The three-methods-of-getting-data TensorFlow link is broken. This just updates the link.