### PR TITLE
Bugfix/evaluate int

### DIFF
--- a/edward/criticisms/evaluate.py
+++ b/edward/criticisms/evaluate.py
@@ -48,7 +48,7 @@ def evaluate(metrics, data, n_samples=500, output_key=None):
   n_samples : int, optional
     Number of posterior samples for making predictions, using the
     posterior predictive distribution.
-  output_key : RandomVariable, optional
+  output_key : RandomVariable or tf.Tensor, optional
     It is the key in ``data`` which corresponds to the model's output.
 
   Returns
@@ -117,8 +117,7 @@ def evaluate(metrics, data, n_samples=500, output_key=None):
     # many times. Alternatively, we could copy ``y_pred``
     # ``n_samples`` many times, so that each copy depends on a
     # different posterior sample. But it's expensive.
-    tensor = tf.convert_to_tensor(output_key)
-    y_pred = [sess.run(tensor, feed_dict) for _ in range(n_samples)]
+    y_pred = [sess.run(output_key, feed_dict) for _ in range(n_samples)]
     y_pred = tf.cast(tf.add_n(y_pred), tf.float32) / \
         tf.cast(n_samples, tf.float32)
 

--- a/edward/criticisms/evaluate.py
+++ b/edward/criticisms/evaluate.py
@@ -119,7 +119,8 @@ def evaluate(metrics, data, n_samples=500, output_key=None):
     # different posterior sample. But it's expensive.
     tensor = tf.convert_to_tensor(output_key)
     y_pred = [sess.run(tensor, feed_dict) for _ in range(n_samples)]
-    y_pred = tf.add_n(y_pred) / tf.cast(n_samples, tf.float32)
+    y_pred = tf.cast(tf.add_n(y_pred), tf.float32) / \
+        tf.cast(n_samples, tf.float32)
 
   # Evaluate y_true (according to y_pred if supervised) for all metrics.
   evaluations = []

--- a/edward/criticisms/evaluate.py
+++ b/edward/criticisms/evaluate.py
@@ -7,7 +7,13 @@ import six
 import tensorflow as tf
 
 from edward.models import RandomVariable
-from edward.util import check_data, get_session, logit
+from edward.util import check_data, get_session
+
+try:
+  from edward.models import Bernoulli, Binomial, Categorical, \
+      Multinomial, OneHotCategorical
+except Exception as e:
+  raise ImportError("{0}. Your TensorFlow version is not supported.".format(e))
 
 
 def evaluate(metrics, data, n_samples=500, output_key=None):
@@ -108,25 +114,31 @@ def evaluate(metrics, data, n_samples=500, output_key=None):
   y_true = data[output_key]
   # Make predictions (if there are any supervised metrics).
   if metrics != ['log_lik'] and metrics != ['log_likelihood']:
-    # Monte Carlo estimate the mean of the posterior predictive.
-    # Note the naive solution of taking the mean of
-    # ``y_pred.sample(n_samples)`` does not work: ``y_pred`` is
-    # parameterized by one posterior sample; this implies each
-    # sample call from ``y_pred`` depends on the same posterior
-    # sample. Instead, we fetch the sample tensor from the graph
-    # many times. Alternatively, we could copy ``y_pred``
-    # ``n_samples`` many times, so that each copy depends on a
-    # different posterior sample. But it's expensive.
-    y_pred = [sess.run(output_key, feed_dict) for _ in range(n_samples)]
-    y_pred = tf.cast(tf.add_n(y_pred), tf.float32) / \
-        tf.cast(n_samples, tf.float32)
+    binary_discrete = (Bernoulli, Binomial)
+    categorical_discrete = (Categorical, Multinomial, OneHotCategorical)
+    if isinstance(output_key, binary_discrete + categorical_discrete):
+      # Average over realizations of their probabilities, then predict
+      # via argmax over probabilities.
+      probs = [sess.run(output_key.probs, feed_dict) for _ in range(n_samples)]
+      probs = tf.add_n(probs) / tf.cast(n_samples, tf.float32)
+      if isinstance(output_key, binary_discrete):
+        # make random prediction whenever probs is exactly 0.5
+        random = tf.random_uniform(shape=tf.shape(probs))
+        y_pred = tf.round(tf.where(tf.equal(0.5, probs), random, probs))
+      else:
+        y_pred = tf.argmax(probs, len(probs.shape) - 1)
+    else:
+      # Monte Carlo estimate the mean of the posterior predictive.
+      y_pred = [sess.run(output_key, feed_dict) for _ in range(n_samples)]
+      y_pred = tf.cast(tf.add_n(y_pred), tf.float32) / \
+          tf.cast(n_samples, tf.float32)
 
   # Evaluate y_true (according to y_pred if supervised) for all metrics.
   evaluations = []
   for metric in metrics:
     if metric == 'accuracy' or metric == 'crossentropy':
       # automate binary or sparse cat depending on its support
