### PR TITLE
multivariate Stochastic Gradient Nosé-Hoover thermostat (mSGNHT)

### DIFF
--- a/edward/__init__.py
+++ b/edward/__init__.py
@@ -9,7 +9,7 @@ from edward import util
 # Direct imports for convenience
 from edward.criticisms import evaluate, ppc
 from edward.inferences import Inference, MonteCarlo, VariationalInference, \
-    HMC, MetropolisHastings, SGLD, SGHMC, \
+    HMC, MetropolisHastings, SGLD, SGHMC, mSGNHT, \
     KLpq, KLqp, ReparameterizationKLqp, ReparameterizationKLKLqp, \
     ReparameterizationEntropyKLqp, ScoreKLqp, ScoreKLKLqp, ScoreEntropyKLqp, \
     GANInference, WGANInference, ImplicitKLqp, MAP, Laplace

--- a/edward/inferences/__init__.py
+++ b/edward/inferences/__init__.py
@@ -14,5 +14,6 @@ from edward.inferences.metropolis_hastings import *
 from edward.inferences.monte_carlo import *
 from edward.inferences.sgld import *
 from edward.inferences.sghmc import *
+from edward.inferences.msgnht import *
 from edward.inferences.variational_inference import *
 from edward.inferences.wgan_inference import *

--- a/edward/inferences/msgnht.py
+++ b/edward/inferences/msgnht.py
@@ -17,7 +17,8 @@ except Exception as e:
 
 
 class mSGNHT(MonteCarlo):
-  """multivariate Stochastic Gradient Nose-Hoover Thermostats with Euler Integrator(Chen et al. 2015).
+  """multivariate Stochastic Gradient Nose-Hoover Thermostats
+   with Euler Integrator(Chen et al. 2015).
 
   Notes
   -----
@@ -65,7 +66,7 @@ class mSGNHT(MonteCarlo):
     self.p = {z: tf.Variable(tf.ones(qz.params.shape[1:]))
               for z, qz in six.iteritems(self.latent_vars)}
     self.xi = {z: tf.Variable(self.D * tf.ones(qz.params.shape[1:]))
-              for z, qz in six.iteritems(self.latent_vars)}
+               for z, qz in six.iteritems(self.latent_vars)}
     self.anneal = anneal
     return super(mSGNHT, self).initialize(*args, **kwargs)
 
@@ -97,10 +98,13 @@ class mSGNHT(MonteCarlo):
                                   list(six.itervalues(old_sample)))
     for z, grad_log_p in zip(six.iterkeys(old_sample), grad_log_joint):
       event_shape = self.latent_vars[z].get_event_shape()
-      zeta = Normal(mu=tf.zeros(event_shape), sigma=learning_rate * tf.ones(event_shape))
-      p_sample[z] = self.p[z] + grad_log_p * learning_rate - tf.multiply(self.xi[z], self.p[z]) * learning_rate\
-                    + tf.sqrt(2 * self.D) * zeta.sample()
-      xi_sample[z] = self.xi[z] + (tf.multiply(p_sample[z], p_sample[z]) - 1) * learning_rate
+      zeta = Normal(mu=tf.zeros(event_shape),
+                    sigma=learning_rate * tf.ones(event_shape))
+      p_sample[z] = self.p[z] + grad_log_p * learning_rate \
+          - tf.multiply(self.xi[z], self.p[z]) * learning_rate \
+          + tf.sqrt(2*self.D) * zeta.sample()
+      xi_sample[z] = self.xi[z] + (tf.multiply(p_sample[z], p_sample[z])
+                                   - 1) * learning_rate
 
     # Update Empirical random variables.
     assign_ops = []

--- a/edward/inferences/msgnht.py
+++ b/edward/inferences/msgnht.py
@@ -48,7 +48,7 @@ class mSGNHT(MonteCarlo):
     """
     super(mSGNHT, self).__init__(*args, **kwargs)
 
-  def initialize(self, D=0.75, step_size=0.005, *args, **kwargs):
+  def initialize(self, D=0.75, step_size=0.0001, *args, **kwargs):
     """
     Parameters
     ----------
