### PR TITLE
changed visualise function to closely match notebook

### DIFF
--- a/docs/tex/tutorials/supervised-regression.tex
+++ b/docs/tex/tutorials/supervised-regression.tex
@@ -132,10 +132,10 @@ dimension).
 
 \begin{lstlisting}[language=Python]
 def visualise(X_data, y_data, w, b, n_samples=10):
-  w_samples = w.sample(n_samples).eval()
+  w_samples = w.sample(n_samples)[0].eval()
   b_samples = b.sample(n_samples).eval()
-  plt.scatter(X_data, y_data)
-  inputs = np.linspace(-1, 10, num=400)
+  plt.scatter(X_data[:, 0], y_data)
+  inputs = np.linspace(-8, 8, num=400)
   for ns in range(n_samples):
     output = inputs * w_samples[ns] + b_samples[ns]
     plt.plot(inputs, output)


### PR DESCRIPTION
I was getting an error when trying to paste in the example code from  [this](http://edwardlib.org/tutorials/supervised-regression) tutorial and when I compared to notebook noticed the plotting functions had different indexing. I changed the example code in docs to more closely match notebook and it should work now.