### PR TITLE
Seal all Edward modules

### DIFF
--- a/edward/__init__.py
+++ b/edward/__init__.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 from edward import criticisms
 from edward import inferences
+from edward import models
 from edward import util
 
 # Direct imports for convenience
@@ -21,4 +22,70 @@ from edward.util import check_data, check_latent_vars, copy, dot, \
     get_descendants, get_parents, get_session, get_siblings, get_variables, \
     logit, Progbar, random_variables, rbf, reduce_logmeanexp, set_seed, \
     to_simplex
-from edward.version import __version__
+from edward.version import __version__, VERSION
+
+from tensorflow.python.util.all_util import remove_undocumented
+
+# Export modules and constants.
+_allowed_symbols = [
+    'criticisms',
+    'inferences',
+    'models',
+    'util',
+    'evaluate',
+    'ppc',
+    'ppc_density_plot',
+    'ppc_stat_hist_plot',
+    'Inference',
+    'MonteCarlo',
+    'VariationalInference',
+    'HMC',
+    'MetropolisHastings',
+    'SGLD',
+    'SGHMC',
+    'KLpq',
+    'KLqp',
+    'ReparameterizationKLqp',
+    'ReparameterizationKLKLqp',
+    'ReparameterizationEntropyKLqp',
+    'ScoreKLqp',
+    'ScoreKLKLqp',
+    'ScoreEntropyKLqp',
+    'GANInference',
+    'BiGANInference',
+    'WGANInference',
+    'ImplicitKLqp',
+    'MAP',
+    'Laplace',
+    'complete_conditional',
+    'Gibbs',
+    'RandomVariable',
+    'check_data',
+    'check_latent_vars',
+    'copy',
+    'dot',
+    'get_ancestors',
+    'get_blanket',
+    'get_children',
+    'get_control_variate_coef',
+    'get_descendants',
+    'get_parents',
+    'get_session',
+    'get_siblings',
+    'get_variables',
+    'logit',
+    'Progbar',
+    'random_variables',
+    'rbf',
+    'reduce_logmeanexp',
+    'set_seed',
+    'to_simplex',
+    '__version__',
+    'VERSION',
+]
+
+# Remove all extra symbols that don't have a docstring or are not explicitly
+# referenced in the whitelist.
+remove_undocumented(__name__, _allowed_symbols, [
+    criticisms, inferences, models, util
+])

--- a/edward/criticisms/__init__.py
+++ b/edward/criticisms/__init__.py
@@ -1,3 +1,5 @@
+"""
+"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -5,3 +7,14 @@ from __future__ import print_function
 from edward.criticisms.evaluate import *
 from edward.criticisms.ppc import *
 from edward.criticisms.ppc_plots import *
+
+from tensorflow.python.util.all_util import remove_undocumented
+
+_allowed_symbols = [
+    'evaluate',
+    'ppc',
+    'ppc_density_plot',
+    'ppc_stat_hist_plot',
+]
+
+remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)

--- a/edward/inferences/__init__.py
+++ b/edward/inferences/__init__.py
@@ -1,9 +1,11 @@
+"""
+"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
 from edward.inferences.bigan_inference import *
-from edward.inferences.conjugacy import complete_conditional
+from edward.inferences.conjugacy import *
 from edward.inferences.gan_inference import *
 from edward.inferences.gibbs import *
 from edward.inferences.hmc import *
@@ -19,3 +21,33 @@ from edward.inferences.sgld import *
 from edward.inferences.sghmc import *
 from edward.inferences.variational_inference import *
 from edward.inferences.wgan_inference import *
+
+from tensorflow.python.util.all_util import remove_undocumented
+
+_allowed_symbols = [
+    'BiGANInference',
+    'complete_conditional',
+    'GANInference',
+    'Gibbs',
+    'HMC',
+    'ImplicitKLqp',
+    'Inference',
+    'KLpq',
+    'KLqp',
+    'ReparameterizationKLqp',
+    'ReparameterizationKLKLqp',
+    'ReparameterizationEntropyKLqp',
+    'ScoreKLqp',
+    'ScoreKLKLqp',
+    'ScoreEntropyKLqp',
+    'Laplace',
+    'MAP',
+    'MetropolisHastings',
+    'MonteCarlo',
+    'SGLD',
+    'SGHMC',
+    'VariationalInference',
+    'WGANInference',
+]
+
+remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)