@@ -89,7 +89,7 @@ class mSGNHT(MonteCarlo):
 
     for z in six.iterkeys(self.latent_vars):
       # Simulate "A" step of the integrator
-      first_sample[z] = self.p[z] * 0.5 * self.h
+      first_sample[z] = old_sample[z] + self.p[z] * 0.5 * self.h
       first_xi_sample[z] = self.xi[z] + (tf.multiply(self.p[z], self.p[z]) - 1) * self.h * 0.5
 
       # Simulate "B" step of the integrator
@@ -106,9 +106,8 @@ class mSGNHT(MonteCarlo):
 
       # Simulate "B" step of the integrator
       final_p_sample[z] = tf.multiply(tf.exp(- first_xi_sample[z] * self.h * 0.5), second_p_sample[z])
-
       # Simulate "A" step of the integrator
-      final_sample[z] = final_p_sample[z] * 0.5 * self.h
+      final_sample[z] = first_sample[z] + final_p_sample[z] * 0.5 * self.h
       final_xi_sample[z] = first_xi_sample[z] + (tf.multiply(final_p_sample[z], final_p_sample[z]) - 1) * self.h * 0.5
 
     # Update Empirical random variables.

--- a/edward/inferences/msgnht.py
+++ b/edward/inferences/msgnht.py
@@ -1,0 +1,149 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import six
+import tensorflow as tf
+import numpy as np
+
+from edward.inferences.monte_carlo import MonteCarlo
+from edward.models import RandomVariable
+from edward.util import copy
+
+try:
+  from edward.models import Normal
+except Exception as e:
+  raise ImportError("{0}. Your TensorFlow version is not supported.".format(e))
+
+
+class mSGNHT(MonteCarlo):
+  """multivariate Stochastic Gradient Nose-Hoover Thermostats with Symmetric Splitting Integrator(Chen et al. 2015).
+
+  Notes
+  -----
+  In conditional inference, we infer :math:`z` in :math:`p(z, \\beta
+  \mid x)` while fixing inference over :math:`\\beta` using another
+  distribution :math:`q(\\beta)`.
+  ``SGLD`` substitutes the model's log marginal density
+
+  .. math::
+
+    \log p(x, z) = \log \mathbb{E}_{q(\\beta)} [ p(x, z, \\beta) ]
+                \\approx \log p(x, z, \\beta^*)
+
+  leveraging a single Monte Carlo sample, where :math:`\\beta^* \sim
+  q(\\beta)`. This is unbiased (and therefore asymptotically exact as a
+  pseudo-marginal method) if :math:`q(\\beta) = p(\\beta \mid x)`.
+  """
+  def __init__(self, *args, **kwargs):
+    """
+    Examples
+    --------
+    >>> z = Normal(mu=0.0, sigma=1.0)
+    >>> x = Normal(mu=tf.ones(10) * z, sigma=1.0)
+    >>>
+    >>> qz = Empirical(tf.Variable(tf.zeros(500)))
+    >>> data = {x: np.array([0.0] * 10, dtype=np.float32)}
+    >>> inference = ed.SGLD({z: qz}, data)
+    """
+    super(mSGNHT, self).__init__(*args, **kwargs)
+
+  def initialize(self, D=0.75, step_size=0.0025, *args, **kwargs):
+    """
+    Parameters
+    ----------
+    D : positive float, optional
+      A positive constant of equation (2) in Chen, et al.(2015).
+    step_size : float, optional
+      Constant scale factor of learning rate.
+    """
+    self.D = float(D)
+    self.h = float(step_size)
+    self.p = {z: tf.Variable(tf.zeros(qz.params.shape[1:]))
+              for z, qz in six.iteritems(self.latent_vars)}
+    self.xi = self.p
+    return super(mSGNHT, self).initialize(*args, **kwargs)
+
+  def build_update(self):
+    """Simulate mSGNHT using a symmetric splitting integrator(SSI).
+     SSI is more accurate than the the traditional Euler integrator.
+
+    Notes
+    -----
+    The updates assume each Empirical random variable is directly
+    parameterized by ``tf.Variable``s.
+    """
+
+    # Simulate mSGNHT according to equation (3) in Chen, et al.(2015).
+    sample = {}
+    p_sample = {}
+    xi_sample = {}
+
+    for z in six.iterkeys(self.latent_vars):
+      # Simulate "A" step of the integrator
+      sample[z] = self.p[z] * 0.5 * self.h
+      xi_sample[z] = self.xi[z] + (tf.multiply(self.p[z], self.p[z]) - 1) * self.h * 0.5
+
+      # Simulate "B" step of the integrator
+      p_sample[z] = tf.multiply(tf.exp(- xi_sample[z] * self.h * 0.5), self.p[z])
+
+    grad_log_joint = tf.gradients(self._log_joint(sample),
+                                  list(six.itervalues(sample)))
+    for z, grad_log_p in zip(six.iterkeys(self.latent_vars), grad_log_joint):
+      # Simulate "O" step of the integrator
+      zeta = tf.random_normal(shape=self.latent_vars[z].get_event_shape())
+      p_sample[z] = p_sample[z] - grad_log_p * self.h + tf.sqrt(2 * self.D) * zeta
+
+      # Simulate "B" step of the integrator
+      p_sample[z] = tf.multiply(tf.exp(- xi_sample[z] * self.h * 0.5), self.p[z])
+
+      # Simulate "A" step of the integrator
+      sample[z] = self.p[z] * 0.5 * self.h
+      xi_sample[z] = self.xi[z] + (tf.multiply(self.p[z], self.p[z]) - 1) * self.h * 0.5
+
+    # Update Empirical random variables.
+    assign_ops = []
+    for z, qz in six.iteritems(self.latent_vars):
+      variable = qz.get_variables()[0]
+      assign_ops.append(tf.scatter_update(variable, self.t, sample[z]))
+      assign_ops.append(tf.assign(self.p[z], p_sample[z]).op)
+      assign_ops.append(tf.assign(self.xi[z], xi_sample[z]).op)
+
+    # Increment n_accept.
+    assign_ops.append(self.n_accept.assign_add(1))
+    return tf.group(*assign_ops)
+
+  def _log_joint(self, z_sample):
+    """Utility function to calculate model's log joint density,
+    log p(x, z), for inputs z (and fixed data x).
+
+    Parameters
+    ----------
+    z_sample : dict
+      Latent variable keys to samples.
+    """
+    scope = 'inference_' + str(id(self))
+    # Form dictionary in order to replace conditioning on prior or
+    # observed variable with conditioning on a specific value.
+    dict_swap = z_sample.copy()
+    for x, qx in six.iteritems(self.data):
+      if isinstance(x, RandomVariable):
+        if isinstance(qx, RandomVariable):
+          qx_copy = copy(qx, scope=scope)
+          dict_swap[x] = qx_copy.value()
+        else:
+          dict_swap[x] = qx
+
+    log_joint = 0.0
+    for z in six.iterkeys(self.latent_vars):
+      z_copy = copy(z, dict_swap, scope=scope)
+      log_joint += tf.reduce_sum(
+          self.scale.get(z, 1.0) * z_copy.log_prob(dict_swap[z]))
+
+    for x in six.iterkeys(self.data):
+      if isinstance(x, RandomVariable):
+        x_copy = copy(x, dict_swap, scope=scope)
+        log_joint += tf.reduce_sum(
+            self.scale.get(x, 1.0) * x_copy.log_prob(dict_swap[x]))
+
+    return log_joint