-      support = tf.reduce_max(y_true).eval()
+      support = sess.run(tf.reduce_max(y_true), feed_dict)
       if support <= 1:
         metric = 'binary_' + metric
       else:
@@ -190,12 +202,10 @@ def binary_accuracy(y_true, y_pred):
   y_true : tf.Tensor
     Tensor of 0s and 1s (most generally, any real values a and b).
   y_pred : tf.Tensor
-    Tensor of probabilities.
+    Tensor of predictions, with same shape as ``y_true``.
   """
   y_true = tf.cast(y_true, tf.float32)
   y_pred = tf.cast(y_pred, tf.float32)
-  random = tf.random_uniform(shape=tf.shape(y_pred))
-  y_pred = tf.round(tf.where(tf.equal(0.5, y_pred), random, y_pred))
   return tf.reduce_mean(tf.cast(tf.equal(y_true, y_pred), tf.float32))
 
 
@@ -208,12 +218,11 @@ def categorical_accuracy(y_true, y_pred):
     Tensor of 0s and 1s, where the outermost dimension of size ``K``
     has only one 1 per row.
   y_pred : tf.Tensor
-    Tensor of probabilities, with same shape as ``y_true``.
-    The outermost dimension denote the categorical probabilities for
-    that data point per row.
+    Tensor of predictions, with shape ``y_true.shape[:-1]``. Each
+    entry is an integer {0, 1, ..., K-1}.
   """
   y_true = tf.cast(tf.argmax(y_true, len(y_true.shape) - 1), tf.float32)
-  y_pred = tf.cast(tf.argmax(y_pred, len(y_pred.shape) - 1), tf.float32)
+  y_pred = tf.cast(y_pred, tf.float32)
   return tf.reduce_mean(tf.cast(tf.equal(y_true, y_pred), tf.float32))
 
 
@@ -226,13 +235,14 @@ def sparse_categorical_accuracy(y_true, y_pred):
   y_true : tf.Tensor
     Tensor of integers {0, 1, ..., K-1}.
   y_pred : tf.Tensor
-    Tensor of probabilities, with shape ``(y_true.shape, K)``.
-    The outermost dimension are the categorical probabilities for
-    that data point.
+    Tensor of predictions, with same shape as ``y_true``.
   """
   y_true = tf.cast(y_true, tf.float32)
-  y_pred = tf.cast(tf.argmax(y_pred, len(y_pred.shape) - 1), tf.float32)
+  y_pred = tf.cast(y_pred, tf.float32)
   return tf.reduce_mean(tf.cast(tf.equal(y_true, y_pred), tf.float32))
+
+
+# Classification metrics (with real-valued predictions)
 
 
 def binary_crossentropy(y_true, y_pred):
@@ -243,10 +253,11 @@ def binary_crossentropy(y_true, y_pred):
   y_true : tf.Tensor
     Tensor of 0s and 1s.
   y_pred : tf.Tensor
-    Tensor of probabilities.
+    Tensor of real values (logit probabilities), with same shape as
+    ``y_true``.
   """
   y_true = tf.cast(y_true, tf.float32)
-  y_pred = logit(tf.cast(y_pred, tf.float32))
+  y_pred = tf.cast(y_pred, tf.float32)
   return tf.reduce_mean(
       tf.nn.sigmoid_cross_entropy_with_logits(logits=y_pred, labels=y_true))
 