--- a/edward/inferences/conjugacy/__init__.py
+++ b/edward/inferences/conjugacy/__init__.py
@@ -1,5 +1,15 @@
+"""
+"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
 from edward.inferences.conjugacy.conjugacy import *
+
+from tensorflow.python.util.all_util import remove_undocumented
+
+_allowed_symbols = [
+    'complete_conditional',
+]
+
+remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)

--- a/edward/inferences/conjugacy/conjugacy.py
+++ b/edward/inferences/conjugacy/conjugacy.py
@@ -33,7 +33,7 @@ _suff_stat_to_dist['binary'][(('#x',),)] = (
 _suff_stat_to_dist['01'][(('#Log', ('#One_minus', ('#x',))),
                           ('#Log', ('#x',)))] = (
     Beta, lambda p1, p2: {'concentration1': p2 + 1,
-                              'concentration0': p1 + 1})
+                          'concentration0': p1 + 1})
 _suff_stat_to_dist['categorical'][(('#OneHot', ('#x',),),)] = (
     Categorical, lambda p1: {'logits': p1})
 _suff_stat_to_dist['nonnegative'][(('#Log', ('#x',)),)] = (

--- a/edward/inferences/conjugacy/conjugacy.py
+++ b/edward/inferences/conjugacy/conjugacy.py
@@ -11,7 +11,7 @@ import time
 from collections import defaultdict
 from edward.inferences.conjugacy.simplify \
     import symbolic_suff_stat, full_simplify, expr_contains, reconstruct_expr
-from edward.models import random_variables as rvs
+from edward.models.random_variables import *
 from edward.util import copy, get_blanket
 
 
@@ -29,33 +29,33 @@ def normal_from_natural_params(p1, p2):
 
 _suff_stat_to_dist = defaultdict(dict)
 _suff_stat_to_dist['binary'][(('#x',),)] = (
-    rvs.Bernoulli, lambda p1: {'logits': p1})
+    Bernoulli, lambda p1: {'logits': p1})
 _suff_stat_to_dist['01'][(('#Log', ('#One_minus', ('#x',))),
                           ('#Log', ('#x',)))] = (
-    rvs.Beta, lambda p1, p2: {'concentration1': p2 + 1,
+    Beta, lambda p1, p2: {'concentration1': p2 + 1,
                               'concentration0': p1 + 1})
 _suff_stat_to_dist['categorical'][(('#OneHot', ('#x',),),)] = (
-    rvs.Categorical, lambda p1: {'logits': p1})
+    Categorical, lambda p1: {'logits': p1})
 _suff_stat_to_dist['nonnegative'][(('#Log', ('#x',)),)] = (
-    rvs.Chi2, lambda p1: {'df': 2.0 * (p1 + 1)})
+    Chi2, lambda p1: {'df': 2.0 * (p1 + 1)})
 _suff_stat_to_dist['simplex'][(('#Log', ('#x',)),)] = (
-    rvs.Dirichlet, lambda p1: {'concentration': p1 + 1})
+    Dirichlet, lambda p1: {'concentration': p1 + 1})
 _suff_stat_to_dist['nonnegative'][(('#x',),)] = (
-    rvs.Exponential, lambda p1: {'rate': -p1})
+    Exponential, lambda p1: {'rate': -p1})
 _suff_stat_to_dist['nonnegative'][(('#Log', ('#x',)),
                                    ('#x',))] = (
-    rvs.Gamma, lambda p1, p2: {'concentration': p1 + 1, 'rate': -p2})
+    Gamma, lambda p1, p2: {'concentration': p1 + 1, 'rate': -p2})
 _suff_stat_to_dist['nonnegative'][(('#CPow-1.0000e+00', ('#x',)),
                                    ('#Log', ('#x',)))] = (
-    rvs.InverseGamma, lambda p1, p2: {'concentration': -p2 - 1, 'rate': -p1})
+    InverseGamma, lambda p1, p2: {'concentration': -p2 - 1, 'rate': -p1})
 _suff_stat_to_dist['multivariate_real'][(('#CPow2.0000e+00', ('#x',)),
                                         ('#x',))] = (
-    rvs.MultivariateNormalDiag, mvn_diag_from_natural_params)
+    MultivariateNormalDiag, mvn_diag_from_natural_params)
 _suff_stat_to_dist['real'][(('#CPow2.0000e+00', ('#x',)),
                             ('#x',))] = (
-    rvs.Normal, normal_from_natural_params)
+    Normal, normal_from_natural_params)
 _suff_stat_to_dist['countable'][(('#x',),)] = (
-    rvs.Poisson, lambda p1: {'rate': tf.exp(p1)})
+    Poisson, lambda p1: {'rate': tf.exp(p1)})
 
 
 def complete_conditional(rv, cond_set=None):

--- a/edward/inferences/conjugacy/conjugate_log_probs.py
+++ b/edward/inferences/conjugacy/conjugate_log_probs.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 import numpy as np
 import tensorflow as tf
 
-from edward.models import random_variables as rvs
+from edward.models.random_variables import *
 
 
 def _val_wrapper(f):
@@ -150,17 +150,17 @@ def poisson_log_prob(self, val):
   return result
 
 
-rvs.Bernoulli.conjugate_log_prob = bernoulli_log_prob
-rvs.Beta.conjugate_log_prob = beta_log_prob
-rvs.Binomial.conjugate_log_prob = binomial_log_prob
-rvs.Categorical.conjugate_log_prob = categorical_log_prob
-rvs.Chi2.conjugate_log_prob = chi2_log_prob
-rvs.Dirichlet.conjugate_log_prob = dirichlet_log_prob
-rvs.Exponential.conjugate_log_prob = exponential_log_prob
-rvs.Gamma.conjugate_log_prob = gamma_log_prob
-rvs.InverseGamma.conjugate_log_prob = inverse_gamma_log_prob
-rvs.Laplace.conjugate_log_prob = laplace_log_prob
-rvs.Multinomial.conjugate_log_prob = multinomial_log_prob
-rvs.MultivariateNormalDiag.conjugate_log_prob = mvn_diag_log_prob
-rvs.Normal.conjugate_log_prob = normal_log_prob
-rvs.Poisson.conjugate_log_prob = poisson_log_prob
+Bernoulli.conjugate_log_prob = bernoulli_log_prob
+Beta.conjugate_log_prob = beta_log_prob
+Binomial.conjugate_log_prob = binomial_log_prob
+Categorical.conjugate_log_prob = categorical_log_prob
+Chi2.conjugate_log_prob = chi2_log_prob
+Dirichlet.conjugate_log_prob = dirichlet_log_prob
+Exponential.conjugate_log_prob = exponential_log_prob
+Gamma.conjugate_log_prob = gamma_log_prob
+InverseGamma.conjugate_log_prob = inverse_gamma_log_prob
+Laplace.conjugate_log_prob = laplace_log_prob
+Multinomial.conjugate_log_prob = multinomial_log_prob
+MultivariateNormalDiag.conjugate_log_prob = mvn_diag_log_prob
+Normal.conjugate_log_prob = normal_log_prob
+Poisson.conjugate_log_prob = poisson_log_prob

--- a/edward/models/__init__.py
+++ b/edward/models/__init__.py
@@ -8,9 +8,11 @@ from edward.models.dirichlet_process import *
 from edward.models.empirical import *
 from edward.models.param_mixture import *
 from edward.models.point_mass import *
-from edward.models.random_variable import *
+from edward.models.random_variable import RandomVariable
+from edward.models.random_variables import *
 
 from tensorflow.python.util.all_util import remove_undocumented
+from edward.models import random_variables as _module
 
 _allowed_symbols = [
     'DirichletProcess',
@@ -19,8 +21,11 @@ _allowed_symbols = [
     'PointMass',
     'RandomVariable',
 ]
+for name in dir(_module):
+  obj = getattr(_module, name)
+  if (isinstance(obj, type) and
+          issubclass(obj, RandomVariable) and
+          obj != RandomVariable):
+    _allowed_symbols.append(name)
 
 remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)
-
-# Import after auto-sealing modules above; we manually seal the below.
-from edward.models.random_variables import *

--- a/edward/models/__init__.py
+++ b/edward/models/__init__.py
@@ -1,3 +1,5 @@
+"""
+"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -7,4 +9,18 @@ from edward.models.empirical import *
 from edward.models.param_mixture import *
 from edward.models.point_mass import *
 from edward.models.random_variable import *
