### PR TITLE
Speed up logic in ed.copy; distinguish reference tensor from tf.Variable

### DIFF
--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -200,10 +200,9 @@ def copy(org_instance, dict_swap=None, scope="copied",
       return random_variables[new_name]
   elif isinstance(org_instance, (tf.Tensor, tf.Operation)):
     try:
-      already_present = graph.as_graph_element(new_name,
-                                               allow_tensor=True,
-                                               allow_operation=True)
-      return already_present
+      return graph.as_graph_element(new_name,
+                                    allow_tensor=True,
+                                    allow_operation=True)
     except:
       pass
 

--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -140,7 +140,7 @@ def copy(org_instance, dict_swap=None, scope="copied",
   >>> # `x` -> `z` <- y`, `qx`
   >>>
   >>> # This adds a subgraph with newly copied nodes,
-  >>> # `copied/qx` -> `copied/z` <- `copied/y`
+  >>> # `qx` -> `copied/z` <- `copied/y`
   >>> z_new = ed.copy(z, {x: qx})
   >>>
   >>> sess = tf.Session()
@@ -185,7 +185,13 @@ def copy(org_instance, dict_swap=None, scope="copied",
         if variable in dict_swap and replace_itself:
           # Deal with case when `org_instance` is the associated _ref
           # tensor for a tf.Variable.
-          return dict_swap[variable]
+          org_instance = dict_swap[variable]
+          if not copy_q or isinstance(org_instance, tf.Variable):
+            return org_instance
+          for variable in tf.global_variables():
+            if org_instance.name == variable.name:
+              return variable
+          break
         else:
           return variable
 

--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -200,10 +200,9 @@ def copy(org_instance, dict_swap=None, scope="copied",
 
   # If an instance of the same name exists, return it.
   if isinstance(org_instance, RandomVariable):
-    random_variables = {x.name: x for x in
-                        graph.get_collection(RANDOM_VARIABLE_COLLECTION)}
-    if new_name in random_variables:
-      return random_variables[new_name]
+    for rv in graph.get_collection(RANDOM_VARIABLE_COLLECTION):
+      if new_name == rv.name:
+        return rv
   elif isinstance(org_instance, (tf.Tensor, tf.Operation)):
     try:
       return graph.as_graph_element(new_name,

--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -198,10 +198,9 @@ def copy(org_instance, dict_swap=None, scope="copied",
   # Note we check variables via their name and not their type. This
   # is because if we get variables through an op's inputs, it has
   # type tf.Tensor: we can only tell it is a Variable via its name.
-  variables = {x.name: x for
-               x in graph.get_collection(tf.GraphKeys.GLOBAL_VARIABLES)}
-  if org_instance.name in variables:
-    return graph.get_tensor_by_name(variables[org_instance.name].name)
+  variables = [x for x in tf.global_variables() if org_instance.name == x.name]
+  if variables:
+    return variables[0]
 
   # Do the same for tf.placeholders.
   if isinstance(org_instance, tf.Tensor) and \

--- a/tests/test-util/test_copy.py
+++ b/tests/test-util/test_copy.py
@@ -85,15 +85,15 @@ class test_copy_class(tf.test.TestCase):
       z_new = ed.copy(z, {x: qx})
       self.assertEqual(z_new.eval(), 12.0)
 
-  # def test_swap_variable_tensor(self):
-  #   with self.test_session():
-  #     x = tf.Variable(2.0, name="CustomName")
-  #     y = tf.constant(3.0)
-  #     z = x * y
-  #     qx = tf.constant(4.0)
-  #     z_new = ed.copy(z, {x: qx})
-  #     tf.variables_initializer([x]).run()
-  #     self.assertEqual(z_new.eval(), 12.0)
+  def test_swap_variable_tensor(self):
+    with self.test_session():
+      x = tf.Variable(2.0, name="CustomName")
+      y = tf.constant(3.0)
+      z = x * y
+      qx = tf.constant(4.0)
+      z_new = ed.copy(z, {x: qx})
+      tf.variables_initializer([x]).run()
+      self.assertEqual(z_new.eval(), 12.0)
 
   def test_swap_tensor_variable(self):
     with self.test_session() as sess:

--- a/tests/test-util/test_copy.py
+++ b/tests/test-util/test_copy.py
@@ -85,6 +85,24 @@ class test_copy_class(tf.test.TestCase):
       z_new = ed.copy(z, {x: qx})
       self.assertEqual(z_new.eval(), 12.0)
 
+  def test_swap_placeholder_tensor(self):
+    with self.test_session():
+      x = tf.placeholder(tf.float32, name="CustomName")
+      y = tf.constant(3.0)
+      z = x * y
+      qx = tf.constant(4.0)
+      z_new = ed.copy(z, {x: qx})
+      self.assertEqual(z_new.eval(), 12.0)
+
+  def test_swap_tensor_placeholder(self):
+    with self.test_session() as sess:
+      x = tf.constant(2.0)
+      y = tf.constant(3.0)
+      z = x * y
+      qx = tf.placeholder(tf.float32, name="CustomName")
+      z_new = ed.copy(z, {x: qx})
+      self.assertEqual(sess.run(z_new, feed_dict={qx: 4.0}), 12.0)
+
   def test_swap_variable_tensor(self):
     with self.test_session():
       x = tf.Variable(2.0, name="CustomName")
@@ -104,24 +122,6 @@ class test_copy_class(tf.test.TestCase):
       z_new = ed.copy(z, {x: qx})
       tf.variables_initializer([qx]).run()
       self.assertEqual(z_new.eval(), 12.0)
-
-  def test_swap_placeholder_tensor(self):
-    with self.test_session():
-      x = tf.placeholder(tf.float32, name="CustomName")
-      y = tf.constant(3.0)
-      z = x * y
-      qx = tf.constant(4.0)
-      z_new = ed.copy(z, {x: qx})
-      self.assertEqual(z_new.eval(), 12.0)
-
-  def test_swap_tensor_placeholder(self):
-    with self.test_session() as sess:
-      x = tf.constant(2.0)
-      y = tf.constant(3.0)
-      z = x * y
-      qx = tf.placeholder(tf.float32, name="CustomName")
-      z_new = ed.copy(z, {x: qx})
-      self.assertEqual(sess.run(z_new, feed_dict={qx: 4.0}), 12.0)
 
   def test_swap_rv_rv(self):
     with self.test_session():

--- a/tests/test-util/test_copy.py
+++ b/tests/test-util/test_copy.py
@@ -2,11 +2,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import edward as ed
 import numpy as np
 import tensorflow as tf
 
 from edward.models import Categorical, Mixture, Normal
-from edward.util import copy, set_seed
 
 
 class test_copy_class(tf.test.TestCase):
@@ -16,7 +16,7 @@ class test_copy_class(tf.test.TestCase):
       x = tf.placeholder(tf.float32, name="CustomName")
       y = tf.constant(3.0)
       z = x * y
-      z_new = copy(z)
+      z_new = ed.copy(z)
       self.assertEqual(sess.run(z_new, feed_dict={x: 4.0}), 12.0)
 
   def test_variable(self):
@@ -24,7 +24,7 @@ class test_copy_class(tf.test.TestCase):
       x = tf.Variable(2.0, name="CustomName")
       y = tf.constant(3.0)
       z = x * y
-      z_new = copy(z)
+      z_new = ed.copy(z)
       tf.variables_initializer([x]).run()
       self.assertEqual(z_new.eval(), 6.0)
 
@@ -35,7 +35,7 @@ class test_copy_class(tf.test.TestCase):
                          name='CustomName')
       y = tf.constant(3.0)
       z = x * y
-      z_new = copy(z)
+      z_new = ed.copy(z)
       coord = tf.train.Coordinator()
       threads = tf.train.start_queue_runners(coord=coord)
       self.assertAllEqual(sess.run(z_new), np.array([0.0, 3.0]))
@@ -51,107 +51,107 @@ class test_copy_class(tf.test.TestCase):
       components = [Normal(mu=x, sigma=tf.constant(0.1))
                     for _ in range(5)]
       z = Mixture(cat=cat, components=components)
-      z_new = copy(z, {x: y.value()})
+      z_new = ed.copy(z, {x: y.value()})
       self.assertGreater(z_new.value().eval(), 5.0)
 
-  def test_tensor_tensor(self):
+  def test_scan(self):
+    with self.test_session() as sess:
+      ed.set_seed(42)
+      op = tf.scan(lambda a, x: a + x, tf.constant([2.0, 3.0, 1.0]))
+      copy_op = ed.copy(op)
+
+      result_copy, result = sess.run([copy_op, op])
+      self.assertAllClose(result_copy, [2.0, 5.0, 6.0])
+      self.assertAllClose(result, [2.0, 5.0, 6.0])
+
+  def test_scan_random(self):
+    with self.test_session() as sess:
+      ed.set_seed(1234)
+      op = tf.scan(lambda a, x: a + x, tf.random_normal([3]))
+      copy_op = ed.copy(op)
+
+      # check that the random inputs are different
+      # currently ed.set_seed prevents variate generation to work
+      # result_copy, result = sess.run([copy_op, op])
+      # for elem_copy, elem in zip(result_copy, result):
+      #   self.assertNotAlmostEquals(elem_copy, elem)
+
+  def test_swap_tensor_tensor(self):
     with self.test_session():
       x = tf.constant(2.0)
       y = tf.constant(3.0)
       z = x * y
       qx = tf.constant(4.0)
-      z_new = copy(z, {x: qx})
+      z_new = ed.copy(z, {x: qx})
       self.assertEqual(z_new.eval(), 12.0)
 
-  # def test_variable_tensor(self):
+  # def test_swap_variable_tensor(self):
   #   with self.test_session():
   #     x = tf.Variable(2.0, name="CustomName")
   #     y = tf.constant(3.0)
   #     z = x * y
   #     qx = tf.constant(4.0)
-  #     z_new = copy(z, {x: qx})
+  #     z_new = ed.copy(z, {x: qx})
+  #     tf.variables_initializer([x]).run()
   #     self.assertEqual(z_new.eval(), 12.0)
 
-  def test_tensor_variable(self):
+  def test_swap_tensor_variable(self):
     with self.test_session() as sess:
       x = tf.constant(2.0)
       y = tf.constant(3.0)
       z = x * y
       qx = tf.Variable(4.0, name="CustomName")
-      z_new = copy(z, {x: qx})
+      z_new = ed.copy(z, {x: qx})
       tf.variables_initializer([qx]).run()
       self.assertEqual(z_new.eval(), 12.0)
 
-  def test_placeholder_tensor(self):
+  def test_swap_placeholder_tensor(self):
     with self.test_session():
       x = tf.placeholder(tf.float32, name="CustomName")
       y = tf.constant(3.0)
       z = x * y
       qx = tf.constant(4.0)
-      z_new = copy(z, {x: qx})
+      z_new = ed.copy(z, {x: qx})
       self.assertEqual(z_new.eval(), 12.0)
 
-  def test_tensor_placeholder(self):
+  def test_swap_tensor_placeholder(self):
     with self.test_session() as sess:
       x = tf.constant(2.0)
       y = tf.constant(3.0)
       z = x * y
       qx = tf.placeholder(tf.float32, name="CustomName")
-      z_new = copy(z, {x: qx})
+      z_new = ed.copy(z, {x: qx})
       self.assertEqual(sess.run(z_new, feed_dict={qx: 4.0}), 12.0)
 
-  def test_dict_rv_rv(self):
+  def test_swap_rv_rv(self):
     with self.test_session():
-      set_seed(325135)
+      ed.set_seed(325135)
       x = Normal(mu=0.0, sigma=0.1)
       y = tf.constant(1.0)
       z = x * y
       qx = Normal(mu=10.0, sigma=0.1)
-      z_new = copy(z, {x: qx})
+      z_new = ed.copy(z, {x: qx})
       self.assertGreater(z_new.eval(), 5.0)
 
-  def test_dict_rv_tensor(self):
+  def test_swap_rv_tensor(self):
     with self.test_session():
-      set_seed(289362)
+      ed.set_seed(289362)
       x = Normal(mu=0.0, sigma=0.1)
       y = tf.constant(1.0)
       z = x * y
       qx = Normal(mu=10.0, sigma=0.1)
-      z_new = copy(z, {x: qx.value()})
+      z_new = ed.copy(z, {x: qx.value()})
       self.assertGreater(z_new.eval(), 5.0)
 
-  def test_dict_tensor_rv(self):
+  def test_swap_tensor_rv(self):
     with self.test_session():
-      set_seed(95258)
+      ed.set_seed(95258)
       x = Normal(mu=0.0, sigma=0.1)
       y = tf.constant(1.0)
       z = x * y
       qx = Normal(mu=10.0, sigma=0.1)
-      z_new = copy(z, {x.value(): qx})
+      z_new = ed.copy(z, {x.value(): qx})
       self.assertGreater(z_new.eval(), 5.0)
-
-  def test_scan(self):
-    with self.test_session():
-      set_seed(42)
-      op = tf.scan(lambda a, x: a + x, tf.constant([2.0, 3.0, 1.0]))
-
-      self.assertAllClose(op.eval(), [2.0, 5.0, 6.0])
-      self.assertAllClose(copy(op).eval(), [2.0, 5.0, 6.0])
-
-  def test_scan_random(self):
-    with self.test_session() as session:
-      set_seed(1234)
-      op = tf.scan(lambda a, x: a + x, tf.random_normal([3]))
-      copy_op = copy(op)
-
-      result = session.run([copy_op, copy_op, op, op])
-      self.assertAllClose(result[0], result[1])
-      self.assertAllClose(result[2], result[3])
-
-      # currently set_seed does seem to prevent variate generation to work
-      # self.assertNotAlmostEquals(result[0][0], result[2][0])
-      # self.assertNotAlmostEquals(result[0][1], result[2][1])
-      # self.assertNotAlmostEquals(result[0][2], result[2][2])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes the note in https://github.com/blei-lab/edward/issues/471#issuecomment-291529088. As a minimal working example:
```python
import edward as ed
import tensorflow as tf
from edward.models import WishartCholesky

W_prior = tf.Variable(tf.constant([[1., 0.], [0., 1.]]))
sigma = WishartCholesky(df=3.0, scale=W_prior)
ed.copy(sigma)
```
With this PR it succeeds; previously it fails (`tf.__version__ == '1.0.1'`). It was an issue where returning the reference tensor forces a downstream error when building `WishartCholesky`; returning the associated `tf.Variable` fixes it.

I also sped up some of the logic in `ed.copy`.