@@ -260,12 +271,11 @@ def categorical_crossentropy(y_true, y_pred):
     Tensor of 0s and 1s, where the outermost dimension of size K
     has only one 1 per row.
   y_pred : tf.Tensor
-    Tensor of probabilities, with same shape as y_true.
-    The outermost dimension denote the categorical probabilities for
-    that data point per row.
+    Tensor of real values (logit probabilities), with same shape as
+    ``y_true``. The outermost dimension is the number of classes.
   """
   y_true = tf.cast(y_true, tf.float32)
-  y_pred = logit(tf.cast(y_pred, tf.float32))
+  y_pred = tf.cast(y_pred, tf.float32)
   return tf.reduce_mean(
       tf.nn.softmax_cross_entropy_with_logits(logits=y_pred, labels=y_true))
 
@@ -279,12 +289,11 @@ def sparse_categorical_crossentropy(y_true, y_pred):
   y_true : tf.Tensor
     Tensor of integers {0, 1, ..., K-1}.
   y_pred : tf.Tensor
-    Tensor of probabilities, with shape ``(y_true.shape, K)``.
-    The outermost dimension are the categorical probabilities for
-    that data point.
+    Tensor of real values (logit probabilities), with shape
+    ``(y_true.shape, K)``. The outermost dimension is the number of classes.
   """
   y_true = tf.cast(y_true, tf.int64)
-  y_pred = logit(tf.cast(y_pred, tf.float32))
+  y_pred = tf.cast(y_pred, tf.float32)
   return tf.reduce_mean(tf.nn.sparse_softmax_cross_entropy_with_logits(
       logits=y_pred, labels=y_true))
 
@@ -297,7 +306,7 @@ def hinge(y_true, y_pred):
   y_true : tf.Tensor
     Tensor of 0s and 1s.
   y_pred : tf.Tensor
-    Tensor of real value.
+    Tensor of real values, with same shape as ``y_true``.
   """
   y_true = tf.cast(y_true, tf.float32)
   y_pred = tf.cast(y_pred, tf.float32)
@@ -312,7 +321,7 @@ def squared_hinge(y_true, y_pred):
   y_true : tf.Tensor
     Tensor of 0s and 1s.
   y_pred : tf.Tensor
-    Tensor of real value.
+    Tensor of real values, with same shape as ``y_true``.
   """
   y_true = tf.cast(y_true, tf.float32)
   y_pred = tf.cast(y_pred, tf.float32)

--- a/tests/test-criticisms/test_evaluate.py
+++ b/tests/test-criticisms/test_evaluate.py
@@ -6,7 +6,7 @@ import edward as ed
 import numpy as np
 import tensorflow as tf
 
-from edward.models import Bernoulli, Normal
+from edward.models import Bernoulli, Categorical, Multinomial, Normal
 
 
 class test_evaluate_class(tf.test.TestCase):
@@ -22,6 +22,55 @@ class test_evaluate_class(tf.test.TestCase):
       self.assertRaises(TypeError, ed.evaluate, x, {x: x_data}, n_samples=1)
       self.assertRaises(NotImplementedError, ed.evaluate, 'hello world',
                         {x: x_data}, n_samples=1)
