### PR TITLE
Prettify TensorBoard scalars and histogram summaries

### DIFF
--- a/edward/inferences/gan_inference.py
+++ b/edward/inferences/gan_inference.py
@@ -103,9 +103,9 @@ class GANInference(VariationalInference):
 
     if self.logging:
       summary_key = 'summaries_' + str(id(self))
-      tf.summary.scalar('loss/discriminative', self.loss_d,
+      tf.summary.scalar("loss/discriminative", self.loss_d,
                         collections=[summary_key])
-      tf.summary.scalar('loss/generative', self.loss,
+      tf.summary.scalar("loss/generative", self.loss,
                         collections=[summary_key])
       self.summarize = tf.summary.merge_all(key=summary_key)
 
@@ -120,7 +120,7 @@ class GANInference(VariationalInference):
 
     if self.logging:
       summary_key = 'summaries_' + str(id(self))
-      tf.summary.histogram('discriminator_outputs',
+      tf.summary.histogram("discriminator_outputs",
                            tf.concat(d_true, d_fake, axis=0),
                            collections=[summary_key])
 

--- a/edward/inferences/gan_inference.py
+++ b/edward/inferences/gan_inference.py
@@ -103,9 +103,9 @@ class GANInference(VariationalInference):
 
     if self.logging:
       summary_key = 'summaries_' + str(id(self))
-      tf.summary.scalar('loss_discriminative', self.loss_d,
+      tf.summary.scalar('loss/discriminative', self.loss_d,
                         collections=[summary_key])
-      tf.summary.scalar('loss_generative', self.loss,
+      tf.summary.scalar('loss/generative', self.loss,
                         collections=[summary_key])
       self.summarize = tf.summary.merge_all(key=summary_key)
 

--- a/edward/inferences/gan_inference.py
+++ b/edward/inferences/gan_inference.py
@@ -120,7 +120,8 @@ class GANInference(VariationalInference):
 
     if self.logging:
       summary_key = 'summaries_' + str(id(self))
-      tf.summary.histogram('disc_outputs', tf.concat(d_true, d_fake, axis=0),
+      tf.summary.histogram('discriminator_outputs',
+                           tf.concat(d_true, d_fake, axis=0),
                            collections=[summary_key])
 
     loss_d = tf.nn.sigmoid_cross_entropy_with_logits(

--- a/edward/inferences/inference.py
+++ b/edward/inferences/inference.py
@@ -159,7 +159,7 @@ class Inference(object):
       Number of iterations for algorithm.
     n_print : int, optional
       Number of iterations for each print progress. To suppress print
-      progress, then specify 0. Default is ``int(n_iter / 10)``.
+      progress, then specify 0. Default is ``int(n_iter / 100)``.
     scale : dict of RandomVariable to tf.Tensor, optional
       A tensor to scale computation for any random variable that it is
       binded to. Its shape must be broadcastable; it is multiplied
@@ -176,7 +176,7 @@ class Inference(object):
     """
     self.n_iter = n_iter
     if n_print is None:
-      self.n_print = int(n_iter / 10)
+      self.n_print = int(n_iter / 100)
     else:
       self.n_print = n_print
 

--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -131,9 +131,9 @@ class KLpq(VariationalInference):
 
     if self.logging:
       summary_key = 'summaries_' + str(id(self))
-      tf.summary.scalar("p_log_prob", tf.reduce_mean(p_log_prob),
+      tf.summary.scalar("loss/p_log_prob", tf.reduce_mean(p_log_prob),
                         collections=[summary_key])
-      tf.summary.scalar("q_log_prob", tf.reduce_mean(q_log_prob),
+      tf.summary.scalar("loss/q_log_prob", tf.reduce_mean(q_log_prob),
                         collections=[summary_key])
 
     log_w = p_log_prob - q_log_prob

--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -131,8 +131,10 @@ class KLpq(VariationalInference):
 
     if self.logging:
       summary_key = 'summaries_' + str(id(self))
-      tf.summary.histogram("p_log_prob", p_log_prob, collections=[summary_key])
-      tf.summary.histogram("q_log_prob", q_log_prob, collections=[summary_key])
+      tf.summary.scalar("p_log_prob", tf.reduce_mean(p_log_prob),
+                        collections=[summary_key])
+      tf.summary.scalar("q_log_prob", tf.reduce_mean(q_log_prob),
+                        collections=[summary_key])
 
     log_w = p_log_prob - q_log_prob
     log_w_norm = log_w - tf.reduce_logsumexp(log_w)

--- a/edward/inferences/klqp.py
+++ b/edward/inferences/klqp.py
@@ -446,16 +446,16 @@ def build_reparam_kl_loss_and_gradients(inference, var_list):
 
   p_log_lik = tf.reduce_mean(tf.stack(p_log_lik))
 
-  kl = tf.reduce_sum([
+  kl_penalty = tf.reduce_sum([
       inference.kl_scaling.get(z, 1.0) * tf.reduce_sum(ds.kl(qz, z))
       for z, qz in six.iteritems(inference.latent_vars)])
 
   if inference.logging:
     summary_key = 'summaries_' + str(id(inference))
     tf.summary.scalar('p_log_lik', p_log_lik, collections=[summary_key])
-    tf.summary.scalar('kl', kl, collections=[summary_key])
+    tf.summary.scalar('kl_penalty', kl_penalty, collections=[summary_key])
 
-  loss = -(p_log_lik - kl)
+  loss = -(p_log_lik - kl_penalty)
 
   grads = tf.gradients(loss, var_list)
   grads_and_vars = list(zip(grads, var_list))
@@ -627,7 +627,7 @@ def build_score_kl_loss_and_gradients(inference, var_list):
   p_log_lik = tf.stack(p_log_lik)
   q_log_prob = tf.stack(q_log_prob)
 
-  kl = tf.reduce_sum([
+  kl_penalty = tf.reduce_sum([
       inference.kl_scaling.get(z, 1.0) * tf.reduce_sum(ds.kl(qz, z))
       for z, qz in six.iteritems(inference.latent_vars)])
 
@@ -637,11 +637,11 @@ def build_score_kl_loss_and_gradients(inference, var_list):
                       collections=[summary_key])
     tf.summary.scalar('q_log_prob', tf.reduce_mean(q_log_prob),
                       collections=[summary_key])
-    tf.summary.scalar('kl', kl, collections=[summary_key])
+    tf.summary.scalar('kl_penalty', kl_penalty, collections=[summary_key])
 
-  loss = -(tf.reduce_mean(p_log_lik) - kl)
+  loss = -(tf.reduce_mean(p_log_lik) - kl_penalty)
   grads = tf.gradients(
-      -(tf.reduce_mean(q_log_prob * tf.stop_gradient(p_log_lik)) - kl),
+      -(tf.reduce_mean(q_log_prob * tf.stop_gradient(p_log_lik)) - kl_penalty),
       var_list)
   grads_and_vars = list(zip(grads, var_list))
   return loss, grads_and_vars

--- a/edward/inferences/klqp.py
+++ b/edward/inferences/klqp.py
@@ -388,8 +388,8 @@ def build_reparam_loss_and_gradients(inference, var_list):
         p_log_prob[s] += tf.reduce_sum(
             inference.scale.get(x, 1.0) * x_copy.log_prob(dict_swap[x]))
 
-  p_log_prob = tf.reduce_mean(tf.stack(p_log_prob))
-  q_log_prob = tf.reduce_mean(tf.stack(q_log_prob))
+  p_log_prob = tf.reduce_mean(p_log_prob)
+  q_log_prob = tf.reduce_mean(q_log_prob)
 
   if inference.logging:
     summary_key = 'summaries_' + str(id(inference))
@@ -444,7 +444,7 @@ def build_reparam_kl_loss_and_gradients(inference, var_list):
         p_log_lik[s] += tf.reduce_sum(
             inference.scale.get(x, 1.0) * x_copy.log_prob(dict_swap[x]))
 
-  p_log_lik = tf.reduce_mean(tf.stack(p_log_lik))
+  p_log_lik = tf.reduce_mean(p_log_lik)
 
   kl_penalty = tf.reduce_sum([
       inference.kl_scaling.get(z, 1.0) * tf.reduce_sum(ds.kl(qz, z))
@@ -508,7 +508,7 @@ def build_reparam_entropy_loss_and_gradients(inference, var_list):
         p_log_prob[s] += tf.reduce_sum(
             inference.scale.get(x, 1.0) * x_copy.log_prob(dict_swap[x]))
 
-  p_log_prob = tf.reduce_mean(tf.stack(p_log_prob))
+  p_log_prob = tf.reduce_mean(p_log_prob)
 
   q_entropy = tf.reduce_sum([
       qz.entropy() for z, qz in six.iteritems(inference.latent_vars)])

--- a/edward/inferences/klqp.py
+++ b/edward/inferences/klqp.py
@@ -393,8 +393,8 @@ def build_reparam_loss_and_gradients(inference, var_list):
 
   if inference.logging:
     summary_key = 'summaries_' + str(id(inference))
-    tf.summary.scalar("p_log_prob", p_log_prob, collections=[summary_key])
-    tf.summary.scalar("q_log_prob", q_log_prob, collections=[summary_key])
+    tf.summary.scalar("loss/p_log_prob", p_log_prob, collections=[summary_key])
+    tf.summary.scalar("loss/q_log_prob", q_log_prob, collections=[summary_key])
 
   loss = -(p_log_prob - q_log_prob)
 
@@ -452,8 +452,8 @@ def build_reparam_kl_loss_and_gradients(inference, var_list):
 
   if inference.logging:
     summary_key = 'summaries_' + str(id(inference))
-    tf.summary.scalar('p_log_lik', p_log_lik, collections=[summary_key])
-    tf.summary.scalar('kl_penalty', kl_penalty, collections=[summary_key])
+    tf.summary.scalar("loss/p_log_lik", p_log_lik, collections=[summary_key])
+    tf.summary.scalar("loss/kl_penalty", kl_penalty, collections=[summary_key])
 
   loss = -(p_log_lik - kl_penalty)
 
@@ -515,8 +515,8 @@ def build_reparam_entropy_loss_and_gradients(inference, var_list):
 
   if inference.logging:
     summary_key = 'summaries_' + str(id(inference))
-    tf.summary.scalar('p_log_prob', p_log_prob, collections=[summary_key])
-    tf.summary.scalar('q_entropy', q_entropy, collections=[summary_key])
+    tf.summary.scalar("loss/p_log_prob", p_log_prob, collections=[summary_key])
+    tf.summary.scalar("loss/q_entropy", q_entropy, collections=[summary_key])
 
   loss = -(p_log_prob + q_entropy)
 
@@ -571,9 +571,9 @@ def build_score_loss_and_gradients(inference, var_list):
 
   if inference.logging:
     summary_key = 'summaries_' + str(id(inference))
-    tf.summary.scalar('p_log_prob', tf.reduce_mean(p_log_prob),
+    tf.summary.scalar("loss/p_log_prob", tf.reduce_mean(p_log_prob),
                       collections=[summary_key])
-    tf.summary.scalar('q_log_prob', tf.reduce_mean(q_log_prob),
+    tf.summary.scalar("loss/q_log_prob", tf.reduce_mean(q_log_prob),
                       collections=[summary_key])
 
   losses = p_log_prob - q_log_prob
@@ -633,11 +633,9 @@ def build_score_kl_loss_and_gradients(inference, var_list):
 
   if inference.logging:
     summary_key = 'summaries_' + str(id(inference))
-    tf.summary.scalar('p_log_lik', tf.reduce_mean(p_log_lik),
+    tf.summary.scalar("loss/p_log_lik", tf.reduce_mean(p_log_lik),
                       collections=[summary_key])
-    tf.summary.scalar('q_log_prob', tf.reduce_mean(q_log_prob),
-                      collections=[summary_key])
-    tf.summary.scalar('kl_penalty', kl_penalty, collections=[summary_key])
+    tf.summary.scalar("loss/kl_penalty", kl_penalty, collections=[summary_key])
 
   loss = -(tf.reduce_mean(p_log_lik) - kl_penalty)
   grads = tf.gradients(
@@ -698,11 +696,11 @@ def build_score_entropy_loss_and_gradients(inference, var_list):
 
   if inference.logging:
     summary_key = 'summaries_' + str(id(inference))
-    tf.summary.scalar('p_log_prob', tf.reduce_mean(p_log_prob),
+    tf.summary.scalar("loss/p_log_prob", tf.reduce_mean(p_log_prob),
                       collections=[summary_key])
-    tf.summary.scalar('q_log_prob', tf.reduce_mean(q_log_prob),
+    tf.summary.scalar("loss/q_log_prob", tf.reduce_mean(q_log_prob),
                       collections=[summary_key])
-    tf.summary.scalar('q_entropy', q_entropy, collections=[summary_key])
+    tf.summary.scalar("loss/q_entropy", q_entropy, collections=[summary_key])
 
   loss = -(tf.reduce_mean(p_log_prob) + q_entropy)
   grads = tf.gradients(

--- a/edward/inferences/klqp.py
+++ b/edward/inferences/klqp.py
@@ -392,9 +392,10 @@ def build_reparam_loss_and_gradients(inference, var_list):
   q_log_prob = tf.reduce_mean(tf.stack(q_log_prob))
 
   if inference.logging:
-    summary_key = 'summaries_' + str(id(inference))
-    tf.summary.scalar("p_log_prob", p_log_prob, collections=[summary_key])
-    tf.summary.scalar("q_log_prob", q_log_prob, collections=[summary_key])
+    with tf.name_scope('inference_' + str(id(inference)) + '/'):
+      summary_key = 'summaries_' + str(id(inference))
+      tf.summary.scalar("p_log_prob", p_log_prob, collections=[summary_key])
+      tf.summary.scalar("q_log_prob", q_log_prob, collections=[summary_key])
 
   loss = -(p_log_prob - q_log_prob)
 
@@ -451,9 +452,10 @@ def build_reparam_kl_loss_and_gradients(inference, var_list):
       for z, qz in six.iteritems(inference.latent_vars)])
 
   if inference.logging:
-    summary_key = 'summaries_' + str(id(inference))
-    tf.summary.scalar('p_log_lik', p_log_lik, collections=[summary_key])
-    tf.summary.scalar('kl_penalty', kl_penalty, collections=[summary_key])
+    with tf.name_scope('inference_' + str(id(inference)) + '/'):
+      summary_key = 'summaries_' + str(id(inference))
+      tf.summary.scalar('p_log_lik', p_log_lik, collections=[summary_key])
+      tf.summary.scalar('kl_penalty', kl_penalty, collections=[summary_key])
 
   loss = -(p_log_lik - kl_penalty)
 
@@ -514,9 +516,10 @@ def build_reparam_entropy_loss_and_gradients(inference, var_list):
       qz.entropy() for z, qz in six.iteritems(inference.latent_vars)])
 
   if inference.logging:
-    summary_key = 'summaries_' + str(id(inference))
-    tf.summary.scalar('p_log_prob', p_log_prob, collections=[summary_key])
-    tf.summary.scalar('q_entropy', q_entropy, collections=[summary_key])
+    with tf.name_scope('inference_' + str(id(inference)) + '/'):
+      summary_key = 'summaries_' + str(id(inference))
+      tf.summary.scalar('p_log_prob', p_log_prob, collections=[summary_key])
+      tf.summary.scalar('q_entropy', q_entropy, collections=[summary_key])
 
   loss = -(p_log_prob + q_entropy)
 
@@ -570,11 +573,12 @@ def build_score_loss_and_gradients(inference, var_list):
   q_log_prob = tf.stack(q_log_prob)
 
   if inference.logging:
-    summary_key = 'summaries_' + str(id(inference))
-    tf.summary.scalar('p_log_prob', tf.reduce_mean(p_log_prob),
-                      collections=[summary_key])
-    tf.summary.scalar('q_log_prob', tf.reduce_mean(q_log_prob),
-                      collections=[summary_key])
+    with tf.name_scope('inference_' + str(id(inference)) + '/'):
+      summary_key = 'summaries_' + str(id(inference))
+      tf.summary.scalar('p_log_prob', tf.reduce_mean(p_log_prob),
+                        collections=[summary_key])
+      tf.summary.scalar('q_log_prob', tf.reduce_mean(q_log_prob),
+                        collections=[summary_key])
 
   losses = p_log_prob - q_log_prob
   loss = -tf.reduce_mean(losses)
@@ -632,12 +636,13 @@ def build_score_kl_loss_and_gradients(inference, var_list):
       for z, qz in six.iteritems(inference.latent_vars)])
 
   if inference.logging:
-    summary_key = 'summaries_' + str(id(inference))
-    tf.summary.scalar('p_log_lik', tf.reduce_mean(p_log_lik),
-                      collections=[summary_key])
-    tf.summary.scalar('q_log_prob', tf.reduce_mean(q_log_prob),
-                      collections=[summary_key])
-    tf.summary.scalar('kl_penalty', kl_penalty, collections=[summary_key])
+    with tf.name_scope('inference_' + str(id(inference)) + '/'):
+      summary_key = 'summaries_' + str(id(inference))
+      tf.summary.scalar('p_log_lik', tf.reduce_mean(p_log_lik),
+                        collections=[summary_key])
+      tf.summary.scalar('q_log_prob', tf.reduce_mean(q_log_prob),
+                        collections=[summary_key])
+      tf.summary.scalar('kl_penalty', kl_penalty, collections=[summary_key])
 
   loss = -(tf.reduce_mean(p_log_lik) - kl_penalty)
   grads = tf.gradients(
@@ -697,12 +702,13 @@ def build_score_entropy_loss_and_gradients(inference, var_list):
       qz.entropy() for z, qz in six.iteritems(inference.latent_vars)])
 
   if inference.logging:
-    summary_key = 'summaries_' + str(id(inference))
-    tf.summary.scalar('p_log_prob', tf.reduce_mean(p_log_prob),
-                      collections=[summary_key])
-    tf.summary.scalar('q_log_prob', tf.reduce_mean(q_log_prob),
-                      collections=[summary_key])
-    tf.summary.scalar('q_entropy', q_entropy, collections=[summary_key])
+    with tf.name_scope('inference_' + str(id(inference)) + '/'):
+      summary_key = 'summaries_' + str(id(inference))
+      tf.summary.scalar('p_log_prob', tf.reduce_mean(p_log_prob),
+                        collections=[summary_key])
+      tf.summary.scalar('q_log_prob', tf.reduce_mean(q_log_prob),
+                        collections=[summary_key])
+      tf.summary.scalar('q_entropy', q_entropy, collections=[summary_key])
 
   loss = -(tf.reduce_mean(p_log_prob) + q_entropy)
   grads = tf.gradients(

--- a/edward/inferences/klqp.py
+++ b/edward/inferences/klqp.py
@@ -392,10 +392,9 @@ def build_reparam_loss_and_gradients(inference, var_list):
   q_log_prob = tf.reduce_mean(tf.stack(q_log_prob))
 
   if inference.logging:
-    with tf.name_scope('inference_' + str(id(inference)) + '/'):
-      summary_key = 'summaries_' + str(id(inference))
-      tf.summary.scalar("p_log_prob", p_log_prob, collections=[summary_key])
-      tf.summary.scalar("q_log_prob", q_log_prob, collections=[summary_key])
+    summary_key = 'summaries_' + str(id(inference))
+    tf.summary.scalar("p_log_prob", p_log_prob, collections=[summary_key])
+    tf.summary.scalar("q_log_prob", q_log_prob, collections=[summary_key])
 
   loss = -(p_log_prob - q_log_prob)
 
@@ -452,10 +451,9 @@ def build_reparam_kl_loss_and_gradients(inference, var_list):
       for z, qz in six.iteritems(inference.latent_vars)])
 
   if inference.logging:
-    with tf.name_scope('inference_' + str(id(inference)) + '/'):
-      summary_key = 'summaries_' + str(id(inference))
-      tf.summary.scalar('p_log_lik', p_log_lik, collections=[summary_key])
-      tf.summary.scalar('kl_penalty', kl_penalty, collections=[summary_key])
+    summary_key = 'summaries_' + str(id(inference))
+    tf.summary.scalar('p_log_lik', p_log_lik, collections=[summary_key])
+    tf.summary.scalar('kl_penalty', kl_penalty, collections=[summary_key])
 
   loss = -(p_log_lik - kl_penalty)
 
@@ -516,10 +514,9 @@ def build_reparam_entropy_loss_and_gradients(inference, var_list):
       qz.entropy() for z, qz in six.iteritems(inference.latent_vars)])
 
   if inference.logging:
-    with tf.name_scope('inference_' + str(id(inference)) + '/'):
-      summary_key = 'summaries_' + str(id(inference))
-      tf.summary.scalar('p_log_prob', p_log_prob, collections=[summary_key])
-      tf.summary.scalar('q_entropy', q_entropy, collections=[summary_key])
+    summary_key = 'summaries_' + str(id(inference))
+    tf.summary.scalar('p_log_prob', p_log_prob, collections=[summary_key])
+    tf.summary.scalar('q_entropy', q_entropy, collections=[summary_key])
 
   loss = -(p_log_prob + q_entropy)
 
@@ -573,12 +570,11 @@ def build_score_loss_and_gradients(inference, var_list):
   q_log_prob = tf.stack(q_log_prob)
 
   if inference.logging:
-    with tf.name_scope('inference_' + str(id(inference)) + '/'):
-      summary_key = 'summaries_' + str(id(inference))
-      tf.summary.scalar('p_log_prob', tf.reduce_mean(p_log_prob),
-                        collections=[summary_key])
-      tf.summary.scalar('q_log_prob', tf.reduce_mean(q_log_prob),
-                        collections=[summary_key])
+    summary_key = 'summaries_' + str(id(inference))
+    tf.summary.scalar('p_log_prob', tf.reduce_mean(p_log_prob),
+                      collections=[summary_key])
+    tf.summary.scalar('q_log_prob', tf.reduce_mean(q_log_prob),
+                      collections=[summary_key])
 
   losses = p_log_prob - q_log_prob
   loss = -tf.reduce_mean(losses)
@@ -636,13 +632,12 @@ def build_score_kl_loss_and_gradients(inference, var_list):
       for z, qz in six.iteritems(inference.latent_vars)])
 
   if inference.logging:
-    with tf.name_scope('inference_' + str(id(inference)) + '/'):
-      summary_key = 'summaries_' + str(id(inference))
-      tf.summary.scalar('p_log_lik', tf.reduce_mean(p_log_lik),
-                        collections=[summary_key])
-      tf.summary.scalar('q_log_prob', tf.reduce_mean(q_log_prob),
-                        collections=[summary_key])
-      tf.summary.scalar('kl_penalty', kl_penalty, collections=[summary_key])
+    summary_key = 'summaries_' + str(id(inference))
+    tf.summary.scalar('p_log_lik', tf.reduce_mean(p_log_lik),
+                      collections=[summary_key])
+    tf.summary.scalar('q_log_prob', tf.reduce_mean(q_log_prob),
+                      collections=[summary_key])
+    tf.summary.scalar('kl_penalty', kl_penalty, collections=[summary_key])
 
   loss = -(tf.reduce_mean(p_log_lik) - kl_penalty)
   grads = tf.gradients(
@@ -702,13 +697,12 @@ def build_score_entropy_loss_and_gradients(inference, var_list):
       qz.entropy() for z, qz in six.iteritems(inference.latent_vars)])
 
   if inference.logging:
-    with tf.name_scope('inference_' + str(id(inference)) + '/'):
-      summary_key = 'summaries_' + str(id(inference))
-      tf.summary.scalar('p_log_prob', tf.reduce_mean(p_log_prob),
-                        collections=[summary_key])
-      tf.summary.scalar('q_log_prob', tf.reduce_mean(q_log_prob),
-                        collections=[summary_key])
-      tf.summary.scalar('q_entropy', q_entropy, collections=[summary_key])
+    summary_key = 'summaries_' + str(id(inference))
+    tf.summary.scalar('p_log_prob', tf.reduce_mean(p_log_prob),
+                      collections=[summary_key])
+    tf.summary.scalar('q_log_prob', tf.reduce_mean(q_log_prob),
+                      collections=[summary_key])
+    tf.summary.scalar('q_entropy', q_entropy, collections=[summary_key])
 
   loss = -(tf.reduce_mean(p_log_prob) + q_entropy)
   grads = tf.gradients(

--- a/edward/inferences/monte_carlo.py
+++ b/edward/inferences/monte_carlo.py
@@ -99,7 +99,7 @@ class MonteCarlo(Inference):
 
     if self.logging:
       summary_key = 'summaries_' + str(id(self))
-      tf.summary.scalar('n_accept', self.n_accept, collections=[summary_key])
+      tf.summary.scalar("n_accept", self.n_accept, collections=[summary_key])
       self.summarize = tf.summary.merge_all(key=summary_key)
 
   def update(self, feed_dict=None):

--- a/edward/inferences/variational_inference.py
+++ b/edward/inferences/variational_inference.py
@@ -74,46 +74,21 @@ class VariationalInference(Inference):
     self.loss, grads_and_vars = self.build_loss_and_gradients(var_list)
 
     if self.logging:
-      summary_key = 'summaries_' + str(id(self))
-      tf.summary.scalar("loss", self.loss, collections=[summary_key])
-      with tf.name_scope('variational'):
+      # TODO maybe i can do this name scoping only if i spot more than one
+      with tf.name_scope('inference_' + str(id(self)) + '/'):
+        summary_key = 'summaries_' + str(id(self))
+        tf.summary.scalar("loss", self.loss, collections=[summary_key])
         for grad, var in grads_and_vars:
-          if var in latent_var_list:
-            # replace colons which are an invalid character
-            tf.summary.histogram("parameter/" +
-                                 var.name.replace(':', '/'),
-                                 var, collections=[summary_key])
-            tf.summary.histogram("gradient/" +
-                                 var.name.replace(':', '/'),
-                                 grad, collections=[summary_key])
-            tf.summary.scalar("gradient_norm/" +
-                              var.name.replace(':', '/'),
-                              tf.norm(grad), collections=[summary_key])
-
-      with tf.name_scope('model'):
-        for grad, var in grads_and_vars:
-          if var in data_var_list:
-            tf.summary.histogram("parameter/" + var.name.replace(':', '/'),
-                                 var, collections=[summary_key])
-            tf.summary.histogram("gradient/" +
-                                 var.name.replace(':', '/'),
-                                 grad, collections=[summary_key])
-            tf.summary.scalar("gradient_norm/" +
-                              var.name.replace(':', '/'),
-                              tf.norm(grad), collections=[summary_key])
-
-      # when var_list is not initialized with None
-      with tf.name_scope(''):
-        for grad, var in grads_and_vars:
-          if var not in latent_var_list and var not in data_var_list:
-            tf.summary.histogram("parameter/" + var.name.replace(':', '/'),
-                                 var, collections=[summary_key])
-            tf.summary.histogram("gradient/" +
-                                 var.name.replace(':', '/'),
-                                 grad, collections=[summary_key])
-            tf.summary.scalar("gradient_norm/" +
-                              var.name.replace(':', '/'),
-                              tf.norm(grad), collections=[summary_key])
+          # replace colons which are an invalid character
+          tf.summary.histogram("parameter/" +
+                               var.name.replace(':', '/'),
+                               var, collections=[summary_key])
+          tf.summary.histogram("gradient/" +
+                               var.name.replace(':', '/'),
+                               grad, collections=[summary_key])
+          tf.summary.scalar("gradient_norm/" +
+                            var.name.replace(':', '/'),
+                            tf.norm(grad), collections=[summary_key])
 
       self.summarize = tf.summary.merge_all(key=summary_key)
 

--- a/edward/inferences/variational_inference.py
+++ b/edward/inferences/variational_inference.py
@@ -74,21 +74,19 @@ class VariationalInference(Inference):
     self.loss, grads_and_vars = self.build_loss_and_gradients(var_list)
 
     if self.logging:
-      # TODO maybe i can do this name scoping only if i spot more than one
-      with tf.name_scope('inference_' + str(id(self)) + '/'):
-        summary_key = 'summaries_' + str(id(self))
-        tf.summary.scalar("loss", self.loss, collections=[summary_key])
-        for grad, var in grads_and_vars:
-          # replace colons which are an invalid character
-          tf.summary.histogram("parameter/" +
-                               var.name.replace(':', '/'),
-                               var, collections=[summary_key])
-          tf.summary.histogram("gradient/" +
-                               var.name.replace(':', '/'),
-                               grad, collections=[summary_key])
-          tf.summary.scalar("gradient_norm/" +
-                            var.name.replace(':', '/'),
-                            tf.norm(grad), collections=[summary_key])
+      summary_key = 'summaries_' + str(id(self))
+      tf.summary.scalar("loss", self.loss, collections=[summary_key])
+      for grad, var in grads_and_vars:
+        # replace colons which are an invalid character
+        tf.summary.histogram("parameter/" +
+                             var.name.replace(':', '/'),
+                             var, collections=[summary_key])
+        tf.summary.histogram("gradient/" +
+                             var.name.replace(':', '/'),
+                             grad, collections=[summary_key])
+        tf.summary.scalar("gradient_norm/" +
+                          var.name.replace(':', '/'),
+                          tf.norm(grad), collections=[summary_key])
 
       self.summarize = tf.summary.merge_all(key=summary_key)
 

--- a/edward/inferences/variational_inference.py
+++ b/edward/inferences/variational_inference.py
@@ -79,40 +79,40 @@ class VariationalInference(Inference):
       with tf.name_scope('variational'):
         for grad, var in grads_and_vars:
           if var in latent_var_list:
-            tf.summary.histogram("parameter_" +
-                                 var.name.replace(':', '_'),
+            # replace colons which are an invalid character
+            tf.summary.histogram("parameter/" +
+                                 var.name.replace(':', '/'),
                                  var, collections=[summary_key])
-            tf.summary.histogram("gradient_" +
-                                 var.name.replace(':', '_'),
+            tf.summary.histogram("gradient/" +
+                                 var.name.replace(':', '/'),
                                  grad, collections=[summary_key])
-            tf.summary.scalar("gradient_norm_" +
-                              var.name.replace(':', '_'),
+            tf.summary.scalar("gradient_norm/" +
+                              var.name.replace(':', '/'),
                               tf.norm(grad), collections=[summary_key])
-      # replace : with _ because tf does not allow : in var names in summaries
 
       with tf.name_scope('model'):
         for grad, var in grads_and_vars:
           if var in data_var_list:
-            tf.summary.histogram("parameter_" + var.name.replace(':', '_'),
+            tf.summary.histogram("parameter/" + var.name.replace(':', '/'),
                                  var, collections=[summary_key])
-            tf.summary.histogram("gradient_" +
-                                 var.name.replace(':', '_'),
+            tf.summary.histogram("gradient/" +
+                                 var.name.replace(':', '/'),
                                  grad, collections=[summary_key])
-            tf.summary.scalar("gradient_norm_" +
-                              var.name.replace(':', '_'),
+            tf.summary.scalar("gradient_norm/" +
+                              var.name.replace(':', '/'),
                               tf.norm(grad), collections=[summary_key])
 
       # when var_list is not initialized with None
       with tf.name_scope(''):
         for grad, var in grads_and_vars:
           if var not in latent_var_list and var not in data_var_list:
-            tf.summary.histogram("parameter_" + var.name.replace(':', '_'),
+            tf.summary.histogram("parameter/" + var.name.replace(':', '/'),
                                  var, collections=[summary_key])
-            tf.summary.histogram("gradient_" +
-                                 var.name.replace(':', '_'),
+            tf.summary.histogram("gradient/" +
+                                 var.name.replace(':', '/'),
                                  grad, collections=[summary_key])
-            tf.summary.scalar("gradient_norm_" +
-                              var.name.replace(':', '_'),
+            tf.summary.scalar("gradient_norm/" +
+                              var.name.replace(':', '/'),
                               tf.norm(grad), collections=[summary_key])
 
       self.summarize = tf.summary.merge_all(key=summary_key)

--- a/examples/bayesian_nn.py
+++ b/examples/bayesian_nn.py
@@ -83,16 +83,7 @@ with tf.name_scope("posterior"):
                   scale=tf.nn.softplus(tf.Variable(tf.random_normal([1]),
                   name="scale")))
 
-with tf.name_scope("inference"):
-  inference = ed.KLqp({W_0: qW_0, b_0: qb_0,
-                       W_1: qW_1, b_1: qb_1,
-                       W_2: qW_2, b_2: qb_2}, data={X: X_train, y: y_train})
-  inference.run(logdir='log/iteration_one')
-
-# This is just to show that TensorBoard can elegantly handle displays
-# of multiple inference runs.
-with tf.name_scope("inference_1"):
-  inference = ed.KLqp({W_0: qW_0, b_0: qb_0,
-                       W_1: qW_1, b_1: qb_1,
-                       W_2: qW_2, b_2: qb_2}, data={X: X_train, y: y_train})
-  inference.run(logdir='log/iteration_two')
+inference = ed.KLqp({W_0: qW_0, b_0: qb_0,
+                     W_1: qW_1, b_1: qb_1,
+                     W_2: qW_2, b_2: qb_2}, data={X: X_train, y: y_train})
+inference.run(logdir='log')

--- a/examples/bayesian_nn.py
+++ b/examples/bayesian_nn.py
@@ -45,31 +45,54 @@ D = 1   # number of features
 X_train, y_train = build_toy_dataset(N)
 
 # MODEL
-W_0 = Normal(loc=tf.zeros([D, 10]), scale=tf.ones([D, 10]))
-W_1 = Normal(loc=tf.zeros([10, 10]), scale=tf.ones([10, 10]))
-W_2 = Normal(loc=tf.zeros([10, 1]), scale=tf.ones([10, 1]))
-b_0 = Normal(loc=tf.zeros(10), scale=tf.ones(10))
-b_1 = Normal(loc=tf.zeros(10), scale=tf.ones(10))
-b_2 = Normal(loc=tf.zeros(1), scale=tf.ones(1))
+with tf.name_scope("model"):
+  W_0 = Normal(loc=tf.zeros([D, 10]), scale=tf.ones([D, 10]), name="W_0")
+  W_1 = Normal(loc=tf.zeros([10, 10]), scale=tf.ones([10, 10]), name="W_1")
+  W_2 = Normal(loc=tf.zeros([10, 1]), scale=tf.ones([10, 1]), name="W_2")
+  b_0 = Normal(loc=tf.zeros(10), scale=tf.ones(10), name="b_0")
+  b_1 = Normal(loc=tf.zeros(10), scale=tf.ones(10), name="b_1")
+  b_2 = Normal(loc=tf.zeros(1), scale=tf.ones(1), name="b_2")
 
-X = tf.placeholder(tf.float32, [N, D])
-y = Normal(loc=neural_network(X), scale=0.1 * tf.ones(N))
+  X = tf.placeholder(tf.float32, [N, D], name="X")
+  y = Normal(loc=neural_network(X), scale=0.1 * tf.ones(N), name="y")
 
 # INFERENCE
-qW_0 = Normal(loc=tf.Variable(tf.random_normal([D, 10])),
-              scale=tf.nn.softplus(tf.Variable(tf.random_normal([D, 10]))))
-qW_1 = Normal(loc=tf.Variable(tf.random_normal([10, 10])),
-              scale=tf.nn.softplus(tf.Variable(tf.random_normal([10, 10]))))
-qW_2 = Normal(loc=tf.Variable(tf.random_normal([10, 1])),
-              scale=tf.nn.softplus(tf.Variable(tf.random_normal([10, 1]))))
-qb_0 = Normal(loc=tf.Variable(tf.random_normal([10])),
-              scale=tf.nn.softplus(tf.Variable(tf.random_normal([10]))))
-qb_1 = Normal(loc=tf.Variable(tf.random_normal([10])),
-              scale=tf.nn.softplus(tf.Variable(tf.random_normal([10]))))
-qb_2 = Normal(loc=tf.Variable(tf.random_normal([1])),
-              scale=tf.nn.softplus(tf.Variable(tf.random_normal([1]))))
+with tf.name_scope("posterior"):
+  with tf.name_scope("qW_0"):
+    qW_0 = Normal(loc=tf.Variable(tf.random_normal([D, 10]), name="loc"),
+                  scale=tf.nn.softplus(tf.Variable(tf.random_normal([D, 10]),
+                  name="scale")))
+  with tf.name_scope("qW_1"):
+    qW_1 = Normal(loc=tf.Variable(tf.random_normal([10, 10]), name="loc"),
+                    scale=tf.nn.softplus(tf.Variable(tf.random_normal([10, 10]),
+                    name="scale")))
+  with tf.name_scope("qW_2"):
+    qW_2 = Normal(loc=tf.Variable(tf.random_normal([10, 1]), name="loc"),
+                  scale=tf.nn.softplus(tf.Variable(tf.random_normal([10, 1]),
+                  name="scale")))
+  with tf.name_scope("qb_0"):
+    qb_0 = Normal(loc=tf.Variable(tf.random_normal([10]), name="loc"),
+                  scale=tf.nn.softplus(tf.Variable(tf.random_normal([10]),
+                  name="scale")))
+  with tf.name_scope("qb_1"):
+    qb_1 = Normal(loc=tf.Variable(tf.random_normal([10]), name="loc"),
+                  scale=tf.nn.softplus(tf.Variable(tf.random_normal([10]),
+                  name="scale")))
+  with tf.name_scope("qb_2"):
+    qb_2 = Normal(loc=tf.Variable(tf.random_normal([1]), name="loc"),
+                  scale=tf.nn.softplus(tf.Variable(tf.random_normal([1]),
+                  name="scale")))
 
-inference = ed.KLqp({W_0: qW_0, b_0: qb_0,
-                     W_1: qW_1, b_1: qb_1,
-                     W_2: qW_2, b_2: qb_2}, data={X: X_train, y: y_train})
-inference.run()
+with tf.name_scope("inference"):
+  inference = ed.KLqp({W_0: qW_0, b_0: qb_0,
+                       W_1: qW_1, b_1: qb_1,
+                       W_2: qW_2, b_2: qb_2}, data={X: X_train, y: y_train})
+  inference.run(logdir='log')
+
+# This is just to show that TensorBoard can elegantly handle displays
+# of multiple inference runs.
+with tf.name_scope("inference_1"):
+  inference = ed.KLqp({W_0: qW_0, b_0: qb_0,
+                       W_1: qW_1, b_1: qb_1,
+                       W_2: qW_2, b_2: qb_2}, data={X: X_train, y: y_train})
+  inference.run(logdir='log')

--- a/examples/bayesian_nn.py
+++ b/examples/bayesian_nn.py
@@ -3,6 +3,8 @@
 (see, e.g., Blundell et al. (2015); Kucukelbir et al. (2016)).
 
 Inspired by autograd's Bayesian neural network example.
+This example prettifies some of the tensor naming for visualization in
+TensorBoard. To view TensorBoard, run `tensorboard --logdir=log`.
 
 References
 ----------
@@ -60,28 +62,28 @@ with tf.name_scope("model"):
 with tf.name_scope("posterior"):
   with tf.name_scope("qW_0"):
     qW_0 = Normal(loc=tf.Variable(tf.random_normal([D, 10]), name="loc"),
-                  scale=tf.nn.softplus(tf.Variable(tf.random_normal([D, 10]),
-                  name="scale")))
+                  scale=tf.nn.softplus(
+                      tf.Variable(tf.random_normal([D, 10]), name="scale")))
   with tf.name_scope("qW_1"):
     qW_1 = Normal(loc=tf.Variable(tf.random_normal([10, 10]), name="loc"),
-                    scale=tf.nn.softplus(tf.Variable(tf.random_normal([10, 10]),
-                    name="scale")))
+                  scale=tf.nn.softplus(
+                      tf.Variable(tf.random_normal([10, 10]), name="scale")))
   with tf.name_scope("qW_2"):
     qW_2 = Normal(loc=tf.Variable(tf.random_normal([10, 1]), name="loc"),
-                  scale=tf.nn.softplus(tf.Variable(tf.random_normal([10, 1]),
-                  name="scale")))
+                  scale=tf.nn.softplus(
+                      tf.Variable(tf.random_normal([10, 1]), name="scale")))
   with tf.name_scope("qb_0"):
     qb_0 = Normal(loc=tf.Variable(tf.random_normal([10]), name="loc"),
-                  scale=tf.nn.softplus(tf.Variable(tf.random_normal([10]),
-                  name="scale")))
+                  scale=tf.nn.softplus(
+                      tf.Variable(tf.random_normal([10]), name="scale")))
   with tf.name_scope("qb_1"):
     qb_1 = Normal(loc=tf.Variable(tf.random_normal([10]), name="loc"),
-                  scale=tf.nn.softplus(tf.Variable(tf.random_normal([10]),
-                  name="scale")))
+                  scale=tf.nn.softplus(
+                      tf.Variable(tf.random_normal([10]), name="scale")))
   with tf.name_scope("qb_2"):
     qb_2 = Normal(loc=tf.Variable(tf.random_normal([1]), name="loc"),
-                  scale=tf.nn.softplus(tf.Variable(tf.random_normal([1]),
-                  name="scale")))
+                  scale=tf.nn.softplus(
+                      tf.Variable(tf.random_normal([1]), name="scale")))
 
 inference = ed.KLqp({W_0: qW_0, b_0: qb_0,
                      W_1: qW_1, b_1: qb_1,

--- a/examples/bayesian_nn.py
+++ b/examples/bayesian_nn.py
@@ -87,7 +87,7 @@ with tf.name_scope("inference"):
   inference = ed.KLqp({W_0: qW_0, b_0: qb_0,
                        W_1: qW_1, b_1: qb_1,
                        W_2: qW_2, b_2: qb_2}, data={X: X_train, y: y_train})
-  inference.run(logdir='log')
+  inference.run(logdir='log/iteration_one')
 
 # This is just to show that TensorBoard can elegantly handle displays
 # of multiple inference runs.
@@ -95,4 +95,4 @@ with tf.name_scope("inference_1"):
   inference = ed.KLqp({W_0: qW_0, b_0: qb_0,
                        W_1: qW_1, b_1: qb_1,
                        W_2: qW_2, b_2: qb_2}, data={X: X_train, y: y_train})
-  inference.run(logdir='log')
+  inference.run(logdir='log/iteration_two')

--- a/examples/normal_normal_tensorboard.py
+++ b/examples/normal_normal_tensorboard.py
@@ -26,4 +26,4 @@ qmu = Normal(loc=qmu_mu, scale=qmu_sigma, name='qmu')
 
 # analytic solution: N(loc=0.0, scale=\sqrt{1/51}=0.140)
 inference = ed.KLqp({mu: qmu}, data={x: x_data})
-inference.run(logdir='train')
+inference.run(logdir='log')


### PR DESCRIPTION
This refines #598. See `bayesian_nn.py` for an example. Some pictures of TensorBoard after running `examples/bayesian_nn.py`:

![screen shot 2017-05-28 at 1 08 12 am](https://cloud.githubusercontent.com/assets/2569867/26527143/666d1e0e-4342-11e7-8c9e-d3cbfb12c8bf.png)
![screen shot 2017-05-28 at 1 08 22 am](https://cloud.githubusercontent.com/assets/2569867/26527146/68535f4e-4342-11e7-9b9d-4758d987b907.png)

Related to #353. Fixes #190 (in combination with #653).