### PR TITLE
Improve unit tests for GANs

### DIFF
--- a/edward/inferences/gan_inference.py
+++ b/edward/inferences/gan_inference.py
@@ -156,27 +156,22 @@ class GANInference(VariationalInference):
     """
     if feed_dict is None:
       feed_dict = {}
+    if variables not in (None, "Gen", "Disc"):
+      raise NotImplementedError("variables must be None, 'Gen', or 'Disc'.")
 
     for key, value in six.iteritems(self.data):
       if isinstance(key, tf.Tensor) and "Placeholder" in key.op.type:
         feed_dict[key] = value
 
     sess = get_session()
-    if variables is None:
-      _, _, t, loss, loss_d = sess.run(
-          [self.train, self.train_d, self.increment_t, self.loss, self.loss_d],
-          feed_dict)
-    elif variables == "Gen":
-      _, t, loss = sess.run(
-          [self.train, self.increment_t, self.loss], feed_dict)
-      loss_d = 0.0
-    elif variables == "Disc":
-      _, t, loss_d = sess.run(
-          [self.train_d, self.increment_t, self.loss_d], feed_dict)
-      loss = 0.0
-    else:
-      raise NotImplementedError("variables must be None, 'Gen', or 'Disc'.")
+    loss_d = 0.0
+    loss = 0.0
+    if variables in (None, "Disc"):
+      _, loss_d = sess.run([self.train_d, self.loss_d], feed_dict)
+    if variables in (None, "Gen"):
+      _, loss = sess.run([self.train, self.loss], feed_dict)
 
+    t = sess.run(self.increment_t)
     if self.debug:
       sess.run(self.op_check)
 

--- a/edward/inferences/implicit_klqp.py
+++ b/edward/inferences/implicit_klqp.py
@@ -196,10 +196,12 @@ class ImplicitKLqp(GANInference):
       r_qsample = self.discriminator(x_qsample, qz_sample, qbeta_sample)
 
     # Form ratio loss and ratio estimator.
-    if len(self.scale) <= 1:
+    if len(self.scale) == 0:
       loss_d = tf.reduce_mean(self.ratio_loss(r_psample, r_qsample))
-      scale = list(six.itervalues(self.scale))
-      scale = scale[0] if scale else 1.0
+      scaled_ratio = tf.reduce_sum(r_qsample)
+    elif len(self.scale) == 1:
+      loss_d = tf.reduce_mean(self.ratio_loss(r_psample, r_qsample))
+      scale = list(six.itervalues(self.scale))[0]
       scaled_ratio = tf.reduce_sum(scale * r_qsample)
     else:
       loss_d = [tf.reduce_mean(self.ratio_loss(r_psample[key], r_qsample[key]))

--- a/edward/inferences/implicit_klqp.py
+++ b/edward/inferences/implicit_klqp.py
@@ -32,7 +32,7 @@ class ImplicitKLqp(GANInference):
   random variables (``rv``) satisfies ``rv.is_reparameterized`` and
   ``rv.is_continuous``.
   """