+
+  def test_metrics_classification(self):
+    with self.test_session():
+      x = Bernoulli(probs=0.51)
+      x_data = tf.constant(1)
+      self.assertAllClose(
+          1.0,
+          ed.evaluate('binary_accuracy', {x: x_data}, n_samples=1))
+      x = Bernoulli(probs=0.51, sample_shape=5)
+      x_data = tf.constant([1, 1, 1, 0, 0])
+      self.assertAllClose(
+          0.6,
+          ed.evaluate('binary_accuracy', {x: x_data}, n_samples=1))
+      x = Bernoulli(probs=tf.constant([0.51, 0.49, 0.49]))
+      x_data = tf.constant([1, 0, 1])
+      self.assertAllClose(
+          2.0 / 3,
+          ed.evaluate('binary_accuracy', {x: x_data}, n_samples=1))
+
+      x = Categorical(probs=tf.constant([0.48, 0.51, 0.01]))
+      x_data = tf.constant(1)
+      self.assertAllClose(
+          1.0,
+          ed.evaluate('sparse_categorical_accuracy', {x: x_data}, n_samples=1))
+      x = Categorical(probs=tf.constant([0.48, 0.51, 0.01]), sample_shape=5)
+      x_data = tf.constant([1, 1, 1, 0, 2])
+      self.assertAllClose(
+          0.6,
+          ed.evaluate('sparse_categorical_accuracy', {x: x_data}, n_samples=1))
+      x = Categorical(
+          probs=tf.constant([[0.48, 0.51, 0.01], [0.51, 0.48, 0.01]]))
+      x_data = tf.constant([1, 2])
+      self.assertAllClose(
+          0.5,
+          ed.evaluate('sparse_categorical_accuracy', {x: x_data}, n_samples=1))
+
+      x = Multinomial(total_count=1.0, probs=tf.constant([0.48, 0.51, 0.01]))
+      x_data = tf.constant([0, 1, 0], dtype=x.dtype.as_numpy_dtype)
+      self.assertAllClose(
+          1.0,
+          ed.evaluate('categorical_accuracy', {x: x_data}, n_samples=1))
+      x = Multinomial(total_count=1.0, probs=tf.constant([0.48, 0.51, 0.01]),
+                      sample_shape=5)
+      x_data = tf.constant(
+          [[0, 1, 0], [0, 1, 0], [0, 1, 0], [1, 0, 0], [0, 0, 1]],
+          dtype=x.dtype.as_numpy_dtype)
+      self.assertAllClose(
+          0.6,
+          ed.evaluate('categorical_accuracy', {x: x_data}, n_samples=1))
 
   def test_data(self):
     with self.test_session():
@@ -65,12 +114,6 @@ class test_evaluate_class(tf.test.TestCase):
       self.assertRaises(TypeError, ed.evaluate, 'mean_squared_error',
                         {x: x_data, y: y_data, x_ph: x_ph_data}, n_samples=1,
                         output_key='x')
-
-  def test_dtype_int(self):
-    with self.test_session():
-      x = Bernoulli(probs=0.5)
-      x_data = tf.constant(0)
-      ed.evaluate('binary_accuracy', {x: x_data}, n_samples=1)
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tests/test-criticisms/test_evaluate.py
+++ b/tests/test-criticisms/test_evaluate.py
@@ -6,7 +6,7 @@ import edward as ed
 import numpy as np
 import tensorflow as tf
 
-from edward.models import Normal
+from edward.models import Bernoulli, Normal
 
 
 class test_evaluate_class(tf.test.TestCase):
@@ -65,6 +65,12 @@ class test_evaluate_class(tf.test.TestCase):
       self.assertRaises(TypeError, ed.evaluate, 'mean_squared_error',
                         {x: x_data, y: y_data, x_ph: x_ph_data}, n_samples=1,
                         output_key='x')