+
+from tensorflow.python.util.all_util import remove_undocumented
+
+_allowed_symbols = [
+    'DirichletProcess',
+    'Empirical',
+    'ParamMixture',
+    'PointMass',
+    'RandomVariable',
+]
+
+remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)
+
+# Import after auto-sealing modules above; we manually seal the below.
 from edward.models.random_variables import *

--- a/edward/models/random_variables.py
+++ b/edward/models/random_variables.py
@@ -2,22 +2,22 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import inspect
+import inspect as _inspect
 
-from edward.models.random_variable import RandomVariable
-from tensorflow.contrib import distributions
+from edward.models.random_variable import RandomVariable as _RandomVariable
+from tensorflow.contrib import distributions as _distributions
 
 # Automatically generate random variable classes from classes in
 # tf.contrib.distributions.
 _globals = globals()
-for _name in sorted(dir(distributions)):
-  _candidate = getattr(distributions, _name)
-  if (inspect.isclass(_candidate) and
-          _candidate != distributions.Distribution and
-          issubclass(_candidate, distributions.Distribution)):
+for _name in sorted(dir(_distributions)):
+  _candidate = getattr(_distributions, _name)
+  if (_inspect.isclass(_candidate) and
+          _candidate != _distributions.Distribution and
+          issubclass(_candidate, _distributions.Distribution)):
 
