### PR TITLE
WIP: multiple iters per sample

### DIFF
--- a/edward/inferences/sghmc.py
+++ b/edward/inferences/sghmc.py
@@ -69,7 +69,8 @@ class SGHMC(MonteCarlo):
 
     Implements the update equations from (15) of Chen et al. (2014).
     """
-    old_sample = {z: tf.gather(qz.params, tf.maximum(self.t - 1, 0))
+    idx = tf.floor_div(tf.maximum(self.t - 1, 0), self.iters_per_sample)
+    old_sample = {z: tf.gather(qz.params, idx)
                   for z, qz in six.iteritems(self.latent_vars)}
     old_v_sample = {z: v for z, v in six.iteritems(self.v)}
 
@@ -97,7 +98,8 @@ class SGHMC(MonteCarlo):
     assign_ops = []
     for z, qz in six.iteritems(self.latent_vars):
       variable = qz.get_variables()[0]
-      assign_ops.append(tf.scatter_update(variable, self.t, sample[z]))
+      idx = tf.floor_div(self.t, self.iters_per_sample)
+      assign_ops.append(tf.scatter_update(variable, idx, sample[z]))
       assign_ops.append(tf.assign(self.v[z], v_sample[z]).op)
 
     # Increment n_accept.


### PR DESCRIPTION
With long simulations, storing every Monte Carlo sample is not going to fit in memory, nor really meaningful. For instance with minibatches, for me storing samples per minibatch is too much, only once per full data should be enough.

This is the simple if somewhat hacky solution that uses `floor_div` to only increment the empirical index once every iters_per_sample. I guess another solution could be to allocate a separate variable for current state, and have a separate "sample" index that could be conditionally incremented or something (this could also be used to store nothing during burnin). This would make sense if we don't want to store the latent parameters at all. (Rather than storing the model, it might in some cases make sense to just store predictions of the model). What do you think would be the best?