+
+  def test_dtype_int(self):
+    with self.test_session():
+      x = Bernoulli(probs=0.5)
+      x_data = tf.constant(0)
+      ed.evaluate('binary_accuracy', {x: x_data}, n_samples=1)
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tests/test-criticisms/test_metrics.py
+++ b/tests/test-criticisms/test_metrics.py
@@ -9,16 +9,14 @@ from edward import criticisms
 
 all_classification_metrics = [
     criticisms.binary_accuracy,
-    criticisms.categorical_accuracy,
+    criticisms.sparse_categorical_accuracy,
+]
+
+all_real_classification_metrics = [
     criticisms.binary_crossentropy,
     criticisms.categorical_crossentropy,
     criticisms.hinge,
     criticisms.squared_hinge,
-]
-
-all_sparse_metrics = [
-    criticisms.sparse_categorical_accuracy,
-    criticisms.sparse_categorical_crossentropy,
 ]
 
 all_regression_metrics = [
@@ -30,32 +28,48 @@ all_regression_metrics = [
     criticisms.cosine_proximity,
 ]
 
+all_specialized_input_output_metrics = [
+    criticisms.categorical_accuracy,
+    criticisms.sparse_categorical_crossentropy,
+]
+
 
 class test_metrics_class(tf.test.TestCase):
 
   def test_classification_metrics(self):
     with self.test_session():
-      y_a = tf.convert_to_tensor(np.random.randint(0, 7, (6, 7)),
-                                 dtype=tf.float32)
-      y_b = tf.convert_to_tensor(np.random.random((6, 7)))
+      y_true = tf.convert_to_tensor(np.random.randint(0, 1, (2, 3)))
+      y_pred = tf.convert_to_tensor(np.random.randint(0, 1, (2, 3)))
       for metric in all_classification_metrics:
-        self.assertEqual(metric(y_a, y_b).eval().shape, ())
+        self.assertEqual(metric(y_true, y_pred).eval().shape, ())
 
-  def test_sparse_classification_metrics(self):
+  def test_real_classification_metrics(self):
     with self.test_session():
-      y_a = tf.convert_to_tensor(np.random.randint(0, 7, (6,)),
-                                 dtype=tf.float32)
-      y_b = tf.convert_to_tensor(np.random.random((6, 7)))
-      for metric in all_sparse_metrics:
-        self.assertEqual(metric(y_a, y_b).eval().shape, ())
+      y_true = tf.convert_to_tensor(np.random.randint(0, 5, (6, 7)))
+      y_pred = tf.random_normal([6, 7])
+      for metric in all_real_classification_metrics:
+        self.assertEqual(metric(y_true, y_pred).eval().shape, ())
 
   def test_regression_metrics(self):
     with self.test_session():
-      y_a = tf.convert_to_tensor(np.random.random((6, 7)))
-      y_b = tf.convert_to_tensor(np.random.random((6, 7)))
+      y_true = tf.random_normal([6, 7])
+      y_pred = tf.random_normal([6, 7])
       for metric in all_regression_metrics:
-        output = metric(y_a, y_b)
-        self.assertEqual(output.eval().shape, ())
+        self.assertEqual(metric(y_true, y_pred).eval().shape, ())
+
+  def test_specialized_input_output_metrics(self):
+    with self.test_session():
+      for metric in all_specialized_input_output_metrics:
+        if metric == criticisms.categorical_accuracy:
+          y_true = tf.convert_to_tensor(np.random.randint(0, 1, (6, 7)))
+          y_pred = tf.convert_to_tensor(np.random.randint(0, 7, (6,)))
+          self.assertEqual(metric(y_true, y_pred).eval().shape, ())
+        elif metric == criticisms.sparse_categorical_crossentropy:
+          y_true = tf.convert_to_tensor(np.random.randint(0, 5, (6, 7)))
+          y_pred = tf.random_normal([6, 7])
+          self.assertEqual(metric(y_true, y_pred).eval().shape, ())
+        else:
+          raise NotImplementedError()
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tests/test-criticisms/test_metrics.py
+++ b/tests/test-criticisms/test_metrics.py
@@ -65,7 +65,7 @@ class test_metrics_class(tf.test.TestCase):
           y_pred = tf.convert_to_tensor(np.random.randint(0, 7, (6,)))
           self.assertEqual(metric(y_true, y_pred).eval().shape, ())
         elif metric == criticisms.sparse_categorical_crossentropy:
-          y_true = tf.convert_to_tensor(np.random.randint(0, 5, (6, 7)))
+          y_true = tf.convert_to_tensor(np.random.randint(0, 5, (6)))
           y_pred = tf.random_normal([6, 7])
           self.assertEqual(metric(y_true, y_pred).eval().shape, ())
         else:


### PR DESCRIPTION
Bug noted by @jzf2101 on May 31 2017 on Gitter. A minimal example is
```python
ed.evaluate('binary_accuracy', data={Bernoulli(probs=0.5): np.array(1)})
```
This problem occurs for any random variable whose realizations produce non-float dtypes. 

This PR fixes the type cast error. More generally, it makes predictions with discrete random variables and classification metrics more statistically efficient.