### PR TITLE
Add reset op for all inference classes

### DIFF
--- a/edward/inferences/inference.py
+++ b/edward/inferences/inference.py
@@ -151,10 +151,10 @@ class Inference(object):
   def initialize(self, n_iter=1000, n_print=None, scale=None, logdir=None,
                  log_timestamp=True, log_vars=None, debug=False):
     """Initialize inference algorithm. It initializes hyperparameters
-    and builds ops for the algorithm's computational graph. No ops
-    should be created outside the call to ``initialize()``.
+    and builds ops for the algorithm's computation graph.
 
     Any derived class of ``Inference`` **must** implement this method.
+    No methods which build ops should be called outside ``initialize()``.
 
     Parameters
     ----------
@@ -219,6 +219,10 @@ class Inference(object):
     self.debug = debug
     if self.debug:
       self.op_check = tf.add_check_numerics_ops()
+
+    # Store reset ops which user can call. Subclasses should append
+    # any ops needed to reset internal variables in inference.
+    self.reset = [tf.variables_initializer([self.t])]
 
   @abc.abstractmethod
   def update(self, feed_dict=None):

--- a/edward/inferences/inference.py
+++ b/edward/inferences/inference.py
@@ -29,6 +29,10 @@ class Inference(object):
   minimum implement ``initialize`` and ``update``: the former builds
   the computational graph for the algorithm; the latter runs the
   computational graph for the algorithm.
+
+  To reset inference (e.g., internal variable counters incremented
+  over training), fetch inference's reset ops from session with
+  ``sess.run(inference.reset)``.
   """
   def __init__(self, latent_vars=None, data=None):
     """Initialization.

--- a/edward/inferences/monte_carlo.py
+++ b/edward/inferences/monte_carlo.py
@@ -97,8 +97,7 @@ class MonteCarlo(Inference):
     self.n_accept_over_t = self.n_accept / self.t
     self.train = self.build_update()
 
-    # Subclasses should append any other ops needed to reset chain state
-    self.reset = [tf.assign(self.t, 0), tf.assign(self.n_accept, 0)]
+    self.reset.append(tf.variables_initializer([self.n_accept]))
 
     if self.logging:
       summary_key = 'summaries_' + str(id(self))

--- a/tests/test-inferences/test_inference_reset.py
+++ b/tests/test-inferences/test_inference_reset.py
@@ -1,0 +1,34 @@
+"""Test that reset op works."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import edward as ed
+import tensorflow as tf
+
+from edward.models import Normal
+
+
+class test_inference_reset_class(tf.test.TestCase):
+
+  def test(self):
+    with self.test_session() as sess:
+      mu = Normal(loc=0.0, scale=1.0)
+      x = Normal(loc=mu, scale=1.0, sample_shape=5)
+
+      qmu = Normal(loc=tf.Variable(0.0), scale=tf.constant(1.0))
+
+      inference = ed.KLqp({mu: qmu}, data={x: tf.zeros(5)})
+      inference.initialize()
+      tf.global_variables_initializer().run()
+
+      first = sess.run(inference.t)
+      inference.update()
+      second = sess.run(inference.t)
+      self.assertEqual(first, second - 1)
+      sess.run(inference.reset)
+      third = sess.run(inference.t)
+      self.assertEqual(first, third)
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tests/test-inferences/test_klqp.py
+++ b/tests/test-inferences/test_klqp.py
@@ -38,7 +38,7 @@ class test_klqp_class(tf.test.TestCase):
       sess.run(inference.reset)
       new_t, new_variables = sess.run([inference.t, variables])
       self.assertEqual(new_t, 0)
-      self.assertNotEquals(old_variables, new_variables)
+      self.assertNotEqual(old_variables, new_variables)
 
 if __name__ == '__main__':
   ed.set_seed(42)

--- a/tests/test-inferences/test_klqp.py
+++ b/tests/test-inferences/test_klqp.py
@@ -23,12 +23,22 @@ class test_klqp_class(tf.test.TestCase):
       qmu = Normal(loc=qmu_loc, scale=qmu_scale)
 
       # analytic solution: N(loc=0.0, scale=\sqrt{1/51}=0.140)
+      n_iter = 5000
       inference = ed.KLqp({mu: qmu}, data={x: x_data})
-      inference.run(n_iter=5000)
+      inference.run(n_iter=n_iter)
 
       self.assertAllClose(qmu.mean().eval(), 0, rtol=1e-1, atol=1e-1)
       self.assertAllClose(qmu.stddev().eval(), np.sqrt(1 / 51),
                           rtol=1e-1, atol=1e-1)
+
+      variables = tf.get_collection(
+          tf.GraphKeys.GLOBAL_VARIABLES, scope='optimizer')
+      old_t, old_variables = sess.run([inference.t, variables])
+      self.assertEqual(old_t, n_iter)
+      sess.run(inference.reset)
+      new_t, new_variables = sess.run([inference.t, variables])
+      self.assertEqual(new_t, 0)
+      self.assertNotEquals(old_variables, new_variables)
 
 if __name__ == '__main__':
   ed.set_seed(42)

--- a/tests/test-inferences/test_metropolishastings.py
+++ b/tests/test-inferences/test_metropolishastings.py
@@ -33,12 +33,12 @@ class test_metropolishastings_class(tf.test.TestCase):
                           rtol=1e-2, atol=1e-2)
 
       old_t, old_n_accept = sess.run([inference.t, inference.n_accept])
-      self.assertEquals(old_t, n_samples)
+      self.assertEqual(old_t, n_samples)
       self.assertGreater(old_n_accept, 0.1)
       sess.run(inference.reset)
       new_t, new_n_accept = sess.run([inference.t, inference.n_accept])
-      self.assertEquals(new_t, 0)
-      self.assertEquals(new_n_accept, 0)
+      self.assertEqual(new_t, 0)
+      self.assertEqual(new_n_accept, 0)
 
 if __name__ == '__main__':
   ed.set_seed(42)


### PR DESCRIPTION
This builds off #674 to include reset ops for variational inference and inference more generally. Users can reset inference by calling
```python
sess = ed.get_session()
sess.run(inference.reset)
```