--- a/edward/inferences/msgnht.py
+++ b/edward/inferences/msgnht.py
@@ -45,7 +45,7 @@ class mSGNHT(MonteCarlo):
     >>>
     >>> qz = Empirical(tf.Variable(tf.zeros(500)))
     >>> data = {x: np.array([0.0] * 10, dtype=np.float32)}
-    >>> inference = ed.SGLD({z: qz}, data)
+    >>> inference = ed.mSGNHT({z: qz}, data)
     """
     super(mSGNHT, self).__init__(*args, **kwargs)
 

--- a/edward/inferences/msgnht.py
+++ b/edward/inferences/msgnht.py
@@ -97,7 +97,7 @@ class mSGNHT(MonteCarlo):
     for z, grad_log_p in zip(six.iterkeys(old_sample), grad_log_joint):
       event_shape = self.latent_vars[z].get_event_shape()
       zeta = Normal(mu=tf.zeros(event_shape), sigma=learning_rate * tf.ones(event_shape))
-      p_sample[z] = self.p[z] - grad_log_p * learning_rate - tf.multiply(self.xi[z], self.p[z]) * learning_rate\
+      p_sample[z] = self.p[z] + grad_log_p * learning_rate - tf.multiply(self.xi[z], self.p[z]) * learning_rate\
                     + tf.sqrt(2 * self.D) * zeta.sample()
       xi_sample[z] = self.xi[z] + (tf.multiply(p_sample[z], p_sample[z]) - 1) * learning_rate
 

--- a/edward/inferences/msgnht.py
+++ b/edward/inferences/msgnht.py
@@ -102,9 +102,9 @@ class mSGNHT(MonteCarlo):
                     sigma=learning_rate * tf.ones(event_shape))
       p_sample[z] = self.p[z] + grad_log_p * learning_rate \
           - tf.multiply(self.xi[z], self.p[z]) * learning_rate \
-          + tf.sqrt(2*self.D) * zeta.sample()
-      xi_sample[z] = self.xi[z] + (tf.multiply(p_sample[z], p_sample[z])
-                                   - 1) * learning_rate
+          + tf.sqrt(2 * self.D) * zeta.sample()
+      xi_sample[z] = self.xi[z] \
+          + (tf.multiply(p_sample[z], p_sample[z]) - 1) * learning_rate
 
     # Update Empirical random variables.
     assign_ops = []

--- a/edward/inferences/msgnht.py
+++ b/edward/inferences/msgnht.py
@@ -57,6 +57,8 @@ class mSGNHT(MonteCarlo):
       which controls the noise inserted by stochastic gradients.
     step_size : float, optional
       Constant scale factor of learning rate.
+    anneal : binary, optional
+      If True, step_size is gradually annealed.
     """
     self.D = float(D)
     self.h = float(step_size)