-  def __init__(self, latent_vars, data=None, discriminator=None,
+  def __init__(self, latent_vars=None, data=None, discriminator=None,
                global_vars=None):
     """
     Parameters

--- a/examples/bayesian_linear_regression_implicitklqp.py
+++ b/examples/bayesian_linear_regression_implicitklqp.py
@@ -74,7 +74,6 @@ D = 2  # number of features
 # DATA
 w_true = np.ones(D) * 5.0
 X_train, y_train = build_toy_dataset(N, w_true)
-X_test, y_test = build_toy_dataset(N, w_true)
 
 # MODEL
 X = tf.placeholder(tf.float32, [M, D])

--- a/examples/temp.py
+++ b/examples/temp.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+"""Bayesian linear regression. Inference uses data subsampling and
+scales the log-likelihood.
+
+One local optima is an inferred posterior mean of about [-5.0 5.0].
+This implies there is some weird symmetry happening; this result can
+be obtained by initializing the first coordinate to be negative.
+Similar occurs for the second coordinate.
+
+Note as with all GAN-style training, the algorithm is not stable. It
+is recommended to monitor training and halt manually according to some
+criterion (e.g., prediction accuracy on validation test, quality of
+samples).
+
+References
+----------
+http://edwardlib.org/tutorials/supervised-regression
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import edward as ed
+import numpy as np
+import tensorflow as tf
+
+from edward.models import Normal
+from tensorflow.contrib import slim
+
+
+def build_toy_dataset(N, w, noise_std=0.1):
+  D = len(w)
+  x = np.random.randn(N, D)
+  y = np.dot(x, w) + np.random.normal(0, noise_std, size=N)
+  return x, y
+
+
+def ratio_estimator(data, local_vars, global_vars):
+  # data[y] has shape (M,); global_vars[w] has shape (D,)
+  # we concatenate w to each data point y, so input has shape (M, 1 + D)
+  input = tf.concat([
+      tf.reshape(data[y], [M, 1]),
+      tf.tile(tf.reshape(global_vars[w], [1, D]), [M, 1])], 1)
+  # this is equivalent to previous. it has the error, meaning it is
+  # not slim. the initializations are the same, as iter 0 is same
+  # hidden = slim.fully_connected(input, 64, activation_fn=None,
+  #     weights_initializer=tf.random_normal_initializer(),
+  #     biases_initializer=None)
+  # output = slim.fully_connected(hidden, 1, activation_fn=None,
+  #     weights_initializer=tf.random_normal_initializer(),
+  #     biases_initializer=None)
+  w1 = tf.get_variable("w1", shape=[3, 64],
+      initializer=tf.random_normal_initializer())
+  w2 = tf.get_variable("w2", shape=[64, 1],
+      initializer=tf.random_normal_initializer())
+  hidden = tf.matmul(input, w1)
+  output = tf.matmul(hidden, w2)
+  return output
+
+
+ed.set_seed(42)
+
+M = 50  # batch size during training
+D = 2  # number of features
+
+# DATA
+w_true = np.ones(D) * 5.0
+X_batch, y_batch = build_toy_dataset(M, w_true)
+
+# MODEL
+X = X_batch.astype(np.float32)
+w = Normal(loc=tf.zeros(D), scale=tf.ones(D))
+y = Normal(loc=ed.dot(X, w), scale=tf.ones(M))
+
+# INFERENCE
+qw = Normal(loc=tf.Variable([1.0, 1.0]), scale=[1.0, 1.0])
+
+inference = ed.ImplicitKLqp(
+    {w: qw}, data={y: y_batch},
+    discriminator=ratio_estimator, global_vars={w: qw})
+inference.initialize(n_iter=50, n_print=10)
+
+sess = ed.get_session()
+tf.global_variables_initializer().run()
+
+# with tf.variable_scope("Disc", reuse=True):
+#   w2 = tf.get_variable("w2")
+#   print(w2.eval().reshape([64]))
+
+for _ in range(inference.n_iter):
+  info_dict = inference.update(variables="Disc")
+  t = info_dict['t']
+  if t == 1 or t % inference.n_print == 0:
+    print(info_dict['loss_d'])

--- a/tests/test-inferences/test_wgan_inference.py
+++ b/tests/test-inferences/test_wgan_inference.py
@@ -49,7 +49,8 @@ class test_wgan_class(tf.test.TestCase):
 
         inference.update(feed_dict={x_ph: x_data}, variables="Gen")
 
-      self.assertAllClose(theta.eval(), 4.0, rtol=1.0, atol=1.0)
+      # CRITICISM
+      self.assertAllClose(theta.eval(), 4.0, atol=1.0)
 
   def test_normal_penalty(self):
     with self.test_session() as sess:
@@ -77,7 +78,7 @@ class test_wgan_class(tf.test.TestCase):
         inference.update(feed_dict={x_ph: x_data}, variables="Gen")
 
       # CRITICISM
-      self.assertAllClose(theta.eval(), 4.0, rtol=1.0, atol=1.0)
+      self.assertAllClose(theta.eval(), 4.0, atol=1.0)
 
 if __name__ == '__main__':
   ed.set_seed(12451)


### PR DESCRIPTION
This improves unit tests for GANs. For example, for `GANInference`, we can check more precise fits by using the optimal discriminator's closed form solution.

It also removes stochasticity when fixing the seed. This was caused by discriminative and generative updates being jointly run. This made it difficult to reproduce exact results.