### PR TITLE
Feature/mc reset

### DIFF
--- a/edward/inferences/monte_carlo.py
+++ b/edward/inferences/monte_carlo.py
@@ -165,3 +165,15 @@ class MonteCarlo(Inference):
     NotImplementedError
     """
     raise NotImplementedError()
+
+  def reset(self):
+    """Returns a list of ops that effectively restart the chain.
+
+    By default, this op does two things:
+    * Set ``t`` to 0.
+    * Set ``n_accept`` to 0.
+
+    Algorithms that have more state than this should append ops that
+    reset that state appropriately.
+    """
+    return [tf.assign(self.t, 0), tf.assign(self.n_accept, 0)]

--- a/edward/inferences/monte_carlo.py
+++ b/edward/inferences/monte_carlo.py
@@ -95,6 +95,7 @@ class MonteCarlo(Inference):
 
     self.n_accept = tf.Variable(0, trainable=False, name="n_accept")
     self.n_accept_over_t = self.n_accept / self.t
+    self.reset = [tf.assign(self.t, 0), tf.assign(self.n_accept, 0)]
     self.train = self.build_update()
 
     if self.logging:
@@ -165,15 +166,3 @@ class MonteCarlo(Inference):
     NotImplementedError
     """
     raise NotImplementedError()
-
-  def reset(self):
-    """Returns a list of ops that effectively restart the chain.
-
-    By default, this op does two things:
-    * Set ``t`` to 0.
-    * Set ``n_accept`` to 0.
-
-    Algorithms that have more state than this should append ops that
-    reset that state appropriately.
-    """
-    return [tf.assign(self.t, 0), tf.assign(self.n_accept, 0)]

--- a/edward/inferences/monte_carlo.py
+++ b/edward/inferences/monte_carlo.py
@@ -95,8 +95,10 @@ class MonteCarlo(Inference):
 
     self.n_accept = tf.Variable(0, trainable=False, name="n_accept")
     self.n_accept_over_t = self.n_accept / self.t
-    self.reset = [tf.assign(self.t, 0), tf.assign(self.n_accept, 0)]
     self.train = self.build_update()
+
+    # Subclasses should append any other ops needed to reset chain state
+    self.reset = [tf.assign(self.t, 0), tf.assign(self.n_accept, 0)]
 
     if self.logging:
       summary_key = 'summaries_' + str(id(self))

--- a/tests/test-inferences/test_metropolishastings.py
+++ b/tests/test-inferences/test_metropolishastings.py
@@ -32,7 +32,6 @@ class test_metropolishastings_class(tf.test.TestCase):
       self.assertAllClose(qmu.stddev().eval(), np.sqrt(1 / 51),
                           rtol=1e-2, atol=1e-2)
 
-      sess = ed.get_session()
       old_t, old_n_accept = sess.run([inference.t, inference.n_accept])
       self.assertEquals(old_t, n_samples)
       self.assertGreater(old_n_accept, 0.1)

--- a/tests/test-inferences/test_metropolishastings.py
+++ b/tests/test-inferences/test_metropolishastings.py
@@ -25,11 +25,13 @@ class test_metropolishastings_class(tf.test.TestCase):
       inference = ed.MetropolisHastings({mu: qmu},
                                         {mu: proposal_mu},
                                         data={x: x_data})
+      reset_ops = inference.reset()
       inference.run()
 
       self.assertAllClose(qmu.mean().eval(), 0, rtol=1e-2, atol=1e-2)
       self.assertAllClose(qmu.stddev().eval(), np.sqrt(1 / 51),
                           rtol=1e-2, atol=1e-2)
+
 
 if __name__ == '__main__':
   ed.set_seed(42)

--- a/tests/test-inferences/test_metropolishastings.py
+++ b/tests/test-inferences/test_metropolishastings.py
@@ -18,20 +18,28 @@ class test_metropolishastings_class(tf.test.TestCase):
       mu = Normal(loc=0.0, scale=1.0)
       x = Normal(loc=tf.ones(50) * mu, scale=1.0)
 
-      qmu = Empirical(params=tf.Variable(tf.ones(2000)))
+      n_samples = 2000
+      qmu = Empirical(params=tf.Variable(tf.ones(n_samples)))
       proposal_mu = Normal(loc=0.0, scale=1.0)
 
       # analytic solution: N(loc=0.0, scale=\sqrt{1/51}=0.140)
       inference = ed.MetropolisHastings({mu: qmu},
                                         {mu: proposal_mu},
                                         data={x: x_data})
-      reset_ops = inference.reset()
       inference.run()
 
       self.assertAllClose(qmu.mean().eval(), 0, rtol=1e-2, atol=1e-2)
       self.assertAllClose(qmu.stddev().eval(), np.sqrt(1 / 51),
                           rtol=1e-2, atol=1e-2)
 
+      sess = ed.get_session()
+      old_t, old_n_accept = sess.run([inference.t, inference.n_accept])
+      self.assertEquals(old_t, n_samples)
+      self.assertGreater(old_n_accept, 0.1)
+      sess.run(inference.reset)
+      new_t, new_n_accept = sess.run([inference.t, inference.n_accept])
+      self.assertEquals(new_t, 0)
+      self.assertEquals(new_n_accept, 0)
 
 if __name__ == '__main__':
   ed.set_seed(42)


### PR DESCRIPTION
This is a small PR that adds reset ops to the `MonteCarlo` class. This makes it possible to run a chain more than once.

My motivating use case is composing MCMC inference with other algorithms, which requires the ability to either run a chain indefinitely (e.g. using a circular buffer of samples) or the ability to run a fresh chain to convergence each iteration. I've got an ICML paper coming out soon that takes the latter approach, which I'm trying to reimplement in Edward—there'll be a few more PRs related to that coming.