-    params = {'__doc__': _candidate.__doc__}
-    _globals[_name] = type(_name, (RandomVariable, _candidate), params)
+    _params = {'__doc__': _candidate.__doc__}
+    _globals[_name] = type(_name, (_RandomVariable, _candidate), _params)
 
     del _candidate
 
@@ -36,3 +36,7 @@ Multinomial.support = 'onehot'
 MultivariateNormalDiag.support = 'multivariate_real'
 Normal.support = 'real'
 Poisson.support = 'countable'
+
+del absolute_import
+del division
+del print_function

--- a/edward/util/__init__.py
+++ b/edward/util/__init__.py
@@ -1,3 +1,5 @@
+"""
+"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -6,3 +8,30 @@ from edward.util.graphs import *
 from edward.util.progbar import *
 from edward.util.random_variables import *
 from edward.util.tensorflow import *
+
+from tensorflow.python.util.all_util import remove_undocumented
+
+_allowed_symbols = [
+    'check_data',
+    'check_latent_vars',
+    'copy',
+    'dot',
+    'get_ancestors',
+    'get_blanket',
+    'get_children',
+    'get_control_variate_coef',
+    'get_descendants',
+    'get_parents',
+    'get_session',
+    'get_siblings',
+    'get_variables',
+    'logit',
+    'Progbar',
+    'random_variables',
+    'rbf',
+    'reduce_logmeanexp',
+    'set_seed',
+    'to_simplex',
+]
+
+remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)

--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -79,7 +79,7 @@ def check_latent_vars(latent_vars):
                       "dtype: {}, {}".format(key.dtype, value.dtype))
 
 
-def copy_default(x, *args, **kwargs):
+def _copy_default(x, *args, **kwargs):
   if isinstance(x, (RandomVariable, tf.Operation, tf.Tensor, tf.Variable)):
     x = copy(x, *args, **kwargs)
 
@@ -216,16 +216,16 @@ def copy(org_instance, dict_swap=None, scope="copied",
     rv = org_instance
 
     # If it has copiable arguments, copy them.
-    args = [copy_default(arg, dict_swap, scope, True, copy_q)
+    args = [_copy_default(arg, dict_swap, scope, True, copy_q)
             for arg in rv._args]
 
     kwargs = {}
     for key, value in six.iteritems(rv._kwargs):
       if isinstance(value, list):
-        kwargs[key] = [copy_default(v, dict_swap, scope, True, copy_q)
+        kwargs[key] = [_copy_default(v, dict_swap, scope, True, copy_q)
                        for v in value]
       else:
-        kwargs[key] = copy_default(value, dict_swap, scope, True, copy_q)
+        kwargs[key] = _copy_default(value, dict_swap, scope, True, copy_q)
 
     kwargs['name'] = new_name
     # Create new random variable with copied arguments.

--- a/edward/version.py
+++ b/edward/version.py
@@ -1,1 +1,2 @@
 __version__ = '1.3.3'
+VERSION = __version__

--- a/tests/test-criticisms/test_metrics.py
+++ b/tests/test-criticisms/test_metrics.py
@@ -5,32 +5,32 @@ from __future__ import print_function
 import numpy as np
 import tensorflow as tf
 
-from edward import criticisms
+from edward.criticisms.evaluate import *
 
 all_classification_metrics = [
-    criticisms.binary_accuracy,
-    criticisms.sparse_categorical_accuracy,
+    binary_accuracy,
+    sparse_categorical_accuracy,
 ]
 
 all_real_classification_metrics = [
-    criticisms.binary_crossentropy,
-    criticisms.categorical_crossentropy,
-    criticisms.hinge,
-    criticisms.squared_hinge,
+    binary_crossentropy,
+    categorical_crossentropy,
+    hinge,
+    squared_hinge,
 ]
 
 all_regression_metrics = [
-    criticisms.mean_squared_error,
-    criticisms.mean_absolute_error,
-    criticisms.mean_absolute_percentage_error,
-    criticisms.mean_squared_logarithmic_error,
-    criticisms.poisson,
-    criticisms.cosine_proximity,
+    mean_squared_error,
+    mean_absolute_error,
+    mean_absolute_percentage_error,
+    mean_squared_logarithmic_error,
+    poisson,
+    cosine_proximity,
 ]
 
 all_specialized_input_output_metrics = [
-    criticisms.categorical_accuracy,
-    criticisms.sparse_categorical_crossentropy,
+    categorical_accuracy,
+    sparse_categorical_crossentropy,
 ]
 
 
@@ -60,11 +60,11 @@ class test_metrics_class(tf.test.TestCase):
   def test_specialized_input_output_metrics(self):
     with self.test_session():
       for metric in all_specialized_input_output_metrics:
-        if metric == criticisms.categorical_accuracy:
+        if metric == categorical_accuracy:
           y_true = tf.convert_to_tensor(np.random.randint(0, 1, (6, 7)))
           y_pred = tf.convert_to_tensor(np.random.randint(0, 7, (6,)))
           self.assertEqual(metric(y_true, y_pred).eval().shape, ())
-        elif metric == criticisms.sparse_categorical_crossentropy:
+        elif metric == sparse_categorical_crossentropy:
           y_true = tf.convert_to_tensor(np.random.randint(0, 5, (6)))
           y_pred = tf.random_normal([6, 7])
           self.assertEqual(metric(y_true, y_pred).eval().shape, ())

--- a/tests/test-inferences/test_simplify.py
+++ b/tests/test-inferences/test_simplify.py
@@ -6,7 +6,7 @@ import edward as ed
 import numpy as np
 import tensorflow as tf
 
-from edward.inferences.conjugacy import simplify
+from edward.inferences.conjugacy.simplify import *
 
 
 class test_simplify_class(tf.test.TestCase):
@@ -15,171 +15,171 @@ class test_simplify_class(tf.test.TestCase):
     a = tf.constant(1.0)
     b = tf.constant(2.0)
     c = tf.constant(3.0)
-    ab = simplify._mul_n([a, b])
-    abc = simplify._mul_n([a, b, c])
+    ab = _mul_n([a, b])
+    abc = _mul_n([a, b, c])
 
     with self.test_session() as sess:
       self.assertEqual(sess.run(ab), 2.0)
       self.assertEqual(sess.run(abc), 6.0)
 
   def test_is_number(self):
-    self.assertTrue(simplify.is_number(1))
-    self.assertFalse(simplify.is_number('one'))
+    self.assertTrue(is_number(1))
+    self.assertFalse(is_number('one'))
 
   def test_identity_op_simplify(self):
     expr = ('#Identity', ('#Mul', ('#Identity', ('#x',)),
                           ('#Identity', (3.7,))))
-    did_something, new_expr = simplify.identity_op_simplify(expr)
+    did_something, new_expr = identity_op_simplify(expr)
     self.assertTrue(did_something)
     self.assertEqual(new_expr, ('#Mul', ('#x',), (3.7,)))
-    did_something, new_expr = simplify.power_op_simplify(new_expr)
+    did_something, new_expr = power_op_simplify(new_expr)
     self.assertFalse(did_something)
 
   def test_pow_simplify_and_power_op_simplify(self):
     expr = ('#Square', ('#Reciprocal', ('#Sqrt', ('#x',))))
-    did_something, new_expr = simplify.power_op_simplify(expr)
+    did_something, new_expr = power_op_simplify(expr)
     self.assertTrue(did_something)
     self.assertEqual(new_expr,
                      ('#CPow2.0000e+00',
                       ('#CPow-1.0000e+00', ('#CPow5.0000e-01', ('#x',)))))
-    did_something, new_expr = simplify.power_op_simplify(new_expr)
+    did_something, new_expr = power_op_simplify(new_expr)
     self.assertFalse(did_something)
 
-    did_something, new_expr = simplify.pow_simplify(new_expr)
+    did_something, new_expr = pow_simplify(new_expr)
     self.assertTrue(did_something)
     self.assertEqual(new_expr, ('#CPow-1.0000e+00', ('#x',)))
-    did_something, new_expr = simplify.pow_simplify(new_expr)
+    did_something, new_expr = pow_simplify(new_expr)
     self.assertFalse(did_something)
 
   def test_log_cpow_simplify(self):
     expr = ('#Log', ('#CPow2.3000e+01', ('#x',)))
-    did_something, new_expr = simplify.log_pow_simplify(expr)
+    did_something, new_expr = log_pow_simplify(expr)
     self.assertTrue(did_something)
     self.assertEqual(new_expr, ('#Mul', (2.3000e+01,), ('#Log', ('#x',))))
-    did_something, new_expr = simplify.log_pow_simplify(new_expr)
+    did_something, new_expr = log_pow_simplify(new_expr)
     self.assertFalse(did_something)
 
   def test_log_pow_simplify(self):
     expr = ('#Mul', (3.3,), ('#Log', ('#Pow', (2.3,), (1.3,))))
-    did_something, new_expr = simplify.log_pow_simplify(expr)
+    did_something, new_expr = log_pow_simplify(expr)
     self.assertTrue(did_something)
     self.assertEqual(new_expr, ('#Mul', (3.3,), ('#Mul', (1.3,),
                                                  ('#Log', (2.3,)))))
-    did_something, new_expr = simplify.log_pow_simplify(new_expr)
+    did_something, new_expr = log_pow_simplify(new_expr)
     self.assertFalse(did_something)
 
   def test_log_mul_simplify(self):
     expr = ('#Log', ('#Mul', (3,), (4.2,), (1.2e+01,), ('#x',)))
-    did_something, new_expr = simplify.log_mul_simplify(expr)
+    did_something, new_expr = log_mul_simplify(expr)
     self.assertTrue(did_something)
     self.assertEqual(new_expr, ('#Add', ('#Log', (3,)),
                                 ('#Log', (4.2,)), ('#Log', (1.2e+01,)),
                                 ('#Log', ('#x',))))
-    did_something, new_expr = simplify.log_mul_simplify(new_expr)
+    did_something, new_expr = log_mul_simplify(new_expr)
     self.assertFalse(did_something)
 
   def test_cpow_mul_simplify(self):
     expr = ('#CPow2.1', ('#Mul', (3,), (4.0,), (1.2e+01,)))
-    did_something, new_expr = simplify.pow_mul_simplify(expr)
+    did_something, new_expr = pow_mul_simplify(expr)
     self.assertTrue(did_something)
     self.assertEqual(new_expr, ('#Mul', ('#CPow2.1', (3,)),
                                 ('#CPow2.1', (4.0,)),
                                 ('#CPow2.1', (1.2e+01,))))
-    did_something, new_expr = simplify.pow_mul_simplify(new_expr)
+    did_something, new_expr = pow_mul_simplify(new_expr)
     self.assertFalse(did_something)
 
   def test_pow_mul_simplify(self):
     expr = ('#Pow', ('#Mul', (3,), (4.0,), (1.2e+01,)), (2.1,))
-    did_something, new_expr = simplify.pow_mul_simplify(expr)
+    did_something, new_expr = pow_mul_simplify(expr)
     self.assertTrue(did_something)
     self.assertEqual(new_expr, ('#Mul', ('#Pow', (3,), (2.1,)),
                                 ('#Pow', (4.0,), (2.1,)),
                                 ('#Pow', (1.2e+01,), (2.1,))))
-    did_something, new_expr = simplify.pow_mul_simplify(new_expr)
+    did_something, new_expr = pow_mul_simplify(new_expr)
     self.assertFalse(did_something)
 
   def test_mul_add_simplify(self):
     expr = ('#Mul', ('#Add', (3.0,), (2.0,)),
             ('#Add', (4.0,), (5.0,)))
-    did_something, new_expr = simplify.mul_add_simplify(expr)
+    did_something, new_expr = mul_add_simplify(expr)
     self.assertTrue(did_something)
     self.assertEqual(new_expr, ('#Add', ('#Add', ('#Mul', (3.0,), (4.0,)),
                                          ('#Mul', (3.0,), (5.0,))),
                                 ('#Add', ('#Mul', (2.0,), (4.0,)),
                                  ('#Mul', (2.0,), (5.0,)))))
-    did_something, new_expr = simplify.pow_mul_simplify(new_expr)
+    did_something, new_expr = pow_mul_simplify(new_expr)
     self.assertFalse(did_something)
 
   def test_add_add_simplify(self):
     expr = ('#Add', (3.0,), ('#Add', (4.0,), (5.0,), ('#Add', (6.0,))))
-    did_something, new_expr = simplify.add_add_simplify(expr)
+    did_something, new_expr = add_add_simplify(expr)
     self.assertTrue(did_something)
     self.assertEqual(new_expr, ('#Add', (3.0,), (4.0,), (5.0,), (6.0,)))
-    did_something, new_expr = simplify.add_add_simplify(new_expr)
+    did_something, new_expr = add_add_simplify(new_expr)
     self.assertFalse(did_something)
 
   def test_mul_mul_simplify(self):
     expr = ('#Mul', (3.0,), ('#Mul', (4.0,), (5.0,), ('#Mul', (6.0,))))
-    did_something, new_expr = simplify.mul_mul_simplify(expr)
+    did_something, new_expr = mul_mul_simplify(expr)
     self.assertTrue(did_something)
     self.assertEqual(new_expr, ('#Mul', (3.0,), (4.0,), (5.0,), (6.0,)))
-    did_something, new_expr = simplify.mul_mul_simplify(new_expr)
+    did_something, new_expr = mul_mul_simplify(new_expr)
     self.assertFalse(did_something)
 
   def test_mul_one_simplify(self):
     expr = ('#Mul', (3.0,), (1.0,), (4.0,), (5.0,), (6.0,), (1.0,))
-    did_something, new_expr = simplify.mul_one_simplify(expr)
+    did_something, new_expr = mul_one_simplify(expr)
     self.assertTrue(did_something)
     self.assertEqual(new_expr, ('#Mul', (3.0,), (4.0,), (5.0,), (6.0,)))
-    did_something, new_expr = simplify.mul_one_simplify(new_expr)
+    did_something, new_expr = mul_one_simplify(new_expr)
     self.assertFalse(did_something)
 
   def test_add_zero_simplify(self):
     expr = ('#Add', (3.0,), (0.0,), (4.0,), (5.0,), (6.0,), (0.0,))
-    did_something, new_expr = simplify.add_zero_simplify(expr)
+    did_something, new_expr = add_zero_simplify(expr)
     self.assertTrue(did_something)
     self.assertEqual(new_expr, ('#Add', (3.0,), (4.0,), (5.0,), (6.0,)))
-    did_something, new_expr = simplify.add_zero_simplify(new_expr)
+    did_something, new_expr = add_zero_simplify(new_expr)
     self.assertFalse(did_something)
 
   def test_mul_zero_simplify(self):
     expr = ('#Mul', (3.0,), (0.0,), (5.0,), (6.0,), (1.0,))
-    did_something, new_expr = simplify.mul_zero_simplify(expr)
+    did_something, new_expr = mul_zero_simplify(expr)
     self.assertTrue(did_something)
     self.assertEqual(new_expr, (0,))
-    did_something, new_expr = simplify.mul_zero_simplify(new_expr)
+    did_something, new_expr = mul_zero_simplify(new_expr)
     self.assertFalse(did_something)
 
   def test_square_add_simplify(self):
     expr = ('#CPow2.0000e+00', ('#Add', (1.0,), ('#Neg', (2.0,))))
-    did_something, new_expr = simplify.square_add_simplify(expr)
+    did_something, new_expr = square_add_simplify(expr)
     self.assertTrue(did_something)
     self.assertEqual(new_expr, ('#Add', ('#CPow2.0000e+00', (1.0,)),
                                 ('#Mul', (2.0,), (1.0,), ('#Neg', (2.0,))),
                                 ('#CPow2.0000e+00', ('#Neg', (2.0,)))))
-    did_something, new_expr = simplify.square_add_simplify(new_expr)
+    did_something, new_expr = square_add_simplify(new_expr)
     self.assertFalse(did_something)
 
   def test_expr_contains(self):
     expr = ('#Add', ('#Mul', (1.5, ('#CPow1.2000e+00', ('#x',)))),
             ('#Mul', (1.2,), (7,)))
-    self.assertTrue(simplify.expr_contains(expr, '#x'))
-    self.assertFalse(simplify.expr_contains(expr, '#CPow'))
-    self.assertTrue(simplify.expr_contains(expr, '#CPow1.2000e+00'))
-    self.assertTrue(simplify.expr_contains(expr, '#Mul'))
-    self.assertTrue(simplify.expr_contains(expr, '#Add'))
-    self.assertTrue(simplify.expr_contains(expr[1], '#x'))
-    self.assertFalse(simplify.expr_contains(expr[2], '#x'))
+    self.assertTrue(expr_contains(expr, '#x'))
+    self.assertFalse(expr_contains(expr, '#CPow'))
+    self.assertTrue(expr_contains(expr, '#CPow1.2000e+00'))
+    self.assertTrue(expr_contains(expr, '#Mul'))
+    self.assertTrue(expr_contains(expr, '#Add'))
+    self.assertTrue(expr_contains(expr[1], '#x'))
+    self.assertFalse(expr_contains(expr[2], '#x'))
 
   def test_add_const_simplify(self):
     expr = ('#Add', ('#Mul', (1.5, ('#CPow1.2000e+00', ('#x',)))),
             ('#Mul', (1.2,), (7,)))
-    did_something, new_expr = simplify.add_const_simplify(expr)
+    did_something, new_expr = add_const_simplify(expr)
     self.assertTrue(did_something)
     self.assertEqual(new_expr, ('#Add', ('#Mul',
                                          (1.5,
                                           ('#CPow1.2000e+00', ('#x',))))))
-    did_something, new_expr = simplify.add_const_simplify(new_expr)
+    did_something, new_expr = add_const_simplify(new_expr)
     self.assertFalse(did_something)
 
 

--- a/tests/test-inferences/test_simplify.py
+++ b/tests/test-inferences/test_simplify.py
@@ -7,6 +7,7 @@ import numpy as np
 import tensorflow as tf
 
 from edward.inferences.conjugacy.simplify import *
+from edward.inferences.conjugacy.simplify import _mul_n
 
 
 class test_simplify_class(tf.test.TestCase):


### PR DESCRIPTION
This PR removes any namespace bloat in Edward modules. We take the approach as described in [TensorFlow's documentation guide](https://www.tensorflow.org/community/documentation).

For example, before this PR:
```python
ed.inferences.__dict__.keys()
## ['GANInference', 'inference', 'klqp', 'build_score_loss_and_gradients', 'conjugacy', 'random', 'ReparameterizationKLKLqp', 'absolute_import', 'check_latent_vars', 'ReparameterizationKLqp', '__path__', 'build_score_entropy_loss_and_gradients', 'Gibbs', 'SGHMC', 'build_score_kl_loss_and_gradients', 'OrderedDict', 'hinge_loss', 'PointMass', 'KLqp', 'copy', 'ReparameterizationEntropyKLqp', 'ScoreKLqp', 'pt', 'Normal', 'datetime', 'VariationalInference', 'check_data', 'six', 'complete_conditional', 'KLpq', 'BiGANInference', '__package__', 'MonteCarlo', 'kl_divergence', 'bigan_inference', 'gibbs', 'sghmc', 'tf', 'ImplicitKLqp', 'Uniform', '__doc__', 'np', 'HMC', 'division', 'get_session', 'build_reparam_loss_and_gradients', 'MAP', '__builtins__', '__file__', 'ScoreEntropyKLqp', 'Empirical', 'wgan_inference', 'monte_carlo', 'variational_inference', 'abc', 'MultivariateNormalTriL', 'MetropolisHastings', '__name__', 'gan_inference', 'Laplace', 'print_function', 'hmc', 'leapfrog', 'SGLD', 'metropolis_hastings', 'Inference', 'build_reparam_kl_loss_and_gradients', 'build_reparam_entropy_loss_and_gradients', 'klpq', 'os', 'ScoreKLKLqp', 'MultivariateNormalDiag', 'get_variables', 'map', 'log_loss', 'WGANInference', 'RandomVariable', 'sgld', 'Progbar', 'laplace', 'implicit_klqp']
len(ed.inferences.__dict__.keys())
## 81 
```

After this PR:
```python
ed.inferences.__dict__.keys()
## ['GANInference', 'ReparameterizationKLKLqp', 'ReparameterizationKLqp', '__path__', 'Gibbs', 'SGHMC', 'KLqp', 'ReparameterizationEntropyKLqp', 'ScoreKLqp', 'VariationalInference', 'complete_conditional', 'KLpq', 'BiGANInference', '__package__', 'MonteCarlo', 'ImplicitKLqp', '__doc__', 'HMC', 'MAP', '__builtins__', '__file__', 'ScoreEntropyKLqp', 'MetropolisHastings', '__name__', 'Laplace', 'SGLD', 'Inference', '_allowed_symbols', 'ScoreKLKLqp', 'WGANInference']
len(ed.inferences.__dict__.keys())
## 30
```

This is one step in progress towards #681.