@@ -68,8 +70,7 @@ class mSGNHT(MonteCarlo):
     return super(mSGNHT, self).initialize(*args, **kwargs)
 
   def build_update(self):
-    """Simulate mSGNHT using a symmetric splitting integrator(SSI).
-     SSI is more accurate than the the traditional Euler integrator.
+    """Simulate mSGNHT using a Euler integrator.
 
     Notes
     -----

--- a/examples/normal_msgnht.py
+++ b/examples/normal_msgnht.py
@@ -22,7 +22,7 @@ z = MultivariateNormalFull(
 qz = Empirical(params=tf.Variable(tf.random_normal([2000, 2])))
 
 inference = ed.mSGNHT({z: qz})
-inference.run(step_size=0.001)
+inference.run(step_size=0.00001, anneal=False)
 
 # CRITICISM
 sess = ed.get_session()

--- a/examples/normal_msgnht.py
+++ b/examples/normal_msgnht.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+"""Correlated normal posterior. Inference with multivariate Stochastic
+Gradient Nose-Hoover Thermostats.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import edward as ed
+import tensorflow as tf
+
+from edward.models import Empirical, MultivariateNormalFull
+
+ed.set_seed(42)
+
+# MODEL
+z = MultivariateNormalFull(
+    mu=tf.constant([10., -10.]),
+    sigma=tf.constant([[1.0, 0.8], [0.8, 1.0]]))
+
+# INFERENCE
+qz = Empirical(params=tf.Variable(tf.random_normal([2000, 2])))
+
+inference = ed.mSGNHT({z: qz})
+inference.run()
+
+# CRITICISM
+sess = ed.get_session()
+mean, std = sess.run([qz.mean(), qz.std()])
+print("Inferred posterior mean:")
+print(mean)
+print("Inferred posterior std:")
+print(std)

--- a/examples/normal_msgnht.py
+++ b/examples/normal_msgnht.py
@@ -22,7 +22,7 @@ z = MultivariateNormalFull(
 qz = Empirical(params=tf.Variable(tf.random_normal([2000, 2])))
 
 inference = ed.mSGNHT({z: qz})
-inference.run()
+inference.run(step_size=0.005)
 
 # CRITICISM
 sess = ed.get_session()

--- a/examples/normal_msgnht.py
+++ b/examples/normal_msgnht.py
@@ -22,7 +22,7 @@ z = MultivariateNormalFull(
 qz = Empirical(params=tf.Variable(tf.random_normal([2000, 2])))
 
 inference = ed.mSGNHT({z: qz})
-inference.run(step_size=0.005)
+inference.run(step_size=0.001)
 
 # CRITICISM
 sess = ed.get_session()

--- a/tests/test-inferences/test_msgnht.py
+++ b/tests/test-inferences/test_msgnht.py
@@ -18,17 +18,20 @@ class test_sgld_class(tf.test.TestCase):
       mu = Normal(mu=0.0, sigma=1.0)
       x = Normal(mu=tf.ones(50) * mu, sigma=1.0)
 
-      qmu = Empirical(params=tf.Variable(tf.ones(2000)))
+      qmu = Empirical(params=tf.Variable(tf.ones(5000)))
 
       # analytic solution: N(mu=0.0, sigma=\sqrt{1/51}=0.140)
       # Since, in this case, unknown noise inserted by stochastic gradients does not exists,
       # D is supposed to be 0
       inference = ed.mSGNHT({mu: qmu}, data={x: x_data})
-      inference.run()
+      inference.run(step_size=0.00081)
 
       self.assertAllClose(qmu.mean().eval(), 0, rtol=1e-2, atol=1e-2)
       self.assertAllClose(qmu.std().eval(), np.sqrt(1 / 51),
-                          rtol=5e-1, atol=5e-1)
+                          rtol=5e-2, atol=5e-2)
+      v = qmu.get_variables()[0].eval()
+      for i in range(5000):
+        print(v[i])
 
 if __name__ == '__main__':
   ed.set_seed(42)

--- a/tests/test-inferences/test_msgnht.py
+++ b/tests/test-inferences/test_msgnht.py
@@ -22,7 +22,7 @@ class test_sgld_class(tf.test.TestCase):
 
       # analytic solution: N(mu=0.0, sigma=\sqrt{1/51}=0.140)
       inference = ed.mSGNHT({mu: qmu}, data={x: x_data})
-      inference.run(step_size=0.1, D=30)
+      inference.run(step_size=0.05, anneal=False)
 
       v = qmu.get_variables()[0].eval(session=sess)
       for i in range(2000):

--- a/tests/test-inferences/test_msgnht.py
+++ b/tests/test-inferences/test_msgnht.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import edward as ed
+import numpy as np
+import tensorflow as tf
+
+from edward.models import Normal, Empirical
+
+
+class test_sgld_class(tf.test.TestCase):
+
+  def test_normalnormal_run(self):
+    with self.test_session() as sess:
+      x_data = np.array([0.0] * 50, dtype=np.float32)
+
+      mu = Normal(mu=0.0, sigma=1.0)
+      x = Normal(mu=tf.ones(50) * mu, sigma=1.0)
+
+      qmu = Empirical(params=tf.Variable(tf.ones(2000)))
+
+      # analytic solution: N(mu=0.0, sigma=\sqrt{1/51}=0.140)
+      # Since, in this case, unknown noise inserted by stochastic gradients does not exists,
+      # D is supposed to be 0
+      inference = ed.mSGNHT({mu: qmu}, data={x: x_data})
+      inference.run()
+
+      self.assertAllClose(qmu.mean().eval(), 0, rtol=1e-2, atol=1e-2)
+      self.assertAllClose(qmu.std().eval(), np.sqrt(1 / 51),
+                          rtol=5e-1, atol=5e-1)
+
+if __name__ == '__main__':
+  ed.set_seed(42)
+  tf.test.main()

--- a/tests/test-inferences/test_msgnht.py
+++ b/tests/test-inferences/test_msgnht.py
@@ -18,20 +18,20 @@ class test_sgld_class(tf.test.TestCase):
       mu = Normal(mu=0.0, sigma=1.0)
       x = Normal(mu=tf.ones(50) * mu, sigma=1.0)
 
-      qmu = Empirical(params=tf.Variable(tf.ones(4000)))
+      qmu = Empirical(params=tf.Variable(tf.ones([2000])))
 
       # analytic solution: N(mu=0.0, sigma=\sqrt{1/51}=0.140)
-      # Since, in this case, unknown noise inserted by stochastic gradients does not exists,
-      # D is supposed to be 0
       inference = ed.mSGNHT({mu: qmu}, data={x: x_data})
-      inference.run(step_size=0.00005)
+      inference.run(step_size=0.1, D=30)
+
+      v = qmu.get_variables()[0].eval(session=sess)
+      for i in range(2000):
+        print(v[i])
 
       self.assertAllClose(qmu.mean().eval(), 0, rtol=1e-2, atol=1e-2)
       self.assertAllClose(qmu.std().eval(), np.sqrt(1 / 51),
                           rtol=5e-2, atol=5e-2)
-      v = qmu.get_variables()[0].eval()
-      for i in range(5000):
-        print(v[i])
+
 
 if __name__ == '__main__':
   ed.set_seed(42)

--- a/tests/test-inferences/test_msgnht.py
+++ b/tests/test-inferences/test_msgnht.py
@@ -18,13 +18,13 @@ class test_sgld_class(tf.test.TestCase):
       mu = Normal(mu=0.0, sigma=1.0)
       x = Normal(mu=tf.ones(50) * mu, sigma=1.0)
 
-      qmu = Empirical(params=tf.Variable(tf.ones(5000)))
+      qmu = Empirical(params=tf.Variable(tf.ones(4000)))
 
       # analytic solution: N(mu=0.0, sigma=\sqrt{1/51}=0.140)
       # Since, in this case, unknown noise inserted by stochastic gradients does not exists,
       # D is supposed to be 0
       inference = ed.mSGNHT({mu: qmu}, data={x: x_data})
-      inference.run(step_size=0.00081)
+      inference.run(step_size=0.00005)
 
       self.assertAllClose(qmu.mean().eval(), 0, rtol=1e-2, atol=1e-2)
       self.assertAllClose(qmu.std().eval(), np.sqrt(1 / 51),

--- a/tests/test-inferences/test_msgnht.py
+++ b/tests/test-inferences/test_msgnht.py
@@ -24,10 +24,6 @@ class test_sgld_class(tf.test.TestCase):
       inference = ed.mSGNHT({mu: qmu}, data={x: x_data})
       inference.run(step_size=0.05, anneal=False)
 
-      v = qmu.get_variables()[0].eval(session=sess)
-      for i in range(2000):
-        print(v[i])
-
       self.assertAllClose(qmu.mean().eval(), 0, rtol=1e-2, atol=1e-2)
       self.assertAllClose(qmu.std().eval(), np.sqrt(1 / 51),
                           rtol=5e-2, atol=5e-2)


### PR DESCRIPTION
I have implemented the new algorithm for Edward, called
"multivariate Stochastic Gradient Nosé-Hoover thermostat(mSGNHT)"
mSGNHT is one of SGMCMC algorithms.

SGNHT was originally introduced in [1][Bayesian Sampling Using Stochastic Gradient Thermostats](http://machinelearning.wustl.edu/mlpapers/papers/NIPS2014_5592) and then extended to multivariate version in [2][Scalable Deep Poisson Factor Analysis for Topic Modeling](http://people.ee.duke.edu/~lcarin/DeepPFA_ICML2015.pdf).
The detailed analysis of these algorithm can be found in [3][High-Order Stochastic Gradient Thermostats for Bayesian Learning of Deep Models](https://arxiv.org/abs/1512.07662). 

More specifically, I have implemented the simulation of Stochastic Gradient Nosé-Hoover thermostat dynamics using "Euler Integrator", which is different from the Symmetric Splitting Integrator(SSI) introduced in [3]. The reason why I have not used SSI is that i'm not sure how to calculate the gradient appearing at "O-step" of SSI in Edward.

[Contributions]
- Implementation of mSGNHT using Euler Integrator.
- a test for mSGNHT added.
- an example for mSGNHT added.
