### PR TITLE
Reformat all docstrings from NumPy style to TensorFlow style

### DIFF
--- a/docs/tex/contributing.tex
+++ b/docs/tex/contributing.tex
@@ -56,14 +56,10 @@ Write code in this fork with the following guidelines.
 Follow
 \href{https://www.tensorflow.org/community/style_guide}{TensorFlow's
 style guide}
-for writing code, which more or less follows PEP 8.
+for writing code.
 Follow
-\href{https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt}
-{NumPy's documentation guide}
-for writing documentation,
-and follow
 \href{https://www.tensorflow.org/community/documentation}{TensorFlow's documentation guide}
-for describing TensorFlow tensors in the documentation.
+for writing documentation.
 
 \textbf{Unit testing.}
 Unit testing is awesome. It's useful not only

--- a/edward/criticisms/evaluate.py
+++ b/edward/criticisms/evaluate.py
@@ -27,62 +27,61 @@ def evaluate(metrics, data, n_samples=500, output_key=None):
   the probability of observing the data is calculated under the
   posterior predictive's log-density.
 
-  Parameters
-  ----------
-  metrics : list of str or str
-    List of metrics or a single metric:
-    ``'binary_accuracy'``,
-    ``'categorical_accuracy'``,
-    ``'sparse_categorical_accuracy'``,
-    ``'log_loss'`` or ``'binary_crossentropy'``,
-    ``'categorical_crossentropy'``,
-    ``'sparse_categorical_crossentropy'``,
-    ``'hinge'``,
-    ``'squared_hinge'``,
-    ``'mse'`` or ``'MSE'`` or ``'mean_squared_error'``,
-    ``'mae'`` or ``'MAE'`` or ``'mean_absolute_error'``,
-    ``'mape'`` or ``'MAPE'`` or ``'mean_absolute_percentage_error'``,
-    ``'msle'`` or ``'MSLE'`` or ``'mean_squared_logarithmic_error'``,
-    ``'poisson'``,
-    ``'cosine'`` or ``'cosine_proximity'``,
-    ``'log_lik'`` or ``'log_likelihood'``.
-  data : dict
-    Data to evaluate model with. It binds observed variables (of type
-    ``RandomVariable`` or ``tf.Tensor``) to their realizations (of
-    type ``tf.Tensor``). It can also bind placeholders (of type
-    ``tf.Tensor``) used in the model to their realizations.
-  n_samples : int, optional
-    Number of posterior samples for making predictions, using the
-    posterior predictive distribution.
-  output_key : RandomVariable or tf.Tensor, optional
-    It is the key in ``data`` which corresponds to the model's output.
+  Args:
+    metrics: list of str or str.
+      List of metrics or a single metric:
+      `'binary_accuracy'`,
+      `'categorical_accuracy'`,
+      `'sparse_categorical_accuracy'`,
+      `'log_loss'` or `'binary_crossentropy'`,
+      `'categorical_crossentropy'`,
+      `'sparse_categorical_crossentropy'`,
+      `'hinge'`,
+      `'squared_hinge'`,
+      `'mse'` or `'MSE'` or `'mean_squared_error'`,
+      `'mae'` or `'MAE'` or `'mean_absolute_error'`,
+      `'mape'` or `'MAPE'` or `'mean_absolute_percentage_error'`,
+      `'msle'` or `'MSLE'` or `'mean_squared_logarithmic_error'`,
+      `'poisson'`,
+      `'cosine'` or `'cosine_proximity'`,
+      `'log_lik'` or `'log_likelihood'`.
+    data: dict.
+      Data to evaluate model with. It binds observed variables (of type
+      `RandomVariable` or `tf.Tensor`) to their realizations (of
+      type `tf.Tensor`). It can also bind placeholders (of type
+      `tf.Tensor`) used in the model to their realizations.
+    n_samples: int, optional.
+      Number of posterior samples for making predictions, using the
+      posterior predictive distribution.
+    output_key: RandomVariable or tf.Tensor, optional.
+      It is the key in `data` which corresponds to the model's output.
 
-  Returns
-  -------
-  list of float or float
+  Returns:
+    list of float or float.
     A list of evaluations or a single evaluation.
 
-  Raises
-  ------
-  NotImplementedError
+  Raises:
+    NotImplementedError.
     If an input metric does not match an implemented metric in Edward.
 
-  Examples
-  --------
-  >>> # build posterior predictive after inference: it is
-  >>> # parameterized by a posterior sample
-  >>> x_post = ed.copy(x, {z: qz, beta: qbeta})
-  >>>
-  >>> # log-likelihood performance
-  >>> ed.evaluate('log_likelihood', data={x_post: x_train})
-  >>>
-  >>> # classification accuracy
-  >>> # here, ``x_ph`` is any features the model is defined with respect to,
-  >>> # and ``y_post`` is the posterior predictive distribution
-  >>> ed.evaluate('binary_accuracy', data={y_post: y_train, x_ph: x_train})
-  >>>
-  >>> # mean squared error
-  >>> ed.evaluate('mean_squared_error', data={y: y_data, x: x_data})
+  #### Examples
+
+  ```python
+  # build posterior predictive after inference: it is
+  # parameterized by a posterior sample
+  x_post = ed.copy(x, {z: qz, beta: qbeta})
+
+  # log-likelihood performance
+  ed.evaluate('log_likelihood', data={x_post: x_train})
+
+  # classification accuracy
+  # here, `x_ph` is any features the model is defined with respect to,
+  # and `y_post` is the posterior predictive distribution
+  ed.evaluate('binary_accuracy', data={y_post: y_train, x_ph: x_train})
+
+  # mean squared error
+  ed.evaluate('mean_squared_error', data={y: y_data, x: x_data})
+  ```
   """
   sess = get_session()
   if isinstance(metrics, str):
@@ -197,12 +196,11 @@ def evaluate(metrics, data, n_samples=500, output_key=None):
 def binary_accuracy(y_true, y_pred):
   """Binary prediction accuracy, also known as 0/1-loss.
 
-  Parameters
-  ----------
-  y_true : tf.Tensor
-    Tensor of 0s and 1s (most generally, any real values a and b).
-  y_pred : tf.Tensor
-    Tensor of predictions, with same shape as ``y_true``.
+  Args:
+    y_true: tf.Tensor.
+      Tensor of 0s and 1s (most generally, any real values a and b).
+    y_pred: tf.Tensor.
+      Tensor of predictions, with same shape as `y_true`.
   """
   y_true = tf.cast(y_true, tf.float32)
   y_pred = tf.cast(y_pred, tf.float32)
@@ -210,16 +208,15 @@ def binary_accuracy(y_true, y_pred):
 
 
 def categorical_accuracy(y_true, y_pred):
-  """Multi-class prediction accuracy. One-hot representation for ``y_true``.
+  """Multi-class prediction accuracy. One-hot representation for `y_true`.
 
-  Parameters
-  ----------
-  y_true : tf.Tensor
-    Tensor of 0s and 1s, where the outermost dimension of size ``K``
-    has only one 1 per row.
-  y_pred : tf.Tensor
-    Tensor of predictions, with shape ``y_true.shape[:-1]``. Each
-    entry is an integer {0, 1, ..., K-1}.
+  Args:
+    y_true: tf.Tensor.
+      Tensor of 0s and 1s, where the outermost dimension of size `K`
+      has only one 1 per row.
+    y_pred: tf.Tensor.
+      Tensor of predictions, with shape `y_true.shape[:-1]`. Each
+      entry is an integer {0, 1, ..., K-1}.
   """
   y_true = tf.cast(tf.argmax(y_true, len(y_true.shape) - 1), tf.float32)
   y_pred = tf.cast(y_pred, tf.float32)
@@ -228,14 +225,13 @@ def categorical_accuracy(y_true, y_pred):
 
 def sparse_categorical_accuracy(y_true, y_pred):
   """Multi-class prediction accuracy. Label {0, 1, .., K-1}
-  representation for ``y_true``.
+  representation for `y_true`.
 
-  Parameters
-  ----------
-  y_true : tf.Tensor
-    Tensor of integers {0, 1, ..., K-1}.
-  y_pred : tf.Tensor
-    Tensor of predictions, with same shape as ``y_true``.
+  Args:
+    y_true: tf.Tensor.
+      Tensor of integers {0, 1, ..., K-1}.
+    y_pred: tf.Tensor.
+      Tensor of predictions, with same shape as `y_true`.
   """
   y_true = tf.cast(y_true, tf.float32)
   y_pred = tf.cast(y_pred, tf.float32)
@@ -248,13 +244,12 @@ def sparse_categorical_accuracy(y_true, y_pred):
 def binary_crossentropy(y_true, y_pred):
   """Binary cross-entropy.
 
-  Parameters
-  ----------
-  y_true : tf.Tensor
-    Tensor of 0s and 1s.
-  y_pred : tf.Tensor
-    Tensor of real values (logit probabilities), with same shape as
-    ``y_true``.
+  Args:
+    y_true: tf.Tensor.
+      Tensor of 0s and 1s.
+    y_pred: tf.Tensor.
+      Tensor of real values (logit probabilities), with same shape as
+      `y_true`.
   """
   y_true = tf.cast(y_true, tf.float32)
   y_pred = tf.cast(y_pred, tf.float32)
@@ -263,16 +258,15 @@ def binary_crossentropy(y_true, y_pred):
 
 
 def categorical_crossentropy(y_true, y_pred):
-  """Multi-class cross entropy. One-hot representation for ``y_true``.
+  """Multi-class cross entropy. One-hot representation for `y_true`.
 
-  Parameters
-  ----------
-  y_true : tf.Tensor
-    Tensor of 0s and 1s, where the outermost dimension of size K
-    has only one 1 per row.
-  y_pred : tf.Tensor
-    Tensor of real values (logit probabilities), with same shape as
-    ``y_true``. The outermost dimension is the number of classes.
+  Args:
+    y_true: tf.Tensor.
+      Tensor of 0s and 1s, where the outermost dimension of size K
+      has only one 1 per row.
+    y_pred: tf.Tensor.
+      Tensor of real values (logit probabilities), with same shape as
+      `y_true`. The outermost dimension is the number of classes.
   """
   y_true = tf.cast(y_true, tf.float32)
   y_pred = tf.cast(y_pred, tf.float32)
@@ -282,15 +276,14 @@ def categorical_crossentropy(y_true, y_pred):
 
 def sparse_categorical_crossentropy(y_true, y_pred):
   """Multi-class cross entropy. Label {0, 1, .., K-1} representation
-  for ``y_true.``
+  for `y_true.`
 
-  Parameters
-  ----------
-  y_true : tf.Tensor
-    Tensor of integers {0, 1, ..., K-1}.
-  y_pred : tf.Tensor
-    Tensor of real values (logit probabilities), with shape
-    ``(y_true.shape, K)``. The outermost dimension is the number of classes.
+  Args:
+    y_true: tf.Tensor.
+      Tensor of integers {0, 1, ..., K-1}.
+    y_pred: tf.Tensor.
+      Tensor of real values (logit probabilities), with shape
+      `(y_true.shape, K)`. The outermost dimension is the number of classes.
   """
   y_true = tf.cast(y_true, tf.int64)
   y_pred = tf.cast(y_pred, tf.float32)
@@ -301,12 +294,11 @@ def sparse_categorical_crossentropy(y_true, y_pred):
 def hinge(y_true, y_pred):
   """Hinge loss.
 
-  Parameters
-  ----------
-  y_true : tf.Tensor
-    Tensor of 0s and 1s.
-  y_pred : tf.Tensor
-    Tensor of real values, with same shape as ``y_true``.
+  Args:
+    y_true: tf.Tensor.
+      Tensor of 0s and 1s.
+    y_pred: tf.Tensor.
+      Tensor of real values, with same shape as `y_true`.
   """
   y_true = tf.cast(y_true, tf.float32)
   y_pred = tf.cast(y_pred, tf.float32)
@@ -316,12 +308,11 @@ def hinge(y_true, y_pred):
 def squared_hinge(y_true, y_pred):
   """Squared hinge loss.
 
-  Parameters
-  ----------
-  y_true : tf.Tensor
-    Tensor of 0s and 1s.
-  y_pred : tf.Tensor
-    Tensor of real values, with same shape as ``y_true``.
+  Args:
+    y_true: tf.Tensor.
+      Tensor of 0s and 1s.
+    y_pred: tf.Tensor.
+      Tensor of real values, with same shape as `y_true`.
   """
   y_true = tf.cast(y_true, tf.float32)
   y_pred = tf.cast(y_pred, tf.float32)
@@ -334,11 +325,10 @@ def squared_hinge(y_true, y_pred):
 def mean_squared_error(y_true, y_pred):
   """Mean squared error loss.
 
-  Parameters
-  ----------
-  y_true : tf.Tensor
-  y_pred : tf.Tensor
-    Tensors of same shape and type.
+  Args:
+    y_true: tf.Tensor.
+    y_pred: tf.Tensor.
+      Tensors of same shape and type.
   """
   return tf.reduce_mean(tf.square(y_pred - y_true))
 
@@ -346,11 +336,10 @@ def mean_squared_error(y_true, y_pred):
 def mean_absolute_error(y_true, y_pred):
   """Mean absolute error loss.
 
-  Parameters
-  ----------
-  y_true : tf.Tensor
-  y_pred : tf.Tensor
-    Tensors of same shape and type.
+  Args:
+    y_true: tf.Tensor.
+    y_pred: tf.Tensor.
+      Tensors of same shape and type.
   """
   return tf.reduce_mean(tf.abs(y_pred - y_true))
 
@@ -358,11 +347,10 @@ def mean_absolute_error(y_true, y_pred):
 def mean_absolute_percentage_error(y_true, y_pred):
   """Mean absolute percentage error loss.
 
-  Parameters
-  ----------
-  y_true : tf.Tensor
-  y_pred : tf.Tensor
-    Tensors of same shape and type.
+  Args:
+    y_true: tf.Tensor.
+    y_pred: tf.Tensor.
+      Tensors of same shape and type.
   """
   diff = tf.abs((y_true - y_pred) / tf.clip_by_value(tf.abs(y_true),
                                                      1e-8, np.inf))
@@ -372,11 +360,10 @@ def mean_absolute_percentage_error(y_true, y_pred):
 def mean_squared_logarithmic_error(y_true, y_pred):
   """Mean squared logarithmic error loss.
 
-  Parameters
-  ----------
-  y_true : tf.Tensor
-  y_pred : tf.Tensor
-    Tensors of same shape and type.
+  Args:
+    y_true: tf.Tensor.
+    y_pred: tf.Tensor.
+      Tensors of same shape and type.
   """
   first_log = tf.log(tf.clip_by_value(y_pred, 1e-8, np.inf) + 1.0)
   second_log = tf.log(tf.clip_by_value(y_true, 1e-8, np.inf) + 1.0)
@@ -384,14 +371,13 @@ def mean_squared_logarithmic_error(y_true, y_pred):
 
 
 def poisson(y_true, y_pred):
-  """Negative Poisson log-likelihood of data ``y_true`` given predictions
-  ``y_pred`` (up to proportion).
+  """Negative Poisson log-likelihood of data `y_true` given predictions
+  `y_pred` (up to proportion).
 
-  Parameters
-  ----------
-  y_true : tf.Tensor
-  y_pred : tf.Tensor
-    Tensors of same shape and type.
+  Args:
+    y_true: tf.Tensor.
+    y_pred: tf.Tensor.
+      Tensors of same shape and type.
   """
   return tf.reduce_sum(y_pred - y_true * tf.log(y_pred + 1e-8))
 
@@ -399,11 +385,10 @@ def poisson(y_true, y_pred):
 def cosine_proximity(y_true, y_pred):
   """Cosine similarity of two vectors.
 
-  Parameters
-  ----------
-  y_true : tf.Tensor
-  y_pred : tf.Tensor
-    Tensors of same shape and type.
+  Args:
+    y_true: tf.Tensor.
+    y_pred: tf.Tensor.
+      Tensors of same shape and type.
   """
   y_true = tf.nn.l2_normalize(y_true, len(y_true.shape) - 1)
   y_pred = tf.nn.l2_normalize(y_pred, len(y_pred.shape) - 1)

--- a/edward/criticisms/ppc.py
+++ b/edward/criticisms/ppc.py
@@ -16,70 +16,69 @@ def ppc(T, data, latent_vars=None, n_samples=100):
 
   PPC's form an empirical distribution for the predictive discrepancy,
 
-  .. math::
-    p(T\mid x) = \int p(T(x^{\\text{rep}})\mid z) p(z\mid x) dz
+  $p(T\mid x) = \int p(T(x^{\\text{rep}})\mid z) p(z\mid x) dz$
 
-  by drawing replicated data sets :math:`x^{\\text{rep}}` and
-  calculating :math:`T(x^{\\text{rep}})` for each data set. Then it
-  compares it to :math:`T(x)`.
+  by drawing replicated data sets \\(x^{\\text{rep}}\\) and
+  calculating \\(T(x^{\\text{rep}})\\) for each data set. Then it
+  compares it to \\(T(x)\\).
 
-  If ``data`` is inputted with the prior predictive distribution, then
+  If `data` is inputted with the prior predictive distribution, then
   it is a prior predictive check (Box, 1980).
 
-  Parameters
-  ----------
-  T : function
-    Discrepancy function, which takes a dictionary of data and
-    dictionary of latent variables as input and outputs a ``tf.Tensor``.
-  data : dict
-    Data to compare to. It binds observed variables (of type
-    ``RandomVariable`` or ``tf.Tensor``) to their realizations (of
-    type ``tf.Tensor``). It can also bind placeholders (of type
-    ``tf.Tensor``) used in the model to their realizations.
-  latent_vars : dict, optional
-    Collection of random variables (of type ``RandomVariable`` or
-    ``tf.Tensor``) binded to their inferred posterior. This argument
-    is used when the discrepancy is a function of latent variables.
-  n_samples : int, optional
-    Number of replicated data sets.
+  Args:
+    T: function.
+      Discrepancy function, which takes a dictionary of data and
+      dictionary of latent variables as input and outputs a `tf.Tensor`.
+    data: dict.
+      Data to compare to. It binds observed variables (of type
+      `RandomVariable` or `tf.Tensor`) to their realizations (of
+      type `tf.Tensor`). It can also bind placeholders (of type
+      `tf.Tensor`) used in the model to their realizations.
+    latent_vars: dict, optional.
+      Collection of random variables (of type `RandomVariable` or
+      `tf.Tensor`) binded to their inferred posterior. This argument
+      is used when the discrepancy is a function of latent variables.
+    n_samples: int, optional.
+      Number of replicated data sets.
 
-  Returns
-  -------
-  list of np.ndarray
+  Returns:
+    list of np.ndarray.
     List containing the reference distribution, which is a NumPy array
-    with ``n_samples`` elements,
+    with `n_samples` elements,
 
     .. math::
       (T(x^{{\\text{rep}},1}, z^{1}), ...,
        T(x^{\\text{rep,nsamples}}, z^{\\text{nsamples}}))
 
     and the realized discrepancy, which is a NumPy array with
-    ``n_samples`` elements,
+    `n_samples` elements,
 
     .. math::
       (T(x, z^{1}), ..., T(x, z^{\\text{nsamples}})).
 
 
-  Examples
-  --------
-  >>> # build posterior predictive after inference:
-  >>> # it is parameterized by a posterior sample
-  >>> x_post = ed.copy(x, {z: qz, beta: qbeta})
-  >>>
-  >>> # posterior predictive check
-  >>> # T is a user-defined function of data, T(data)
-  >>> T = lambda xs, zs: tf.reduce_mean(xs[x_post])
-  >>> ed.ppc(T, data={x_post: x_train})
-  >>>
-  >>> # in general T is a discrepancy function of the data (both response and
-  >>> # covariates) and latent variables, T(data, latent_vars)
-  >>> T = lambda xs, zs: tf.reduce_mean(zs[z])
-  >>> ed.ppc(T, data={y_post: y_train, x_ph: x_train},
-  ...        latent_vars={z: qz, beta: qbeta})
-  >>>
-  >>> # prior predictive check
-  >>> # run ppc on original x
-  >>> ed.ppc(T, data={x: x_train})
+  #### Examples
+
+  ```python
+  # build posterior predictive after inference:
+  # it is parameterized by a posterior sample
+  x_post = ed.copy(x, {z: qz, beta: qbeta})
+
+  # posterior predictive check
+  # T is a user-defined function of data, T(data)
+  T = lambda xs, zs: tf.reduce_mean(xs[x_post])
+  ed.ppc(T, data={x_post: x_train})
+
+  # in general T is a discrepancy function of the data (both response and
+  # covariates) and latent variables, T(data, latent_vars)
+  T = lambda xs, zs: tf.reduce_mean(zs[z])
+  ed.ppc(T, data={y_post: y_train, x_ph: x_train},
+         latent_vars={z: qz, beta: qbeta})
+
+  # prior predictive check
+  # run ppc on original x
+  ed.ppc(T, data={x: x_train})
+  ```
   """
   sess = get_session()
   if not callable(T):
@@ -116,8 +115,8 @@ def ppc(T, data, latent_vars=None, n_samples=100):
     # Take a forward pass (session run) to get new samples for
     # each calculation of the discrepancy.
     # Alternatively, we could unroll the graph by registering this
-    # operation ``n_samples`` times, each for different parent nodes
-    # representing ``xrep`` and ``zrep``. But it's expensive.
+    # operation `n_samples` times, each for different parent nodes
+    # representing `xrep` and `zrep`. But it's expensive.
     Treps += [sess.run(Trep, feed_dict)]
     Ts += [sess.run(Tobs, feed_dict)]
 

--- a/edward/criticisms/ppc.py
+++ b/edward/criticisms/ppc.py
@@ -46,15 +46,13 @@ def ppc(T, data, latent_vars=None, n_samples=100):
     List containing the reference distribution, which is a NumPy array
     with `n_samples` elements,
 
-    .. math::
-      (T(x^{{\\text{rep}},1}, z^{1}), ...,
-       T(x^{\\text{rep,nsamples}}, z^{\\text{nsamples}}))
+    $(T(x^{{\\text{rep}},1}, z^{1}), ...,
+       T(x^{\\text{rep,nsamples}}, z^{\\text{nsamples}}))$
 
     and the realized discrepancy, which is a NumPy array with
     `n_samples` elements,
 
-    .. math::
-      (T(x, z^{1}), ..., T(x, z^{\\text{nsamples}})).
+    $(T(x, z^{1}), ..., T(x, z^{\\text{nsamples}})).$
 
 
   #### Examples

--- a/edward/criticisms/ppc.py
+++ b/edward/criticisms/ppc.py
@@ -18,9 +18,9 @@ def ppc(T, data, latent_vars=None, n_samples=100):
 
   $p(T\mid x) = \int p(T(x^{\\text{rep}})\mid z) p(z\mid x) dz$
 
-  by drawing replicated data sets \\(x^{\\text{rep}}\\) and
-  calculating \\(T(x^{\\text{rep}})\\) for each data set. Then it
-  compares it to \\(T(x)\\).
+  by drawing replicated data sets $x^{\\text{rep}}$ and
+  calculating $T(x^{\\text{rep}})$ for each data set. Then it
+  compares it to $T(x)$.
 
   If `data` is inputted with the prior predictive distribution, then
   it is a prior predictive check (Box, 1980).

--- a/edward/criticisms/ppc_plots.py
+++ b/edward/criticisms/ppc_plots.py
@@ -11,16 +11,14 @@ except ImportError:
 def ppc_density_plot(y, y_rep):
   """Create 1D kernel density plot comparing data to samples from posterior.
 
-  Parameters
-  ----------
-  y : np.ndarray
-    A 1-D NumPy array.
-  y_rep : np.ndarray
-    A 2-D NumPy array where rows represent different samples from posterior.
+  Args:
+    y: np.ndarray.
+      A 1-D NumPy array.
+    y_rep: np.ndarray.
+      A 2-D NumPy array where rows represent different samples from posterior.
 
-  Returns
-  -------
-  matplotlib axes
+  Returns:
+    matplotlib axes
   """
   ax = sns.kdeplot(y, color="maroon")
 
@@ -43,21 +41,18 @@ def ppc_density_plot(y, y_rep):
 def ppc_stat_hist_plot(y_stats, yrep_stats, stat_name=None, **kwargs):
   """Create histogram plot comparing data to samples from posterior.
 
-  Parameters
-  ----------
-  y_stats : float
-    Float representing statistic value of observed data.
-  yrep_stats : np.ndarray
-    A 1-D NumPy array.
-  stat_name : string, optional
-    Optional string value for including statistic name in legend.
-  **kwargs
-    Keyword arguments used by seaborn.distplot can be given to customize plot.
+  Args:
+    y_stats: float.
+      Float representing statistic value of observed data.
+    yrep_stats: np.ndarray.
+      A 1-D NumPy array.
+    stat_name: string, optional.
+      Optional string value for including statistic name in legend.
+    **kwargs:
+      Keyword arguments used by seaborn.distplot can be given to customize plot.
 
-
-  Returns
-  -------
-  matplotlib axes
+  Returns:
+    matplotlib axes.
   """
   ax = sns.distplot(yrep_stats, kde=False, label=r'$T(y_{rep})$', **kwargs)
 

--- a/edward/inferences/bigan_inference.py
+++ b/edward/inferences/bigan_inference.py
@@ -20,9 +20,9 @@ class BiGANInference(GANInference):
   """
   def __init__(self, latent_vars, data, discriminator):
     """
-    Notes
-    -----
-    ``BiGANInference`` matches a mapping from data to latent variables and a
+    #### Notes
+
+    `BiGANInference` matches a mapping from data to latent variables and a
     mapping from latent variables to data through a joint
     discriminator.
 
@@ -33,12 +33,14 @@ class BiGANInference(GANInference):
     encoder and decoder parameters can be accessed with the variable scope
     "Gen".
 
-    Examples
-    --------
-    >>> with tf.variable_scope("Gen"):
-    >>>   xf = gen_data(z_ph)
-    >>>   zf = gen_latent(x_ph)
-    >>> inference = ed.BiGANInference({z_ph: zf}, {xf: x_ph}, discriminator)
+    #### Examples
+
+    ```python
+    with tf.variable_scope("Gen"):
+      xf = gen_data(z_ph)
+      zf = gen_latent(x_ph)
+    inference = ed.BiGANInference({z_ph: zf}, {xf: x_ph}, discriminator)
+    ```
     """
     if not callable(discriminator):
       raise TypeError("discriminator must be a callable function.")

--- a/edward/inferences/conjugacy/conjugacy.py
+++ b/edward/inferences/conjugacy/conjugacy.py
@@ -59,14 +59,14 @@ _suff_stat_to_dist['countable'][(('#x',),)] = (
 
 
 def complete_conditional(rv, cond_set=None):
-  """Returns the conditional distribution ``RandomVariable``
-  :math:`p(\\text{rv} | \\cdot)`.
+  """Returns the conditional distribution `RandomVariable`
+  \\(p(\text{rv} | \cdot)\\).
 
-  This function tries to infer the conditional distribution of ``rv``
-  given ``cond_set``, a set of other ``RandomVariable``s in the graph. It
+  This function tries to infer the conditional distribution of `rv`
+  given `cond_set`, a set of other `RandomVariable`s in the graph. It
   will only be able to do this if
 
-  1. :math:`p(\\text{rv} | \\text{cond_set})` is in a tractable
+  1. \\(p(\text{rv} | \text{cond_set})\\) is in a tractable
      exponential family, AND
   2. the truth of assumption 1 is not obscured in the TensorFlow graph.
 
@@ -74,21 +74,20 @@ def complete_conditional(rv, cond_set=None):
   relationships when they exist. But it may not always be able to do the
   necessary algebra.
 
-  Parameters
-  ----------
-  rv : RandomVariable
-    The random variable whose conditional distribution we are interested in.
-  cond_set : iterable of RandomVariable, optional
-    The set of random variables we want to condition on. Default is all
-    random variables in the graph. (It makes no difference if ``cond_set``
-    does or does not include ``rv``.)
+  Args:
+    rv: RandomVariable.
+      The random variable whose conditional distribution we are interested in.
+    cond_set: iterable of RandomVariable, optional.
+      The set of random variables we want to condition on. Default is all
+      random variables in the graph. (It makes no difference if `cond_set`
+      does or does not include `rv`.)
 
-  Notes
-  -----
-  When calling ``complete_conditional()`` multiple times, one should
-  usually pass an explicit ``cond_set``. Otherwise
-  ``complete_conditional()`` will try to condition on the
-  ``RandomVariable``s returned by previous calls to itself. This may
+  #### Notes
+
+  When calling `complete_conditional()` multiple times, one should
+  usually pass an explicit `cond_set`. Otherwise
+  `complete_conditional()` will try to condition on the
+  `RandomVariable`s returned by previous calls to itself. This may
   result in unpredictable behavior.
   """
   if cond_set is None:

--- a/edward/inferences/conjugacy/conjugacy.py
+++ b/edward/inferences/conjugacy/conjugacy.py
@@ -60,14 +60,14 @@ _suff_stat_to_dist['countable'][(('#x',),)] = (
 
 def complete_conditional(rv, cond_set=None):
   """Returns the conditional distribution `RandomVariable`
-  $p(\\text{rv} | \cdot)$.
+  $p(\\text{rv}\mid \cdot)$.
 
   This function tries to infer the conditional distribution of `rv`
   given `cond_set`, a set of other `RandomVariable`s in the graph. It
   will only be able to do this if
 
-  1. $p(\\text{rv} | \\text{cond_set})$ is in a tractable
-     exponential family; AND
+  1. $p(\\text{rv}\mid \\text{cond\_set})$ is in a tractable
+     exponential family; and
   2. the truth of assumption 1 is not obscured in the TensorFlow graph.
 
   In other words, this function will do its best to recognize conjugate

--- a/edward/inferences/conjugacy/conjugacy.py
+++ b/edward/inferences/conjugacy/conjugacy.py
@@ -60,14 +60,14 @@ _suff_stat_to_dist['countable'][(('#x',),)] = (
 
 def complete_conditional(rv, cond_set=None):
   """Returns the conditional distribution `RandomVariable`
-  \\(p(\text{rv} | \cdot)\\).
+  $p(\\text{rv} | \cdot)$.
 
   This function tries to infer the conditional distribution of `rv`
   given `cond_set`, a set of other `RandomVariable`s in the graph. It
   will only be able to do this if
 
-  1. \\(p(\text{rv} | \text{cond_set})\\) is in a tractable
-     exponential family, AND
+  1. $p(\\text{rv} | \\text{cond_set})$ is in a tractable
+     exponential family; AND
   2. the truth of assumption 1 is not obscured in the TensorFlow graph.
 
   In other words, this function will do its best to recognize conjugate

--- a/edward/inferences/gan_inference.py
+++ b/edward/inferences/gan_inference.py
@@ -19,21 +19,20 @@ class GANInference(VariationalInference):
   """
   def __init__(self, data, discriminator):
     """
-    Parameters
-    ----------
-    data : dict
-      Data dictionary which binds observed variables (of type
-      ``RandomVariable`` or ``tf.Tensor``) to their realizations (of
-      type ``tf.Tensor``).  It can also bind placeholders (of type
-      ``tf.Tensor``) used in the model to their realizations.
-    discriminator : function
-      Function (with parameters) to discriminate samples. It should
-      output logit probabilities (real-valued) and not probabilities
-      in [0, 1].
+    Args:
+      data: dict.
+        Data dictionary which binds observed variables (of type
+        `RandomVariable` or `tf.Tensor`) to their realizations (of
+        type `tf.Tensor`).  It can also bind placeholders (of type
+        `tf.Tensor`) used in the model to their realizations.
+      discriminator: function.
+        Function (with parameters) to discriminate samples. It should
+        output logit probabilities (real-valued) and not probabilities
+        in \\([0, 1]\\).
 
-    Notes
-    -----
-    ``GANInference`` does not support latent variable inference. Note
+    #### Notes
+
+    `GANInference` does not support latent variable inference. Note
     that GAN-style training also samples from the prior: this does not
     work well for latent variables that are shared across many data
     points (global variables).
@@ -42,14 +41,16 @@ class GANInference(VariationalInference):
     discriminator's parameters can be accessed with the variable scope
     "Disc".
 
-    GANs also only work for one observed random variable in ``data``.
+    GANs also only work for one observed random variable in `data`.
 
-    Examples
-    --------
-    >>> z = Normal(loc=tf.zeros([100, 10]), scale=tf.ones([100, 10]))
-    >>> x = generative_network(z)
-    >>>
-    >>> inference = ed.GANInference({x: x_data}, discriminator)
+    #### Examples
+
+    ```python
+    z = Normal(loc=tf.zeros([100, 10]), scale=tf.ones([100, 10]))
+    x = generative_network(z)
+
+    inference = ed.GANInference({x: x_data}, discriminator)
+    ```
     """
     if not callable(discriminator):
       raise TypeError("discriminator must be a callable function.")
@@ -64,28 +65,28 @@ class GANInference(VariationalInference):
 
     Parameters
     ----------
-    optimizer : str or tf.train.Optimizer, optional
+    optimizer: str or tf.train.Optimizer, optional
       A TensorFlow optimizer, to use for optimizing the generator
       objective. Alternatively, one can pass in the name of a
       TensorFlow optimizer, and default parameters for the optimizer
       will be used.
-    optimizer_d : str or tf.train.Optimizer, optional
+    optimizer_d: str or tf.train.Optimizer, optional
       A TensorFlow optimizer, to use for optimizing the discriminator
       objective. Alternatively, one can pass in the name of a
       TensorFlow optimizer, and default parameters for the optimizer
       will be used.
-    global_step : tf.Variable, optional
-      Optional ``Variable`` to increment by one after the variables
+    global_step: tf.Variable, optional
+      Optional `Variable` to increment by one after the variables
       for the generator have been updated. See
-      ``tf.train.Optimizer.apply_gradients``.
-    global_step_d : tf.Variable, optional
-      Optional ``Variable`` to increment by one after the variables
+      `tf.train.Optimizer.apply_gradients`.
+    global_step_d: tf.Variable, optional
+      Optional `Variable` to increment by one after the variables
       for the discriminator have been updated. See
-      ``tf.train.Optimizer.apply_gradients``.
-    var_list : list of tf.Variable, optional
+      `tf.train.Optimizer.apply_gradients`.
+    var_list: list of tf.Variable, optional
       List of TensorFlow variables to optimize over (in the generative
-      model). Default is all trainable variables that ``latent_vars``
-      and ``data`` depend on.
+      model). Default is all trainable variables that `latent_vars`
+      and `data` depend on.
     """
     # call grandparent's method; avoid parent (VariationalInference)
     super(VariationalInference, self).initialize(*args, **kwargs)
@@ -149,10 +150,10 @@ class GANInference(VariationalInference):
 
     Parameters
     ----------
-    feed_dict : dict, optional
+    feed_dict: dict, optional
       Feed dictionary for a TensorFlow session run. It is used to feed
       placeholders that are not fed during initialization.
-    variables : str, optional
+    variables: str, optional
       Which set of variables to update. Either "Disc" or "Gen".
       Default is both.
 
@@ -165,7 +166,7 @@ class GANInference(VariationalInference):
     Notes
     -----
     The outputted iteration number is the total number of calls to
-    ``update``. Each update may include updating only a subset of
+    `update`. Each update may include updating only a subset of
     parameters.
     """
     if feed_dict is None:

--- a/edward/inferences/gan_inference.py
+++ b/edward/inferences/gan_inference.py
@@ -28,7 +28,7 @@ class GANInference(VariationalInference):
       discriminator: function.
         Function (with parameters) to discriminate samples. It should
         output logit probabilities (real-valued) and not probabilities
-        in \\([0, 1]\\).
+        in $[0, 1]$.
 
     #### Notes
 

--- a/edward/inferences/gan_inference.py
+++ b/edward/inferences/gan_inference.py
@@ -63,30 +63,29 @@ class GANInference(VariationalInference):
                  *args, **kwargs):
     """Initialize GAN inference.
 
-    Parameters
-    ----------
-    optimizer: str or tf.train.Optimizer, optional
-      A TensorFlow optimizer, to use for optimizing the generator
-      objective. Alternatively, one can pass in the name of a
-      TensorFlow optimizer, and default parameters for the optimizer
-      will be used.
-    optimizer_d: str or tf.train.Optimizer, optional
-      A TensorFlow optimizer, to use for optimizing the discriminator
-      objective. Alternatively, one can pass in the name of a
-      TensorFlow optimizer, and default parameters for the optimizer
-      will be used.
-    global_step: tf.Variable, optional
-      Optional `Variable` to increment by one after the variables
-      for the generator have been updated. See
-      `tf.train.Optimizer.apply_gradients`.
-    global_step_d: tf.Variable, optional
-      Optional `Variable` to increment by one after the variables
-      for the discriminator have been updated. See
-      `tf.train.Optimizer.apply_gradients`.
-    var_list: list of tf.Variable, optional
-      List of TensorFlow variables to optimize over (in the generative
-      model). Default is all trainable variables that `latent_vars`
-      and `data` depend on.
+    Args:
+      optimizer: str or tf.train.Optimizer, optional.
+        A TensorFlow optimizer, to use for optimizing the generator
+        objective. Alternatively, one can pass in the name of a
+        TensorFlow optimizer, and default parameters for the optimizer
+        will be used.
+      optimizer_d: str or tf.train.Optimizer, optional.
+        A TensorFlow optimizer, to use for optimizing the discriminator
+        objective. Alternatively, one can pass in the name of a
+        TensorFlow optimizer, and default parameters for the optimizer
+        will be used.
+      global_step: tf.Variable, optional.
+        Optional `Variable` to increment by one after the variables
+        for the generator have been updated. See
+        `tf.train.Optimizer.apply_gradients`.
+      global_step_d: tf.Variable, optional.
+        Optional `Variable` to increment by one after the variables
+        for the discriminator have been updated. See
+        `tf.train.Optimizer.apply_gradients`.
+      var_list: list of tf.Variable, optional.
+        List of TensorFlow variables to optimize over (in the generative
+        model). Default is all trainable variables that `latent_vars`
+        and `data` depend on.
     """
     # call grandparent's method; avoid parent (VariationalInference)
     super(VariationalInference, self).initialize(*args, **kwargs)
@@ -148,23 +147,21 @@ class GANInference(VariationalInference):
   def update(self, feed_dict=None, variables=None):
     """Run one iteration of optimization.
 
-    Parameters
-    ----------
-    feed_dict: dict, optional
-      Feed dictionary for a TensorFlow session run. It is used to feed
-      placeholders that are not fed during initialization.
-    variables: str, optional
-      Which set of variables to update. Either "Disc" or "Gen".
-      Default is both.
+    Args:
+      feed_dict: dict, optional.
+        Feed dictionary for a TensorFlow session run. It is used to feed
+        placeholders that are not fed during initialization.
+      variables: str, optional.
+        Which set of variables to update. Either "Disc" or "Gen".
+        Default is both.
 
-    Returns
-    -------
-    dict
+    Returns:
+      dict.
       Dictionary of algorithm-specific information. In this case, the
       iteration number and generative and discriminative losses.
 
-    Notes
-    -----
+    #### Notes
+
     The outputted iteration number is the total number of calls to
     `update`. Each update may include updating only a subset of
     parameters.

--- a/edward/inferences/gibbs.py
+++ b/edward/inferences/gibbs.py
@@ -18,22 +18,23 @@ class Gibbs(MonteCarlo):
   """
   def __init__(self, latent_vars, proposal_vars=None, data=None):
     """
-    Parameters
-    ----------
-    proposal_vars : dict of RandomVariable to RandomVariable, optional
-      Collection of random variables to perform inference on; each is
-      binded to its complete conditionals which Gibbs cycles draws on.
-      If not specified, default is to use ``ed.complete_conditional``.
+    Args:
+      proposal_vars: dict of RandomVariable to RandomVariable, optional.
+        Collection of random variables to perform inference on; each is
+        binded to its complete conditionals which Gibbs cycles draws on.
+        If not specified, default is to use `ed.complete_conditional`.
 
-    Examples
-    --------
-    >>> x_data = np.array([0, 1, 0, 0, 0, 0, 0, 0, 0, 1])
-    >>>
-    >>> p = Beta(1.0, 1.0)
-    >>> x = Bernoulli(probs=p, sample_shape=10)
-    >>>
-    >>> qp = Empirical(tf.Variable(tf.zeros(500)))
-    >>> inference = ed.Gibbs({p: qp}, data={x: x_data})
+    #### Examples
+
+    ```python
+    x_data = np.array([0, 1, 0, 0, 0, 0, 0, 0, 0, 1])
+
+    p = Beta(1.0, 1.0)
+    x = Bernoulli(probs=p, sample_shape=10)
+
+    qp = Empirical(tf.Variable(tf.zeros(500)))
+    inference = ed.Gibbs({p: qp}, data={x: x_data})
+    ```
     """
     if proposal_vars is None:
       proposal_vars = {z: complete_conditional(z)
@@ -46,14 +47,13 @@ class Gibbs(MonteCarlo):
 
   def initialize(self, scan_order='random', *args, **kwargs):
     """
-    Parameters
-    ----------
-    scan_order : list or str, optional
-      The scan order for each Gibbs update. If list, it is the
-      deterministic order of latent variables. An element in the list
-      can be a ``RandomVariable`` or itself a list of
-      ``RandomVariable``s (this defines a blocked Gibbs sampler). If
-      'random', will use a random order at each update.
+    Args:
+      scan_order: list or str, optional.
+        The scan order for each Gibbs update. If list, it is the
+        deterministic order of latent variables. An element in the list
+        can be a `RandomVariable` or itself a list of
+        `RandomVariable`s (this defines a blocked Gibbs sampler). If
+        'random', will use a random order at each update.
     """
     self.scan_order = scan_order
     self.feed_dict = {}
@@ -62,15 +62,13 @@ class Gibbs(MonteCarlo):
   def update(self, feed_dict=None):
     """Run one iteration of Gibbs sampling.
 
-    Parameters
-    ----------
-    feed_dict : dict, optional
-      Feed dictionary for a TensorFlow session run. It is used to feed
-      placeholders that are not fed during initialization.
+    Args:
+      feed_dict: dict, optional.
+        Feed dictionary for a TensorFlow session run. It is used to feed
+        placeholders that are not fed during initialization.
 
-    Returns
-    -------
-    dict
+    Returns:
+      dict.
       Dictionary of algorithm-specific information. In this case, the
       acceptance rate of samples since (and including) this iteration.
     """
@@ -129,13 +127,13 @@ class Gibbs(MonteCarlo):
 
   def build_update(self):
     """
-    Notes
-    -----
+    #### Notes
+
     The updates assume each Empirical random variable is directly
-    parameterized by ``tf.Variable``s.
+    parameterized by `tf.Variable`s.
     """
     # Update Empirical random variables according to the complete
-    # conditionals. We will feed the conditionals when calling ``update()``.
+    # conditionals. We will feed the conditionals when calling `update()`.
     assign_ops = []
     for z, qz in six.iteritems(self.latent_vars):
       variable = qz.get_variables()[0]

--- a/edward/inferences/hmc.py
+++ b/edward/inferences/hmc.py
@@ -20,12 +20,12 @@ class HMC(MonteCarlo):
   """Hamiltonian Monte Carlo, also known as hybrid Monte Carlo
   (Duane et al., 1987; Neal, 2011).
 
-  Notes
-  -----
+  #### Notes
+
   In conditional inference, we infer :math:`z` in :math:`p(z, \\beta
   \mid x)` while fixing inference over :math:`\\beta` using another
   distribution :math:`q(\\beta)`.
-  ``HMC`` substitutes the model's log marginal density
+  `HMC` substitutes the model's log marginal density
 
   .. math::
 
@@ -38,25 +38,26 @@ class HMC(MonteCarlo):
   """
   def __init__(self, *args, **kwargs):
     """
-    Examples
-    --------
-    >>> z = Normal(loc=0.0, scale=1.0)
-    >>> x = Normal(loc=tf.ones(10) * z, scale=1.0)
-    >>>
-    >>> qz = Empirical(tf.Variable(tf.zeros(500)))
-    >>> data = {x: np.array([0.0] * 10, dtype=np.float32)}
-    >>> inference = ed.HMC({z: qz}, data)
+    #### Examples
+
+    ```python
+    z = Normal(loc=0.0, scale=1.0)
+    x = Normal(loc=tf.ones(10) * z, scale=1.0)
+
+    qz = Empirical(tf.Variable(tf.zeros(500)))
+    data = {x: np.array([0.0] * 10, dtype=np.float32)}
+    inference = ed.HMC({z: qz}, data)
+    ```
     """
     super(HMC, self).__init__(*args, **kwargs)
 
   def initialize(self, step_size=0.25, n_steps=2, *args, **kwargs):
     """
-    Parameters
-    ----------
-    step_size : float, optional
-      Step size of numerical integrator.
-    n_steps : int, optional
-      Number of steps of numerical integrator.
+    Args:
+      step_size: float, optional.
+        Step size of numerical integrator.
+      n_steps: int, optional.
+        Number of steps of numerical integrator.
     """
     self.step_size = step_size
     self.n_steps = n_steps
@@ -68,10 +69,10 @@ class HMC(MonteCarlo):
     Correct for the integrator's discretization error using an
     acceptance ratio.
 
-    Notes
-    -----
+    #### Notes
+
     The updates assume each Empirical random variable is directly
-    parameterized by ``tf.Variable``s.
+    parameterized by `tf.Variable`s.
     """
     old_sample = {z: tf.gather(qz.params, tf.maximum(self.t - 1, 0))
                   for z, qz in six.iteritems(self.latent_vars)}
@@ -103,7 +104,7 @@ class HMC(MonteCarlo):
     sample_values = tf.cond(accept, lambda: list(six.itervalues(new_sample)),
                             lambda: list(six.itervalues(old_sample)))
     if not isinstance(sample_values, list):
-      # ``tf.cond`` returns tf.Tensor if output is a list of size 1.
+      # `tf.cond` returns tf.Tensor if output is a list of size 1.
       sample_values = [sample_values]
 
     sample = {z: sample_value for z, sample_value in
@@ -123,10 +124,9 @@ class HMC(MonteCarlo):
     """Utility function to calculate model's log joint density,
     log p(x, z), for inputs z (and fixed data x).
 
-    Parameters
-    ----------
-    z_sample : dict
-      Latent variable keys to samples.
+    Args:
+      z_sample: dict.
+        Latent variable keys to samples.
     """
     self.scope_iter += 1
     scope = 'inference_' + str(id(self)) + '/' + str(self.scope_iter)

--- a/edward/inferences/hmc.py
+++ b/edward/inferences/hmc.py
@@ -22,17 +22,17 @@ class HMC(MonteCarlo):
 
   #### Notes
 
-  In conditional inference, we infer \\(z\\) in \\(p(z, \\beta
-  \mid x)\\) while fixing inference over \\(\\beta\\) using another
-  distribution \\(q(\\beta)\\).
+  In conditional inference, we infer $z$ in $p(z, \\beta
+  \mid x)$ while fixing inference over $\\beta$ using another
+  distribution $q(\\beta)$.
   `HMC` substitutes the model's log marginal density
 
   $\log p(x, z) = \log \mathbb{E}_{q(\\beta)} [ p(x, z, \\beta) ]
                 \\approx \log p(x, z, \\beta^*)$
 
-  leveraging a single Monte Carlo sample, where \\(\\beta^* \sim
-  q(\\beta)\\). This is unbiased (and therefore asymptotically exact as a
-  pseudo-marginal method) if \\(q(\\beta) = p(\\beta \mid x)\\).
+  leveraging a single Monte Carlo sample, where $\\beta^* \sim
+  q(\\beta)$. This is unbiased (and therefore asymptotically exact as a
+  pseudo-marginal method) if $q(\\beta) = p(\\beta \mid x)$.
   """
   def __init__(self, *args, **kwargs):
     """

--- a/edward/inferences/hmc.py
+++ b/edward/inferences/hmc.py
@@ -22,19 +22,17 @@ class HMC(MonteCarlo):
 
   #### Notes
 
-  In conditional inference, we infer :math:`z` in :math:`p(z, \\beta
-  \mid x)` while fixing inference over :math:`\\beta` using another
-  distribution :math:`q(\\beta)`.
+  In conditional inference, we infer \\(z\\) in \\(p(z, \\beta
+  \mid x)\\) while fixing inference over \\(\\beta\\) using another
+  distribution \\(q(\\beta)\\).
   `HMC` substitutes the model's log marginal density
 
-  .. math::
+  $\log p(x, z) = \log \mathbb{E}_{q(\\beta)} [ p(x, z, \\beta) ]
+                \\approx \log p(x, z, \\beta^*)$
 
-    \log p(x, z) = \log \mathbb{E}_{q(\\beta)} [ p(x, z, \\beta) ]
-                \\approx \log p(x, z, \\beta^*)
-
-  leveraging a single Monte Carlo sample, where :math:`\\beta^* \sim
-  q(\\beta)`. This is unbiased (and therefore asymptotically exact as a
-  pseudo-marginal method) if :math:`q(\\beta) = p(\\beta \mid x)`.
+  leveraging a single Monte Carlo sample, where \\(\\beta^* \sim
+  q(\\beta)\\). This is unbiased (and therefore asymptotically exact as a
+  pseudo-marginal method) if \\(q(\\beta) = p(\\beta \mid x)\\).
   """
   def __init__(self, *args, **kwargs):
     """

--- a/edward/inferences/implicit_klqp.py
+++ b/edward/inferences/implicit_klqp.py
@@ -16,17 +16,15 @@ class ImplicitKLqp(GANInference):
 
   It minimizes the KL divergence
 
-  .. math::
+  $\\text{KL}( q(z, \\beta; \lambda) \| p(z, \\beta \mid x) ),$
 
-    \\text{KL}( q(z, \\beta; \lambda) \| p(z, \\beta \mid x) ),
-
-  where :math:`z` are local variables associated to a data point and
-  :math:`\\beta` are global variables shared across data points.
+  where \\(z\\) are local variables associated to a data point and
+  \\(\\beta\\) are global variables shared across data points.
 
   Global latent variables require `log_prob()` and need to return a
   random sample when fetched from the graph. Local latent variables
   and observed variables require only a random sample when fetched
-  from the graph. (This is true for both :math:`p` and :math:`q`.)
+  from the graph. (This is true for both \\(p\\) and \\(q\\).)
 
   All variational factors must be reparameterizable: each of the
   random variables (`rv`) satisfies `rv.is_reparameterized` and
@@ -43,8 +41,8 @@ class ImplicitKLqp(GANInference):
       It takes three arguments: a data dict, local latent variable
       dict, and global latent variable dict. As with GAN
       discriminators, it can take a batch of data points and local
-      variables, of size :math:`M`, and output a vector of length
-      :math:`M`.
+      variables, of size \\(M\\), and output a vector of length
+      \\(M\\).
     global_vars: dict of RandomVariable to RandomVariable, optional
       Identifying which variables in `latent_vars` are global
       variables, shared across data points. These will not be
@@ -107,25 +105,21 @@ class ImplicitKLqp(GANInference):
   def build_loss_and_gradients(self, var_list):
     """Build loss function
 
-    .. math::
-
-      -\Big(\mathbb{E}_{q(\\beta)} [\log p(\\beta) - \log q(\\beta) ] +
+    $-\Big(\mathbb{E}_{q(\\beta)} [\log p(\\beta) - \log q(\\beta) ] +
         \sum_{n=1}^N \mathbb{E}_{q(\\beta)q(z_n\mid\\beta)} [
-            r^*(x_n, z_n, \\beta) ] \Big).
+            r^*(x_n, z_n, \\beta) ] \Big).$
 
     We minimize it with respect to parameterized variational
-    families :math:`q(z, \\beta; \lambda)`.
+    families \\(q(z, \\beta; \lambda)\\).
 
-    :math:`r^*(x_n, z_n, \\beta)` is a function of a single data point
-    :math:`x_n`, single local variable :math:`z_n`, and all global
-    variables :math:`\\beta`. It is equal to the log-ratio
+    \\(r^*(x_n, z_n, \\beta)\\) is a function of a single data point
+    \\(x_n\\), single local variable \\(z_n\\), and all global
+    variables \\(\\beta\\). It is equal to the log-ratio
 
-    .. math::
+    $\log p(x_n, z_n\mid \\beta) - \log q(x_n, z_n\mid \\beta),$
 
-      \log p(x_n, z_n\mid \\beta) - \log q(x_n, z_n\mid \\beta),
-
-    where :math:`q(x_n)` is the empirical data distribution. Rather
-    than explicit calculation, :math:`r^*(x, z, \\beta)` is the
+    where \\(q(x_n)\\) is the empirical data distribution. Rather
+    than explicit calculation, \\(r^*(x, z, \\beta)\\) is the
     solution to a ratio estimation problem, minimizing the specified
     `ratio_loss`.
 
@@ -134,9 +128,9 @@ class ImplicitKLqp(GANInference):
 
     Notes
     -----
-    This also includes model parameters :math:`p(x, z, \\beta; \\theta)`
+    This also includes model parameters \\(p(x, z, \\beta; \\theta)\\)
     and variational distributions with inference networks
-    :math:`q(z\mid x)`.
+    \\(q(z\mid x)\\).
 
     There are a bunch of extensions we could easily do in this
     implementation:

--- a/edward/inferences/implicit_klqp.py
+++ b/edward/inferences/implicit_klqp.py
@@ -23,52 +23,52 @@ class ImplicitKLqp(GANInference):
   where :math:`z` are local variables associated to a data point and
   :math:`\\beta` are global variables shared across data points.
 
-  Global latent variables require ``log_prob()`` and need to return a
+  Global latent variables require `log_prob()` and need to return a
   random sample when fetched from the graph. Local latent variables
   and observed variables require only a random sample when fetched
   from the graph. (This is true for both :math:`p` and :math:`q`.)
 
   All variational factors must be reparameterizable: each of the
-  random variables (``rv``) satisfies ``rv.is_reparameterized`` and
-  ``rv.is_continuous``.
+  random variables (`rv`) satisfies `rv.is_reparameterized` and
+  `rv.is_continuous`.
   """
   def __init__(self, latent_vars, data=None, discriminator=None,
                global_vars=None):
     """
     Parameters
     ----------
-    discriminator : function
-      Function (with parameters). Unlike ``GANInference``, it is
+    discriminator: function
+      Function (with parameters). Unlike `GANInference`, it is
       interpreted as a ratio estimator rather than a discriminator.
       It takes three arguments: a data dict, local latent variable
       dict, and global latent variable dict. As with GAN
       discriminators, it can take a batch of data points and local
       variables, of size :math:`M`, and output a vector of length
       :math:`M`.
-    global_vars : dict of RandomVariable to RandomVariable, optional
-      Identifying which variables in ``latent_vars`` are global
+    global_vars: dict of RandomVariable to RandomVariable, optional
+      Identifying which variables in `latent_vars` are global
       variables, shared across data points. These will not be
       encompassed in the ratio estimation problem, and will be
       estimated with tractable variational approximations.
 
     Notes
     -----
-    Unlike ``GANInference``, ``discriminator`` takes dict's as input,
+    Unlike `GANInference`, `discriminator` takes dict's as input,
     and must subset to the appropriate values through lexical scoping
     from the previously defined model and latent variables. This is
     necessary as the discriminator can take an arbitrary set of data,
     latent, and global variables.
 
-    Note the type for ``discriminator``'s output changes when one
-    passes in the ``scale`` argument to ``initialize()``.
+    Note the type for `discriminator`'s output changes when one
+    passes in the `scale` argument to `initialize()`.
 
-    + If ``scale`` has at most one item, then ``discriminator``
+    + If `scale` has at most one item, then `discriminator`
     outputs a tensor whose multiplication with that element is
     broadcastable. (For example, the output is a tensor and the single
     scale factor is a scalar.)
-    + If ``scale`` has more than one item, then in order to scale
-    its corresponding output, ``discriminator`` must output a
-    dictionary of same size and keys as ``scale``.
+    + If `scale` has more than one item, then in order to scale
+    its corresponding output, `discriminator` must output a
+    dictionary of same size and keys as `scale`.
     """
     if not callable(discriminator):
       raise TypeError("discriminator must be a callable function.")
@@ -87,10 +87,10 @@ class ImplicitKLqp(GANInference):
 
     Parameters
     ----------
-    ratio_loss : str or fn, optional
+    ratio_loss: str or fn, optional
       Loss function minimized to get the ratio estimator. 'log' or 'hinge'.
       Alternatively, one can pass in a function of two inputs,
-      ``psamples`` and ``qsamples``, and output a point-wise value
+      `psamples` and `qsamples`, and output a point-wise value
       with shape matching the shapes of the two inputs.
     """
     if callable(ratio_loss):
@@ -127,7 +127,7 @@ class ImplicitKLqp(GANInference):
     where :math:`q(x_n)` is the empirical data distribution. Rather
     than explicit calculation, :math:`r^*(x, z, \\beta)` is the
     solution to a ratio estimation problem, minimizing the specified
-    ``ratio_loss``.
+    `ratio_loss`.
 
     Gradients are taken using the reparameterization trick (Kingma and
     Welling, 2014).
@@ -144,7 +144,7 @@ class ImplicitKLqp(GANInference):
     + further factorizations can be used to better leverage the
       graph structure for more complicated models;
     + score function gradients for global variables;
-    + use more samples; this would require the ``copy()`` utility
+    + use more samples; this would require the `copy()` utility
       function for q's as well, and an additional loop. we opt not to
       because it complicates the code;
     + analytic KL/swapping out the penalty term for the globals.

--- a/edward/inferences/implicit_klqp.py
+++ b/edward/inferences/implicit_klqp.py
@@ -33,24 +33,23 @@ class ImplicitKLqp(GANInference):
   def __init__(self, latent_vars, data=None, discriminator=None,
                global_vars=None):
     """
-    Parameters
-    ----------
-    discriminator: function
-      Function (with parameters). Unlike `GANInference`, it is
-      interpreted as a ratio estimator rather than a discriminator.
-      It takes three arguments: a data dict, local latent variable
-      dict, and global latent variable dict. As with GAN
-      discriminators, it can take a batch of data points and local
-      variables, of size \\(M\\), and output a vector of length
-      \\(M\\).
-    global_vars: dict of RandomVariable to RandomVariable, optional
-      Identifying which variables in `latent_vars` are global
-      variables, shared across data points. These will not be
-      encompassed in the ratio estimation problem, and will be
-      estimated with tractable variational approximations.
+    Args:
+      discriminator: function.
+        Function (with parameters). Unlike `GANInference`, it is
+        interpreted as a ratio estimator rather than a discriminator.
+        It takes three arguments: a data dict, local latent variable
+        dict, and global latent variable dict. As with GAN
+        discriminators, it can take a batch of data points and local
+        variables, of size \\(M\\), and output a vector of length
+        \\(M\\).
+      global_vars: dict of RandomVariable to RandomVariable, optional.
+        Identifying which variables in `latent_vars` are global
+        variables, shared across data points. These will not be
+        encompassed in the ratio estimation problem, and will be
+        estimated with tractable variational approximations.
 
-    Notes
-    -----
+    #### Notes
+
     Unlike `GANInference`, `discriminator` takes dict's as input,
     and must subset to the appropriate values through lexical scoping
     from the previously defined model and latent variables. This is
@@ -83,13 +82,12 @@ class ImplicitKLqp(GANInference):
   def initialize(self, ratio_loss='log', *args, **kwargs):
     """Initialization.
 
-    Parameters
-    ----------
-    ratio_loss: str or fn, optional
-      Loss function minimized to get the ratio estimator. 'log' or 'hinge'.
-      Alternatively, one can pass in a function of two inputs,
-      `psamples` and `qsamples`, and output a point-wise value
-      with shape matching the shapes of the two inputs.
+    Args:
+      ratio_loss: str or fn, optional.
+        Loss function minimized to get the ratio estimator. 'log' or 'hinge'.
+        Alternatively, one can pass in a function of two inputs,
+        `psamples` and `qsamples`, and output a point-wise value
+        with shape matching the shapes of the two inputs.
     """
     if callable(ratio_loss):
       self.ratio_loss = ratio_loss
@@ -126,8 +124,8 @@ class ImplicitKLqp(GANInference):
     Gradients are taken using the reparameterization trick (Kingma and
     Welling, 2014).
 
-    Notes
-    -----
+    #### Notes
+
     This also includes model parameters \\(p(x, z, \\beta; \\theta)\\)
     and variational distributions with inference networks
     \\(q(z\mid x)\\).

--- a/edward/inferences/implicit_klqp.py
+++ b/edward/inferences/implicit_klqp.py
@@ -18,13 +18,13 @@ class ImplicitKLqp(GANInference):
 
   $\\text{KL}( q(z, \\beta; \lambda) \| p(z, \\beta \mid x) ),$
 
-  where \\(z\\) are local variables associated to a data point and
-  \\(\\beta\\) are global variables shared across data points.
+  where $z$ are local variables associated to a data point and
+  $\\beta$ are global variables shared across data points.
 
   Global latent variables require `log_prob()` and need to return a
   random sample when fetched from the graph. Local latent variables
   and observed variables require only a random sample when fetched
-  from the graph. (This is true for both \\(p\\) and \\(q\\).)
+  from the graph. (This is true for both $p$ and $q$.)
 
   All variational factors must be reparameterizable: each of the
   random variables (`rv`) satisfies `rv.is_reparameterized` and
@@ -40,8 +40,8 @@ class ImplicitKLqp(GANInference):
         It takes three arguments: a data dict, local latent variable
         dict, and global latent variable dict. As with GAN
         discriminators, it can take a batch of data points and local
-        variables, of size \\(M\\), and output a vector of length
-        \\(M\\).
+        variables, of size $M$, and output a vector of length
+        $M$.
       global_vars: dict of RandomVariable to RandomVariable, optional.
         Identifying which variables in `latent_vars` are global
         variables, shared across data points. These will not be
@@ -108,16 +108,16 @@ class ImplicitKLqp(GANInference):
             r^*(x_n, z_n, \\beta) ] \Big).$
 
     We minimize it with respect to parameterized variational
-    families \\(q(z, \\beta; \lambda)\\).
+    families $q(z, \\beta; \lambda)$.
 
-    \\(r^*(x_n, z_n, \\beta)\\) is a function of a single data point
-    \\(x_n\\), single local variable \\(z_n\\), and all global
-    variables \\(\\beta\\). It is equal to the log-ratio
+    $r^*(x_n, z_n, \\beta)$ is a function of a single data point
+    $x_n$, single local variable $z_n$, and all global
+    variables $\\beta$. It is equal to the log-ratio
 
     $\log p(x_n, z_n\mid \\beta) - \log q(x_n, z_n\mid \\beta),$
 
-    where \\(q(x_n)\\) is the empirical data distribution. Rather
-    than explicit calculation, \\(r^*(x, z, \\beta)\\) is the
+    where $q(x_n)$ is the empirical data distribution. Rather
+    than explicit calculation, $r^*(x, z, \\beta)$ is the
     solution to a ratio estimation problem, minimizing the specified
     `ratio_loss`.
 
@@ -126,9 +126,9 @@ class ImplicitKLqp(GANInference):
 
     #### Notes
 
-    This also includes model parameters \\(p(x, z, \\beta; \\theta)\\)
+    This also includes model parameters $p(x, z, \\beta; \\theta)$
     and variational distributions with inference networks
-    \\(q(z\mid x)\\).
+    $q(z\mid x)$.
 
     There are a bunch of extensions we could easily do in this
     implementation:

--- a/edward/inferences/inference.py
+++ b/edward/inferences/inference.py
@@ -17,51 +17,52 @@ from edward.util import get_variables
 @six.add_metaclass(abc.ABCMeta)
 class Inference(object):
   """Abstract base class for inference. All inference algorithms in
-  Edward inherit from ``Inference``, sharing common methods and
+  Edward inherit from `Inference`, sharing common methods and
   properties via a class hierarchy.
 
   Specific algorithms typically inherit from other subclasses of
-  ``Inference`` rather than ``Inference`` directly. For example, one
-  might inherit from the abstract classes ``MonteCarlo`` or
-  ``VariationalInference``.
+  `Inference` rather than `Inference` directly. For example, one
+  might inherit from the abstract classes `MonteCarlo` or
+  `VariationalInference`.
 
-  To build an algorithm inheriting from ``Inference``, one must at the
-  minimum implement ``initialize`` and ``update``: the former builds
+  To build an algorithm inheriting from `Inference`, one must at the
+  minimum implement `initialize` and `update`: the former builds
   the computational graph for the algorithm; the latter runs the
   computational graph for the algorithm.
 
   To reset inference (e.g., internal variable counters incremented
   over training), fetch inference's reset ops from session with
-  ``sess.run(inference.reset)``.
+  `sess.run(inference.reset)`.
   """
   def __init__(self, latent_vars=None, data=None):
     """Initialization.
 
-    Parameters
-    ----------
-    latent_vars : dict, optional
-      Collection of latent variables (of type ``RandomVariable`` or
-      ``tf.Tensor``) to perform inference on. Each random variable is
-      binded to another random variable; the latter will infer the
-      former conditional on data.
-    data : dict, optional
-      Data dictionary which binds observed variables (of type
-      ``RandomVariable`` or ``tf.Tensor``) to their realizations (of
-      type ``tf.Tensor``). It can also bind placeholders (of type
-      ``tf.Tensor``) used in the model to their realizations; and
-      prior latent variables (of type ``RandomVariable``) to posterior
-      latent variables (of type ``RandomVariable``).
+    Args:
+      latent_vars: dict, optional.
+        Collection of latent variables (of type `RandomVariable` or
+        `tf.Tensor`) to perform inference on. Each random variable is
+        binded to another random variable; the latter will infer the
+        former conditional on data.
+      data: dict, optional.
+        Data dictionary which binds observed variables (of type
+        `RandomVariable` or `tf.Tensor`) to their realizations (of
+        type `tf.Tensor`). It can also bind placeholders (of type
+        `tf.Tensor`) used in the model to their realizations; and
+        prior latent variables (of type `RandomVariable`) to posterior
+        latent variables (of type `RandomVariable`).
 
-    Examples
-    --------
-    >>> mu = Normal(loc=tf.constant(0.0), scale=tf.constant(1.0))
-    >>> x = Normal(loc=tf.ones(50) * mu, scale=tf.constant(1.0))
-    >>>
-    >>> qmu_loc = tf.Variable(tf.random_normal([]))
-    >>> qmu_scale = tf.nn.softplus(tf.Variable(tf.random_normal([])))
-    >>> qmu = Normal(loc=qmu_loc, scale=qmu_scale)
-    >>>
-    >>> inference = ed.Inference({mu: qmu}, data={x: tf.zeros(50)})
+    #### Examples
+
+    ```python
+    mu = Normal(loc=tf.constant(0.0), scale=tf.constant(1.0))
+    x = Normal(loc=tf.ones(50) * mu, scale=tf.constant(1.0))
+
+    qmu_loc = tf.Variable(tf.random_normal([]))
+    qmu_scale = tf.nn.softplus(tf.Variable(tf.random_normal([])))
+    qmu = Normal(loc=qmu_loc, scale=qmu_scale)
+
+    inference = ed.Inference({mu: qmu}, data={x: tf.zeros(50)})
+    ```
     """
     sess = get_session()
     if latent_vars is None:
@@ -92,33 +93,32 @@ class Inference(object):
   def run(self, variables=None, use_coordinator=True, *args, **kwargs):
     """A simple wrapper to run inference.
 
-    1. Initialize algorithm via ``initialize``.
+    1. Initialize algorithm via `initialize`.
     2. (Optional) Build a TensorFlow summary writer for TensorBoard.
     3. (Optional) Initialize TensorFlow variables.
     4. (Optional) Start queue runners.
-    5. Run ``update`` for ``self.n_iter`` iterations.
-    6. While running, ``print_progress``.
-    7. Finalize algorithm via ``finalize``.
+    5. Run `update` for `self.n_iter` iterations.
+    6. While running, `print_progress`.
+    7. Finalize algorithm via `finalize`.
     8. (Optional) Stop queue runners.
 
     To customize the way inference is run, run these steps
     individually.
 
-    Parameters
-    ----------
-    variables : list, optional
-      A list of TensorFlow variables to initialize during inference.
-      Default is to initialize all variables (this includes
-      reinitializing variables that were already initialized). To
-      avoid initializing any variables, pass in an empty list.
-    use_coordinator : bool, optional
-      Whether to start and stop queue runners during inference using a
-      TensorFlow coordinator. For example, queue runners are necessary
-      for batch training with file readers.
-    *args
-      Passed into ``initialize``.
-    **kwargs
-      Passed into ``initialize``.
+    Args:
+      variables: list, optional.
+        A list of TensorFlow variables to initialize during inference.
+        Default is to initialize all variables (this includes
+        reinitializing variables that were already initialized). To
+        avoid initializing any variables, pass in an empty list.
+      use_coordinator: bool, optional.
+        Whether to start and stop queue runners during inference using a
+        TensorFlow coordinator. For example, queue runners are necessary
+        for batch training with file readers.
+      *args:
+        Passed into `initialize`.
+      **kwargs:
+        Passed into `initialize`.
     """
     self.initialize(*args, **kwargs)
 
@@ -157,41 +157,40 @@ class Inference(object):
     """Initialize inference algorithm. It initializes hyperparameters
     and builds ops for the algorithm's computation graph.
 
-    Any derived class of ``Inference`` **must** implement this method.
-    No methods which build ops should be called outside ``initialize()``.
+    Any derived class of `Inference` **must** implement this method.
+    No methods which build ops should be called outside `initialize()`.
 
-    Parameters
-    ----------
-    n_iter : int, optional
-      Number of iterations for algorithm when calling ``run()``.
-      Alternatively if controlling inference manually, it is the
-      expected number of calls to ``update()``; this number determines
-      tracking information during the print progress.
-    n_print : int, optional
-      Number of iterations for each print progress. To suppress print
-      progress, then specify 0. Default is ``int(n_iter / 100)``.
-    scale : dict of RandomVariable to tf.Tensor, optional
-      A tensor to scale computation for any random variable that it is
-      binded to. Its shape must be broadcastable; it is multiplied
-      element-wise to the random variable. For example, this is useful
-      for mini-batch scaling when inferring global variables, or
-      applying masks on a random variable.
-    logdir : str, optional
-      Directory where event file will be written. For details,
-      see ``tf.summary.FileWriter``. Default is to log nothing.
-    log_timestamp : bool, optional
-      If True (and ``logdir`` is specified), create a subdirectory of
-      ``logdir`` to save the specific run results. The subdirectory's
-      name is the current UTC timestamp with format 'YYYYMMDD_HHMMSS'.
-    log_vars : list, optional
-      Specifies the list of variables to log after each ``n_print``
-      steps. If None, will log all variables. If ``[]``, no variables
-      will be logged. ``logdir`` must be specified for variables to be
-      logged.
-    debug : bool, optional
-      If True, add checks for ``NaN`` and ``Inf`` to all computations
-      in the graph. May result in substantially slower execution
-      times.
+    Args:
+      n_iter: int, optional.
+        Number of iterations for algorithm when calling `run()`.
+        Alternatively if controlling inference manually, it is the
+        expected number of calls to `update()`; this number determines
+        tracking information during the print progress.
+      n_print: int, optional.
+        Number of iterations for each print progress. To suppress print
+        progress, then specify 0. Default is `int(n_iter / 100)`.
+      scale: dict of RandomVariable to tf.Tensor, optional.
+        A tensor to scale computation for any random variable that it is
+        binded to. Its shape must be broadcastable; it is multiplied
+        element-wise to the random variable. For example, this is useful
+        for mini-batch scaling when inferring global variables, or
+        applying masks on a random variable.
+      logdir: str, optional.
+        Directory where event file will be written. For details,
+        see `tf.summary.FileWriter`. Default is to log nothing.
+      log_timestamp: bool, optional.
+        If True (and `logdir` is specified), create a subdirectory of
+        `logdir` to save the specific run results. The subdirectory's
+        name is the current UTC timestamp with format 'YYYYMMDD_HHMMSS'.
+      log_vars: list, optional.
+        Specifies the list of variables to log after each `n_print`
+        steps. If None, will log all variables. If `[]`, no variables
+        will be logged. `logdir` must be specified for variables to be
+        logged.
+      debug: bool, optional.
+        If True, add checks for `NaN` and `Inf` to all computations
+        in the graph. May result in substantially slower execution
+        times.
     """
     self.n_iter = n_iter
     if n_print is None:
@@ -235,18 +234,16 @@ class Inference(object):
   def update(self, feed_dict=None):
     """Run one iteration of inference.
 
-    Any derived class of ``Inference`` **must** implement this method.
+    Any derived class of `Inference` **must** implement this method.
 
-    Parameters
-    ----------
-    feed_dict : dict, optional
-      Feed dictionary for a TensorFlow session run. It is used to feed
-      placeholders that are not fed during initialization.
+    Args:
+      feed_dict: dict, optional.
+        Feed dictionary for a TensorFlow session run. It is used to feed
+        placeholders that are not fed during initialization.
 
-    Returns
-    -------
-    dict
-      Dictionary of algorithm-specific information.
+    Returns:
+      dict.
+        Dictionary of algorithm-specific information.
     """
     if feed_dict is None:
       feed_dict = {}
@@ -271,10 +268,9 @@ class Inference(object):
   def print_progress(self, info_dict):
     """Print progress to output.
 
-    Parameters
-    ----------
-    info_dict : dict
-      Dictionary of algorithm-specific information.
+    Args:
+      info_dict: dict.
+        Dictionary of algorithm-specific information.
     """
     if self.n_print != 0:
       t = info_dict['t']
@@ -290,15 +286,14 @@ class Inference(object):
   def _set_log_variables(self, log_vars=None):
     """Log variables to TensorBoard.
 
-    For each variable in ``log_vars``, forms a ``tf.summary.scalar``if
-    the variable has scalar shape; otherwise forms a``tf.summary.histogram``.
+    For each variable in `log_vars`, forms a `tf.summary.scalar` if
+    the variable has scalar shape; otherwise forms a `tf.summary.histogram`.
 
-    Parameters
-    ----------
-    log_vars : list, optional
-      Specifies the list of variables to log after each ``n_print``
-      steps. If None, will log all variables. If ``[]``, no variables
-      will be logged.
+    Args:
+      log_vars: list, optional.
+        Specifies the list of variables to log after each `n_print`
+        steps. If None, will log all variables. If `[]`, no variables
+        will be logged.
     """
     summary_key = 'summaries_' + str(id(self))
     if log_vars is None:

--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -66,7 +66,7 @@ class KLpq(VariationalInference):
     The loss function can be estimated as
 
     $\\frac{1}{S} \sum_{s=1}^S [
-        w_{\\text{norm}}(z^s; \lambda) (\log p(x, z^s) - \log q(z^s; \lambda) ],$
+      w_{\\text{norm}}(z^s; \lambda) (\log p(x, z^s) - \log q(z^s; \lambda) ],$
 
     where for \\(z^s \sim q(z; \lambda)\\),
 
@@ -74,12 +74,12 @@ class KLpq(VariationalInference):
           w(z^s; \lambda) / \sum_{s=1}^S w(z^s; \lambda)$
 
     normalizes the importance weights, \\(w(z^s; \lambda) = p(x,
-    z^s) / q(z^s; \lambda)\).
+    z^s) / q(z^s; \lambda)\\).
 
     This provides a gradient,
 
     $- \\frac{1}{S} \sum_{s=1}^S [
-        w_{\\text{norm}}(z^s; \lambda) \\nabla_{\lambda} \log q(z^s; \lambda) ].$
+      w_{\\text{norm}}(z^s; \lambda) \\nabla_{\lambda} \log q(z^s; \lambda) ].$
     """
     p_log_prob = [0.0] * self.n_samples
     q_log_prob = [0.0] * self.n_samples

--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -20,26 +20,26 @@ class KLpq(VariationalInference):
 
   #### Notes
 
-  `KLpq` also optimizes any model parameters \\(p(z\mid x;
-  \\theta)\\). It does this by variational EM, minimizing
+  `KLpq` also optimizes any model parameters $p(z\mid x;
+  \\theta)$. It does this by variational EM, minimizing
 
   $\mathbb{E}_{p(z \mid x; \lambda)} [ \log p(x, z; \\theta) ]$
 
-  with respect to \\(\\theta\\).
+  with respect to $\\theta$.
 
-  In conditional inference, we infer \\(z` in \\(p(z, \\beta
-  \mid x)\\) while fixing inference over \\(\\beta\\) using another
-  distribution \\(q(\\beta)\\). During gradient calculation, instead
+  In conditional inference, we infer $z` in $p(z, \\beta
+  \mid x)$ while fixing inference over $\\beta$ using another
+  distribution $q(\\beta)$. During gradient calculation, instead
   of using the model's density
 
   $\log p(x, z^{(s)}), z^{(s)} \sim q(z; \lambda),$
 
-  for each sample \\(s=1,\ldots,S\\), `KLpq` uses
+  for each sample $s=1,\ldots,S$, `KLpq` uses
 
   $\log p(x, z^{(s)}, \\beta^{(s)}),$
 
-  where \\(z^{(s)} \sim q(z; \lambda)\\) and \\(\\beta^{(s)}
-  \sim q(\\beta)\\).
+  where $z^{(s)} \sim q(z; \lambda)$ and$\\beta^{(s)}
+  \sim q(\\beta)$.
   """
   def __init__(self, *args, **kwargs):
     super(KLpq, self).__init__(*args, **kwargs)
@@ -68,13 +68,13 @@ class KLpq(VariationalInference):
     $\\frac{1}{S} \sum_{s=1}^S [
       w_{\\text{norm}}(z^s; \lambda) (\log p(x, z^s) - \log q(z^s; \lambda) ],$
 
-    where for \\(z^s \sim q(z; \lambda)\\),
+    where for $z^s \sim q(z; \lambda)$,
 
     $w_{\\text{norm}}(z^s; \lambda) =
           w(z^s; \lambda) / \sum_{s=1}^S w(z^s; \lambda)$
 
-    normalizes the importance weights, \\(w(z^s; \lambda) = p(x,
-    z^s) / q(z^s; \lambda)\\).
+    normalizes the importance weights, $w(z^s; \lambda) = p(x,
+    z^s) / q(z^s; \lambda)$.
 
     This provides a gradient,
 

--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -13,41 +13,33 @@ from edward.util import copy
 class KLpq(VariationalInference):
   """Variational inference with the KL divergence
 
-  .. math::
-
-    \\text{KL}( p(z \mid x) \| q(z) ).
+  $\\text{KL}( p(z \mid x) \| q(z) ).$
 
   To perform the optimization, this class uses a technique from
   adaptive importance sampling (Cappe et al., 2008).
 
   #### Notes
 
-  `KLpq` also optimizes any model parameters :math:`p(z\mid x;
-  \\theta)`. It does this by variational EM, minimizing
+  `KLpq` also optimizes any model parameters \\(p(z\mid x;
+  \\theta)\\). It does this by variational EM, minimizing
 
-  .. math::
+  $\mathbb{E}_{p(z \mid x; \lambda)} [ \log p(x, z; \\theta) ]$
 
-    \mathbb{E}_{p(z \mid x; \lambda)} [ \log p(x, z; \\theta) ]
+  with respect to \\(\\theta\\).
 
-  with respect to :math:`\\theta`.
-
-  In conditional inference, we infer :math:`z` in :math:`p(z, \\beta
-  \mid x)` while fixing inference over :math:`\\beta` using another
-  distribution :math:`q(\\beta)`. During gradient calculation, instead
+  In conditional inference, we infer \\(z` in \\(p(z, \\beta
+  \mid x)\\) while fixing inference over \\(\\beta\\) using another
+  distribution \\(q(\\beta)\\). During gradient calculation, instead
   of using the model's density
 
-  .. math::
+  $\log p(x, z^{(s)}), z^{(s)} \sim q(z; \lambda),$
 
-    \log p(x, z^{(s)}), z^{(s)} \sim q(z; \lambda),
+  for each sample \\(s=1,\ldots,S\\), `KLpq` uses
 
-  for each sample :math:`s=1,\ldots,S`, `KLpq` uses
+  $\log p(x, z^{(s)}, \\beta^{(s)}),$
 
-  .. math::
-
-    \log p(x, z^{(s)}, \\beta^{(s)}),
-
-  where :math:`z^{(s)} \sim q(z; \lambda)` and :math:`\\beta^{(s)}
-  \sim q(\\beta)`.
+  where \\(z^{(s)} \sim q(z; \lambda)\\) and \\(\\beta^{(s)}
+  \sim q(\\beta)\\).
   """
   def __init__(self, *args, **kwargs):
     super(KLpq, self).__init__(*args, **kwargs)
@@ -66,33 +58,28 @@ class KLpq(VariationalInference):
   def build_loss_and_gradients(self, var_list):
     """Build loss function
 
-    .. math::
-      \\text{KL}( p(z \mid x) \| q(z) )
-      = \mathbb{E}_{p(z \mid x)} [ \log p(z \mid x) - \log q(z; \lambda) ]
+    $\\text{KL}( p(z \mid x) \| q(z) )
+      = \mathbb{E}_{p(z \mid x)} [ \log p(z \mid x) - \log q(z; \lambda) ]$
 
     and stochastic gradients based on importance sampling.
 
     The loss function can be estimated as
 
-    .. math::
-      \\frac{1}{S} \sum_{s=1}^S [
-        w_{\\text{norm}}(z^s; \lambda) (\log p(x, z^s) - \log q(z^s; \lambda) ],
+    $\\frac{1}{S} \sum_{s=1}^S [
+        w_{\\text{norm}}(z^s; \lambda) (\log p(x, z^s) - \log q(z^s; \lambda) ],$
 
-    where for :math:`z^s \sim q(z; \lambda)`,
+    where for \\(z^s \sim q(z; \lambda)\\),
 
-    .. math::
+    $w_{\\text{norm}}(z^s; \lambda) =
+          w(z^s; \lambda) / \sum_{s=1}^S w(z^s; \lambda)$
 
-      w_{\\text{norm}}(z^s; \lambda) =
-          w(z^s; \lambda) / \sum_{s=1}^S w(z^s; \lambda)
-
-    normalizes the importance weights, :math:`w(z^s; \lambda) = p(x,
-    z^s) / q(z^s; \lambda)`.
+    normalizes the importance weights, \\(w(z^s; \lambda) = p(x,
+    z^s) / q(z^s; \lambda)\).
 
     This provides a gradient,
 
-    .. math::
-      - \\frac{1}{S} \sum_{s=1}^S [
-        w_{\\text{norm}}(z^s; \lambda) \\nabla_{\lambda} \log q(z^s; \lambda) ].
+    $- \\frac{1}{S} \sum_{s=1}^S [
+        w_{\\text{norm}}(z^s; \lambda) \\nabla_{\lambda} \log q(z^s; \lambda) ].$
     """
     p_log_prob = [0.0] * self.n_samples
     q_log_prob = [0.0] * self.n_samples

--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -20,9 +20,9 @@ class KLpq(VariationalInference):
   To perform the optimization, this class uses a technique from
   adaptive importance sampling (Cappe et al., 2008).
 
-  Notes
-  -----
-  ``KLpq`` also optimizes any model parameters :math:`p(z\mid x;
+  #### Notes
+
+  `KLpq` also optimizes any model parameters :math:`p(z\mid x;
   \\theta)`. It does this by variational EM, minimizing
 
   .. math::
@@ -40,7 +40,7 @@ class KLpq(VariationalInference):
 
     \log p(x, z^{(s)}), z^{(s)} \sim q(z; \lambda),
 
-  for each sample :math:`s=1,\ldots,S`, ``KLpq`` uses
+  for each sample :math:`s=1,\ldots,S`, `KLpq` uses
 
   .. math::
 
@@ -55,11 +55,10 @@ class KLpq(VariationalInference):
   def initialize(self, n_samples=1, *args, **kwargs):
     """Initialization.
 
-    Parameters
-    ----------
-    n_samples : int, optional
-      Number of samples from variational model for calculating
-      stochastic gradients.
+    Args:
+      n_samples: int, optional.
+        Number of samples from variational model for calculating
+        stochastic gradients.
     """
     self.n_samples = n_samples
     return super(KLpq, self).initialize(*args, **kwargs)

--- a/edward/inferences/klqp.py
+++ b/edward/inferences/klqp.py
@@ -26,26 +26,26 @@ class KLqp(VariationalInference):
 
   #### Notes
 
-  `KLqp` also optimizes any model parameters \\(p(z \mid x;
-  \\theta)\\). It does this by variational EM, minimizing
+  `KLqp` also optimizes any model parameters $p(z \mid x;
+  \\theta)$. It does this by variational EM, minimizing
 
   $\mathbb{E}_{q(z; \lambda)} [ \log p(x, z; \\theta) ]$
 
-  with respect to \\(\\theta\\).
+  with respect to $\\theta$.
 
-  In conditional inference, we infer \\(z\\) in \\(p(z, \\beta
-  \mid x)\\) while fixing inference over \\(\\beta\\) using another
-  distribution \\(q(\\beta)\\). During gradient calculation, instead
+  In conditional inference, we infer $z$ in $p(z, \\beta
+  \mid x)$ while fixing inference over $\\beta$ using another
+  distribution $q(\\beta)$. During gradient calculation, instead
   of using the model's density
 
   $\log p(x, z^{(s)}), z^{(s)} \sim q(z; \lambda),$
 
-  for each sample \\(s=1,\ldots,S\\), `KLqp` uses
+  for each sample $s=1,\ldots,S$, `KLqp` uses
 
   $\log p(x, z^{(s)}, \\beta^{(s)}),$
 
-  where \\(z^{(s)} \sim q(z; \lambda)\\) and \\(\\beta^{(s)}
-  \sim q(\\beta)\\).
+  where $z^{(s)} \sim q(z; \lambda)$ and $\\beta^{(s)}
+  \sim q(\\beta)$.
   """
   def __init__(self, *args, **kwargs):
     super(KLqp, self).__init__(*args, **kwargs)
@@ -64,8 +64,8 @@ class KLqp(VariationalInference):
         $\\alpha_p \mathbb{E}_{q(z\mid x, \lambda)} [
               \log q(z\mid x, \lambda) - \log p(z)],$
 
-        then pass {\\(p(z)\\): \\(\\alpha_p\\)} as `kl_scaling`,
-        where \\(\\alpha_p\\) is a float that specifies how much to
+        then pass {$p(z)$: $\\alpha_p$} as `kl_scaling`,
+        where $\\alpha_p$ is a float that specifies how much to
         scale the KL term.
     """
     if kl_scaling is None:
@@ -95,8 +95,8 @@ class KLqp(VariationalInference):
         \\text{KL}( q(z; \lambda) \| p(z) ),$
 
     where the KL term is computed analytically (Kingma and Welling,
-    2014). We compute this automatically when \\(p(z)\\) and
-    \\(q(z; \lambda)\\) are Normal.
+    2014). We compute this automatically when $p(z)$ and
+    $q(z; \lambda)$ are Normal.
     """
     is_reparameterizable = all([
         rv.reparameterization_type ==
@@ -175,8 +175,8 @@ class ReparameterizationKLKLqp(VariationalInference):
         $\\alpha_p \mathbb{E}_{q(z\mid x, \lambda)} [
               \log q(z\mid x, \lambda) - \log p(z)],$
 
-        then pass {\\(p(z)\\): \\(\\alpha_p\\)} as `kl_scaling`,
-        where \\(\\alpha_p\\) is a float that specifies how much to
+        then pass {$p(z)$: $\\alpha_p$} as `kl_scaling`,
+        where $\\alpha_p$ is a float that specifies how much to
         scale the KL term.
     """
     if kl_scaling is None:
@@ -268,8 +268,8 @@ class ScoreKLKLqp(VariationalInference):
         $\\alpha_p \mathbb{E}_{q(z\mid x, \lambda)} [
               \log q(z\mid x, \lambda) - \log p(z)],$
 
-        then pass {\\(p(z)\\): \\(\\alpha_p\\)} as `kl_scaling`,
-        where \\(\\alpha_p\\) is a float that specifies how much to
+        then pass {$p(z)$: $\\alpha_p$} as `kl_scaling`,
+        where $\\alpha_p$ is a float that specifies how much to
         scale the KL term.
     """
     if kl_scaling is None:
@@ -318,7 +318,7 @@ def build_reparam_loss_and_gradients(inference, var_list):
 
   based on the reparameterization trick (Kingma and Welling, 2014).
 
-  Computed by sampling from \\(q(z;\lambda)\\) and evaluating the
+  Computed by sampling from $q(z;\lambda)$ and evaluating the
   expectation using Monte Carlo sampling.
   """
   p_log_prob = [0.0] * inference.n_samples
@@ -382,7 +382,7 @@ def build_reparam_kl_loss_and_gradients(inference, var_list):
 
   It assumes the KL is analytic.
 
-  Computed by sampling from \\(q(z;\lambda)\\) and evaluating the
+  Computed by sampling from $q(z;\lambda)$ and evaluating the
   expectation using Monte Carlo sampling.
   """
   p_log_lik = [0.0] * inference.n_samples
@@ -439,7 +439,7 @@ def build_reparam_entropy_loss_and_gradients(inference, var_list):
 
   It assumes the entropy is analytic.
 
-  Computed by sampling from \\(q(z;\lambda)\\) and evaluating the
+  Computed by sampling from $q(z;\lambda)$ and evaluating the
   expectation using Monte Carlo sampling.
   """
   p_log_prob = [0.0] * inference.n_samples
@@ -493,7 +493,7 @@ def build_score_loss_and_gradients(inference, var_list):
   """Build loss function and gradients based on the score function
   estimator (Paisley et al., 2012).
 
-  Computed by sampling from \\(q(z;\lambda)\\) and evaluating the
+  Computed by sampling from $q(z;\lambda)$ and evaluating the
   expectation using Monte Carlo sampling.
   """
   p_log_prob = [0.0] * inference.n_samples
@@ -556,7 +556,7 @@ def build_score_kl_loss_and_gradients(inference, var_list):
 
   It assumes the KL is analytic.
 
-  Computed by sampling from \\(q(z;\lambda)\\) and evaluating the
+  Computed by sampling from $q(z;\lambda)$ and evaluating the
   expectation using Monte Carlo sampling.
   """
   p_log_lik = [0.0] * inference.n_samples
@@ -615,7 +615,7 @@ def build_score_entropy_loss_and_gradients(inference, var_list):
 
   It assumes the entropy is analytic.
 
-  Computed by sampling from \\(q(z;\lambda)\\) and evaluating the
+  Computed by sampling from $q(z;\lambda)$ and evaluating the
   expectation using Monte Carlo sampling.
   """
   p_log_prob = [0.0] * inference.n_samples

--- a/edward/inferences/klqp.py
+++ b/edward/inferences/klqp.py
@@ -19,41 +19,33 @@ except Exception as e:
 class KLqp(VariationalInference):
   """Variational inference with the KL divergence
 
-  .. math::
-
-    \\text{KL}( q(z; \lambda) \| p(z \mid x) ).
+  $\\text{KL}( q(z; \lambda) \| p(z \mid x) ).$
 
   This class minimizes the objective by automatically selecting from a
   variety of black box inference techniques.
 
-  Notes
-  -----
-  ``KLqp`` also optimizes any model parameters :math:`p(z \mid x;
-  \\theta)`. It does this by variational EM, minimizing
+  #### Notes
 
-  .. math::
+  `KLqp` also optimizes any model parameters \\(p(z \mid x;
+  \\theta)\\). It does this by variational EM, minimizing
 
-    \mathbb{E}_{q(z; \lambda)} [ \log p(x, z; \\theta) ]
+  $\mathbb{E}_{q(z; \lambda)} [ \log p(x, z; \\theta) ]$
 
-  with respect to :math:`\\theta`.
+  with respect to \\(\\theta\\).
 
-  In conditional inference, we infer :math:`z` in :math:`p(z, \\beta
-  \mid x)` while fixing inference over :math:`\\beta` using another
-  distribution :math:`q(\\beta)`. During gradient calculation, instead
+  In conditional inference, we infer \\(z\\) in \\(p(z, \\beta
+  \mid x)\\) while fixing inference over \\(\\beta\\) using another
+  distribution \\(q(\\beta)\\). During gradient calculation, instead
   of using the model's density
 
-  .. math::
+  $\log p(x, z^{(s)}), z^{(s)} \sim q(z; \lambda),$
 
-    \log p(x, z^{(s)}), z^{(s)} \sim q(z; \lambda),
+  for each sample \\(s=1,\ldots,S\\), `KLqp` uses
 
-  for each sample :math:`s=1,\ldots,S`, ``KLqp`` uses
+  $\log p(x, z^{(s)}, \\beta^{(s)}),$
 
-  .. math::
-
-    \log p(x, z^{(s)}, \\beta^{(s)}),
-
-  where :math:`z^{(s)} \sim q(z; \lambda)` and :math:`\\beta^{(s)}
-  \sim q(\\beta)`.
+  where \\(z^{(s)} \sim q(z; \lambda)\\) and \\(\\beta^{(s)}
+  \sim q(\\beta)\\).
   """
   def __init__(self, *args, **kwargs):
     super(KLqp, self).__init__(*args, **kwargs)
@@ -61,22 +53,20 @@ class KLqp(VariationalInference):
   def initialize(self, n_samples=1, kl_scaling=None, *args, **kwargs):
     """Initialization.
 
-    Parameters
-    ----------
-    n_samples : int, optional
-      Number of samples from variational model for calculating
-      stochastic gradients.
-    kl_scaling : dict of RandomVariable to float, optional
-      Provides option to scale terms when using ELBO with KL divergence.
-      If the KL divergence terms are
+    Args:
+      n_samples: int, optional>
+        Number of samples from variational model for calculating
+        stochastic gradients.
+      kl_scaling: dict of RandomVariable to float, optional.
+        Provides option to scale terms when using ELBO with KL divergence.
+        If the KL divergence terms are
 
-      .. math::
-        \\alpha_p \mathbb{E}_{q(z\mid x, \lambda)} [
-            \log q(z\mid x, \lambda) - \log p(z)],
+        $\\alpha_p \mathbb{E}_{q(z\mid x, \lambda)} [
+              \log q(z\mid x, \lambda) - \log p(z)],$
 
-      then pass {:math:`p(z)`: :math:`\\alpha_p`} as ``kl_scaling``,
-      where :math:`\\alpha_p` is a float that specifies how much to
-      scale the KL term.
+        then pass {\\(p(z)\\): \\(\\alpha_p\\)} as `kl_scaling`,
+        where \\(\\alpha_p\\) is a float that specifies how much to
+        scale the KL term.
     """
     if kl_scaling is None:
       kl_scaling = {}
@@ -86,12 +76,10 @@ class KLqp(VariationalInference):
     return super(KLqp, self).initialize(*args, **kwargs)
 
   def build_loss_and_gradients(self, var_list):
-    """Wrapper for the ``KLqp`` loss function.
+    """Wrapper for the `KLqp` loss function.
 
-    .. math::
-
-      -\\text{ELBO} =
-        -\mathbb{E}_{q(z; \lambda)} [ \log p(x, z) - \log q(z; \lambda) ]
+    $-\\text{ELBO} =
+        -\mathbb{E}_{q(z; \lambda)} [ \log p(x, z) - \log q(z; \lambda) ]$
 
     KLqp supports
 
@@ -103,14 +91,12 @@ class KLqp(VariationalInference):
     If the KL divergence between the variational model and the prior
     is tractable, then the loss function can be written as
 
-    .. math::
-
-      -\mathbb{E}_{q(z; \lambda)}[\log p(x \mid z)] +
-        \\text{KL}( q(z; \lambda) \| p(z) ),
+    $-\mathbb{E}_{q(z; \lambda)}[\log p(x \mid z)] +
+        \\text{KL}( q(z; \lambda) \| p(z) ),$
 
     where the KL term is computed analytically (Kingma and Welling,
-    2014). We compute this automatically when :math:`p(z)` and
-    :math:`q(z; \lambda)` are Normal.
+    2014). We compute this automatically when \\(p(z)\\) and
+    \\(q(z; \lambda)\\) are Normal.
     """
     is_reparameterizable = all([
         rv.reparameterization_type ==
@@ -141,9 +127,7 @@ class KLqp(VariationalInference):
 class ReparameterizationKLqp(VariationalInference):
   """Variational inference with the KL divergence
 
-  .. math::
-
-    \\text{KL}( q(z; \lambda) \| p(z \mid x) ).
+  $\\text{KL}( q(z; \lambda) \| p(z \mid x) ).$
 
   This class minimizes the objective using the reparameterization
   gradient.
@@ -154,11 +138,10 @@ class ReparameterizationKLqp(VariationalInference):
   def initialize(self, n_samples=1, *args, **kwargs):
     """Initialization.
 
-    Parameters
-    ----------
-    n_samples : int, optional
-      Number of samples from variational model for calculating
-      stochastic gradients.
+    Args:
+      n_samples: int, optional.
+        Number of samples from variational model for calculating
+        stochastic gradients.
     """
     self.n_samples = n_samples
     return super(ReparameterizationKLqp, self).initialize(*args, **kwargs)
@@ -170,9 +153,7 @@ class ReparameterizationKLqp(VariationalInference):
 class ReparameterizationKLKLqp(VariationalInference):
   """Variational inference with the KL divergence
 
-  .. math::
-
-    \\text{KL}( q(z; \lambda) \| p(z \mid x) ).
+  $\\text{KL}( q(z; \lambda) \| p(z \mid x) ).$
 
   This class minimizes the objective using the reparameterization
   gradient and an analytic KL term.
@@ -183,22 +164,20 @@ class ReparameterizationKLKLqp(VariationalInference):
   def initialize(self, n_samples=1, kl_scaling=None, *args, **kwargs):
     """Initialization.
 
-    Parameters
-    ----------
-    n_samples : int, optional
-      Number of samples from variational model for calculating
-      stochastic gradients.
-    kl_scaling : dict of RandomVariable to float, optional
-      Provides option to scale terms when using ELBO with KL divergence.
-      If the KL divergence terms are
+    Args:
+      n_samples: int, optional.
+        Number of samples from variational model for calculating
+        stochastic gradients.
+      kl_scaling: dict of RandomVariable to float, optional.
+        Provides option to scale terms when using ELBO with KL divergence.
+        If the KL divergence terms are
 
-      .. math::
-        \\alpha_p \mathbb{E}_{q(z\mid x, \lambda)} [
-            \log q(z\mid x, \lambda) - \log p(z)],
+        $\\alpha_p \mathbb{E}_{q(z\mid x, \lambda)} [
+              \log q(z\mid x, \lambda) - \log p(z)],$
 
-      then pass {:math:`p(z)`: :math:`\\alpha_p`} as ``kl_scaling``,
-      where :math:`\\alpha_p` is a float that specifies how much to
-      scale the KL term.
+        then pass {\\(p(z)\\): \\(\\alpha_p\\)} as `kl_scaling`,
+        where \\(\\alpha_p\\) is a float that specifies how much to
+        scale the KL term.
     """
     if kl_scaling is None:
       kl_scaling = {}
@@ -214,9 +193,7 @@ class ReparameterizationKLKLqp(VariationalInference):
 class ReparameterizationEntropyKLqp(VariationalInference):
   """Variational inference with the KL divergence
 
-  .. math::
-
-    \\text{KL}( q(z; \lambda) \| p(z \mid x) ).
+  $\\text{KL}( q(z; \lambda) \| p(z \mid x) ).$
 
   This class minimizes the objective using the reparameterization
   gradient and an analytic entropy term.
@@ -227,11 +204,10 @@ class ReparameterizationEntropyKLqp(VariationalInference):
   def initialize(self, n_samples=1, *args, **kwargs):
     """Initialization.
 
-    Parameters
-    ----------
-    n_samples : int, optional
-      Number of samples from variational model for calculating
-      stochastic gradients.
+    Args:
+      n_samples: int, optional.
+        Number of samples from variational model for calculating
+        stochastic gradients.
     """
     self.n_samples = n_samples
     return super(ReparameterizationEntropyKLqp, self).initialize(
@@ -244,9 +220,7 @@ class ReparameterizationEntropyKLqp(VariationalInference):
 class ScoreKLqp(VariationalInference):
   """Variational inference with the KL divergence
 
-  .. math::
-
-    \\text{KL}( q(z; \lambda) \| p(z \mid x) ).
+  $\\text{KL}( q(z; \lambda) \| p(z \mid x) ).$
 
   This class minimizes the objective using the score function
   gradient.
@@ -257,11 +231,10 @@ class ScoreKLqp(VariationalInference):
   def initialize(self, n_samples=1, *args, **kwargs):
     """Initialization.
 
-    Parameters
-    ----------
-    n_samples : int, optional
-      Number of samples from variational model for calculating
-      stochastic gradients.
+    Args:
+      n_samples: int, optional.
+        Number of samples from variational model for calculating
+        stochastic gradients.
     """
     self.n_samples = n_samples
     return super(ScoreKLqp, self).initialize(*args, **kwargs)
@@ -273,9 +246,7 @@ class ScoreKLqp(VariationalInference):
 class ScoreKLKLqp(VariationalInference):
   """Variational inference with the KL divergence
 
-  .. math::
-
-    \\text{KL}( q(z; \lambda) \| p(z \mid x) ).
+  $\\text{KL}( q(z; \lambda) \| p(z \mid x) ).$
 
   This class minimizes the objective using the score function gradient
   and an analytic KL term.
@@ -286,22 +257,20 @@ class ScoreKLKLqp(VariationalInference):
   def initialize(self, n_samples=1, kl_scaling=None, *args, **kwargs):
     """Initialization.
 
-    Parameters
-    ----------
-    n_samples : int, optional
-      Number of samples from variational model for calculating
-      stochastic gradients.
-    kl_scaling : dict of RandomVariable to float, optional
-      Provides option to scale terms when using ELBO with KL divergence.
-      If the KL divergence terms are
+    Args:
+      n_samples: int, optional.
+        Number of samples from variational model for calculating
+        stochastic gradients.
+      kl_scaling: dict of RandomVariable to float, optional.
+        Provides option to scale terms when using ELBO with KL divergence.
+        If the KL divergence terms are
 
-      .. math::
-        \\alpha_p \mathbb{E}_{q(z\mid x, \lambda)} [
-            \log q(z\mid x, \lambda) - \log p(z)],
+        $\\alpha_p \mathbb{E}_{q(z\mid x, \lambda)} [
+              \log q(z\mid x, \lambda) - \log p(z)],$
 
-      then pass {:math:`p(z)`: :math:`\\alpha_p`} as ``kl_scaling``,
-      where :math:`\\alpha_p` is a float that specifies how much to
-      scale the KL term.
+        then pass {\\(p(z)\\): \\(\\alpha_p\\)} as `kl_scaling`,
+        where \\(\\alpha_p\\) is a float that specifies how much to
+        scale the KL term.
     """
     if kl_scaling is None:
       kl_scaling = {}
@@ -317,9 +286,7 @@ class ScoreKLKLqp(VariationalInference):
 class ScoreEntropyKLqp(VariationalInference):
   """Variational inference with the KL divergence
 
-  .. math::
-
-    \\text{KL}( q(z; \lambda) \| p(z \mid x) ).
+  $\\text{KL}( q(z; \lambda) \| p(z \mid x) ).$
 
   This class minimizes the objective using the score function gradient
   and an analytic entropy term.
@@ -330,11 +297,10 @@ class ScoreEntropyKLqp(VariationalInference):
   def initialize(self, n_samples=1, *args, **kwargs):
     """Initialization.
 
-    Parameters
-    ----------
-    n_samples : int, optional
-      Number of samples from variational model for calculating
-      stochastic gradients.
+    Args:
+      n_samples: int, optional.
+        Number of samples from variational model for calculating
+        stochastic gradients.
     """
     self.n_samples = n_samples
     return super(ScoreEntropyKLqp, self).initialize(*args, **kwargs)
@@ -347,14 +313,12 @@ def build_reparam_loss_and_gradients(inference, var_list):
   """Build loss function. Its automatic differentiation
   is a stochastic gradient of
 
-  .. math::
-
-    -\\text{ELBO} =
-      -\mathbb{E}_{q(z; \lambda)} [ \log p(x, z) - \log q(z; \lambda) ]
+  $-\\text{ELBO} =
+      -\mathbb{E}_{q(z; \lambda)} [ \log p(x, z) - \log q(z; \lambda) ]$
 
   based on the reparameterization trick (Kingma and Welling, 2014).
 
-  Computed by sampling from :math:`q(z;\lambda)` and evaluating the
+  Computed by sampling from \\(q(z;\lambda)\\) and evaluating the
   expectation using Monte Carlo sampling.
   """
   p_log_prob = [0.0] * inference.n_samples
@@ -418,7 +382,7 @@ def build_reparam_kl_loss_and_gradients(inference, var_list):
 
   It assumes the KL is analytic.
 
-  Computed by sampling from :math:`q(z;\lambda)` and evaluating the
+  Computed by sampling from \\(q(z;\lambda)\\) and evaluating the
   expectation using Monte Carlo sampling.
   """
   p_log_lik = [0.0] * inference.n_samples
@@ -468,16 +432,14 @@ def build_reparam_entropy_loss_and_gradients(inference, var_list):
   """Build loss function. Its automatic differentiation
   is a stochastic gradient of
 
-  .. math::
-
-    -\\text{ELBO} =  -( \mathbb{E}_{q(z; \lambda)} [ \log p(x , z) ]
-          + \mathbb{H}(q(z; \lambda)) )
+  $-\\text{ELBO} =  -( \mathbb{E}_{q(z; \lambda)} [ \log p(x , z) ]
+          + \mathbb{H}(q(z; \lambda)) )$
 
   based on the reparameterization trick (Kingma and Welling, 2014).
 
   It assumes the entropy is analytic.
 
-  Computed by sampling from :math:`q(z;\lambda)` and evaluating the
+  Computed by sampling from \\(q(z;\lambda)\\) and evaluating the
   expectation using Monte Carlo sampling.
   """
   p_log_prob = [0.0] * inference.n_samples
@@ -531,7 +493,7 @@ def build_score_loss_and_gradients(inference, var_list):
   """Build loss function and gradients based on the score function
   estimator (Paisley et al., 2012).
 
-  Computed by sampling from :math:`q(z;\lambda)` and evaluating the
+  Computed by sampling from \\(q(z;\lambda)\\) and evaluating the
   expectation using Monte Carlo sampling.
   """
   p_log_prob = [0.0] * inference.n_samples
@@ -594,7 +556,7 @@ def build_score_kl_loss_and_gradients(inference, var_list):
 
   It assumes the KL is analytic.
 
-  Computed by sampling from :math:`q(z;\lambda)` and evaluating the
+  Computed by sampling from \\(q(z;\lambda)\\) and evaluating the
   expectation using Monte Carlo sampling.
   """
   p_log_lik = [0.0] * inference.n_samples
@@ -653,7 +615,7 @@ def build_score_entropy_loss_and_gradients(inference, var_list):
 
   It assumes the entropy is analytic.
 
-  Computed by sampling from :math:`q(z;\lambda)` and evaluating the
+  Computed by sampling from \\(q(z;\lambda)\\) and evaluating the
   expectation using Monte Carlo sampling.
   """
   p_log_prob = [0.0] * inference.n_samples

--- a/edward/inferences/laplace.py
+++ b/edward/inferences/laplace.py
@@ -22,43 +22,44 @@ class Laplace(MAP):
   It approximates the posterior distribution using a multivariate
   normal distribution centered at the mode of the posterior.
 
-  We implement this by running ``MAP`` to find the posterior mode.
+  We implement this by running `MAP` to find the posterior mode.
   This forms the mean of the normal approximation. We then compute the
   inverse Hessian at the mode of the posterior. This forms the
   covariance of the normal approximation.
   """
   def __init__(self, latent_vars, data=None):
     """
-    Parameters
-    ----------
-    latent_vars : list of RandomVariable or
-                  dict of RandomVariable to RandomVariable
-      Collection of random variables to perform inference on. If list,
-      each random variable will be implictly optimized using a
-      ``MultivariateNormalTriL`` random variable that is defined
-      internally (with unconstrained support). If dictionary, each
-      random variable must be a ``MultivariateNormalDiag``,
-      ``MultivariateNormalTriL``, or ``Normal`` random variable.
+    Args:
+      latent_vars: list of RandomVariable or
+                    dict of RandomVariable to RandomVariable.
+        Collection of random variables to perform inference on. If list,
+        each random variable will be implictly optimized using a
+        `MultivariateNormalTriL` random variable that is defined
+        internally (with unconstrained support). If dictionary, each
+        random variable must be a `MultivariateNormalDiag`,
+        `MultivariateNormalTriL`, or `Normal` random variable.
 
-    Notes
-    -----
-    If ``MultivariateNormalDiag`` or ``Normal`` random variables are
+    #### Notes
+
+    If `MultivariateNormalDiag` or `Normal` random variables are
     specified as approximations, then the Laplace approximation will
     only produce the diagonal. This does not capture correlation among
     the variables but it does not require a potentially expensive
     matrix inversion.
 
-    Examples
-    --------
-    >>> X = tf.placeholder(tf.float32, [N, D])
-    >>> w = Normal(loc=tf.zeros(D), scale=tf.ones(D))
-    >>> y = Normal(loc=ed.dot(X, w), scale=tf.ones(N))
-    >>>
-    >>> qw = MultivariateNormalTriL(
-    >>>     loc=tf.Variable(tf.random_normal([D])),
-    >>>     scale_tril=tf.Variable(tf.random_normal([D, D])))
-    >>>
-    >>> inference = ed.Laplace({w: qw}, data={X: X_train, y: y_train})
+    #### Examples
+
+    ```python
+    X = tf.placeholder(tf.float32, [N, D])
+    w = Normal(loc=tf.zeros(D), scale=tf.ones(D))
+    y = Normal(loc=ed.dot(X, w), scale=tf.ones(N))
+
+    qw = MultivariateNormalTriL(
+        loc=tf.Variable(tf.random_normal([D])),
+        scale_tril=tf.Variable(tf.random_normal([D, D])))
+
+    inference = ed.Laplace({w: qw}, data={X: X_train, y: y_train})
+    ```
     """
     if isinstance(latent_vars, list):
       with tf.variable_scope("posterior"):
@@ -80,7 +81,7 @@ class Laplace(MAP):
 
   def initialize(self, *args, **kwargs):
     # Store latent variables in a temporary attribute; MAP will
-    # optimize ``PointMass`` random variables, which subsequently
+    # optimize `PointMass` random variables, which subsequently
     # optimizes mean parameters of the normal approximations.
     latent_vars_normal = self.latent_vars.copy()
     self.latent_vars = {z: PointMass(params=qz.loc)
@@ -109,12 +110,11 @@ class Laplace(MAP):
 
     Computes the Hessian at the mode.
 
-    Parameters
-    ----------
-    feed_dict : dict, optional
-      Feed dictionary for a TensorFlow session run during evaluation
-      of Hessian. It is used to feed placeholders that are not fed
-      during initialization.
+    Args:
+      feed_dict: dict, optional.
+        Feed dictionary for a TensorFlow session run during evaluation
+        of Hessian. It is used to feed placeholders that are not fed
+        during initialization.
     """
     if feed_dict is None:
       feed_dict = {}

--- a/edward/inferences/map.py
+++ b/edward/inferences/map.py
@@ -20,15 +20,15 @@ class MAP(VariationalInference):
 
     \min_{z} - p(z \mid x).
 
-  This is equivalent to using a ``PointMass`` variational distribution
+  This is equivalent to using a `PointMass` variational distribution
   and minimizing the unnormalized objective,
 
   .. math::
 
     - \mathbb{E}_{q(z; \lambda)} [ \log p(x, z) ].
 
-  Notes
-  -----
+  #### Notes
+
   This class is currently restricted to optimization over
   differentiable latent variables. For example, it does not solve
   discrete optimization.
@@ -38,7 +38,7 @@ class MAP(VariationalInference):
 
   In conditional inference, we infer :math:`z` in :math:`p(z, \\beta
   \mid x)` while fixing inference over :math:`\\beta` using another
-  distribution :math:`q(\\beta)`. ``MAP`` optimizes
+  distribution :math:`q(\\beta)`. `MAP` optimizes
   :math:`\mathbb{E}_{q(\\beta)} [ \log p(x, z, \\beta) ]`, leveraging
   a single Monte Carlo sample, :math:`\log p(x, z, \\beta^*)`, where
   :math:`\\beta^* \sim q(\\beta)`. This is a lower bound to the
@@ -47,34 +47,37 @@ class MAP(VariationalInference):
   """
   def __init__(self, latent_vars=None, data=None):
     """
-    Parameters
-    ----------
-    latent_vars : list of RandomVariable or
-                  dict of RandomVariable to RandomVariable
-      Collection of random variables to perform inference on. If
-      list, each random variable will be implictly optimized
-      using a ``PointMass`` random variable that is defined
-      internally (with unconstrained support). If dictionary, each
-      value in the dictionary must be a ``PointMass`` random variable.
+    Args:
+      latent_vars: list of RandomVariable or
+                    dict of RandomVariable to RandomVariable.
+        Collection of random variables to perform inference on. If
+        list, each random variable will be implictly optimized
+        using a `PointMass` random variable that is defined
+        internally (with unconstrained support). If dictionary, each
+        value in the dictionary must be a `PointMass` random variable.
 
-    Examples
-    --------
-    Most explicitly, ``MAP`` is specified via a dictionary:
+    #### Examples
 
-    >>> qpi = PointMass(params=ed.to_simplex(tf.Variable(tf.zeros(K-1))))
-    >>> qmu = PointMass(params=tf.Variable(tf.zeros(K*D)))
-    >>> qsigma = PointMass(params=tf.nn.softplus(tf.Variable(tf.zeros(K*D))))
-    >>> ed.MAP({pi: qpi, mu: qmu, sigma: qsigma}, data)
+    Most explicitly, `MAP` is specified via a dictionary:
 
-    We also automate the specification of ``PointMass`` distributions,
+    ```python
+    qpi = PointMass(params=ed.to_simplex(tf.Variable(tf.zeros(K-1))))
+    qmu = PointMass(params=tf.Variable(tf.zeros(K*D)))
+    qsigma = PointMass(params=tf.nn.softplus(tf.Variable(tf.zeros(K*D))))
+    ed.MAP({pi: qpi, mu: qmu, sigma: qsigma}, data)
+    ```
+
+    We also automate the specification of `PointMass` distributions,
     so one can pass in a list of latent variables instead:
 
-    >>> ed.MAP([beta], data)
-    >>> ed.MAP([pi, mu, sigma], data)
+    ```python
+    ed.MAP([beta], data)
+    ed.MAP([pi, mu, sigma], data)
+    ```
 
-    Currently, ``MAP`` can only instantiate ``PointMass`` random variables
+    Currently, `MAP` can only instantiate `PointMass` random variables
     with unconstrained support. To constrain their support, one must
-    manually pass in the ``PointMass`` family.
+    manually pass in the `PointMass` family.
     """
     if isinstance(latent_vars, list):
       with tf.variable_scope("posterior"):

--- a/edward/inferences/map.py
+++ b/edward/inferences/map.py
@@ -16,16 +16,12 @@ class MAP(VariationalInference):
   This class implements gradient-based optimization to solve the
   optimization problem,
 
-  .. math::
-
-    \min_{z} - p(z \mid x).
+  $\min_{z} - p(z \mid x).$
 
   This is equivalent to using a `PointMass` variational distribution
   and minimizing the unnormalized objective,
 
-  .. math::
-
-    - \mathbb{E}_{q(z; \lambda)} [ \log p(x, z) ].
+  $- \mathbb{E}_{q(z; \lambda)} [ \log p(x, z) ].$
 
   #### Notes
 
@@ -34,16 +30,16 @@ class MAP(VariationalInference):
   discrete optimization.
 
   This class also minimizes the loss with respect to any model
-  parameters :math:`p(z \mid x; \\theta)`.
+  parameters \\(p(z \mid x; \\theta)\\).
 
-  In conditional inference, we infer :math:`z` in :math:`p(z, \\beta
-  \mid x)` while fixing inference over :math:`\\beta` using another
-  distribution :math:`q(\\beta)`. `MAP` optimizes
-  :math:`\mathbb{E}_{q(\\beta)} [ \log p(x, z, \\beta) ]`, leveraging
-  a single Monte Carlo sample, :math:`\log p(x, z, \\beta^*)`, where
-  :math:`\\beta^* \sim q(\\beta)`. This is a lower bound to the
-  marginal density :math:`\log p(x, z)`, and it is exact if
-  :math:`q(\\beta) = p(\\beta \mid x)` (up to stochasticity).
+  In conditional inference, we infer \\(z\\) in \\(p(z, \\beta
+  \mid x)\\) while fixing inference over \\(\\beta\\) using another
+  distribution \\(q(\\beta)\\). `MAP` optimizes
+  \\(\mathbb{E}_{q(\\beta)} [ \log p(x, z, \\beta) ]\\), leveraging
+  a single Monte Carlo sample, \\(\log p(x, z, \\beta^*)\\), where
+  \\(\\beta^* \sim q(\\beta)\\). This is a lower bound to the
+  marginal density \\(\log p(x, z)\\), and it is exact if
+  \\(q(\\beta) = p(\\beta \mid x)\\) (up to stochasticity).
   """
   def __init__(self, latent_vars=None, data=None):
     """
@@ -96,8 +92,7 @@ class MAP(VariationalInference):
     """Build loss function. Its automatic differentiation
     is the gradient of
 
-    .. math::
-      - \log p(x,z)
+    $- \log p(x,z).$
     """
     # Form dictionary in order to replace conditioning on prior or
     # observed variable with conditioning on a specific value.

--- a/edward/inferences/map.py
+++ b/edward/inferences/map.py
@@ -30,16 +30,16 @@ class MAP(VariationalInference):
   discrete optimization.
 
   This class also minimizes the loss with respect to any model
-  parameters \\(p(z \mid x; \\theta)\\).
+  parameters $p(z \mid x; \\theta)$.
 
-  In conditional inference, we infer \\(z\\) in \\(p(z, \\beta
-  \mid x)\\) while fixing inference over \\(\\beta\\) using another
-  distribution \\(q(\\beta)\\). `MAP` optimizes
-  \\(\mathbb{E}_{q(\\beta)} [ \log p(x, z, \\beta) ]\\), leveraging
-  a single Monte Carlo sample, \\(\log p(x, z, \\beta^*)\\), where
-  \\(\\beta^* \sim q(\\beta)\\). This is a lower bound to the
-  marginal density \\(\log p(x, z)\\), and it is exact if
-  \\(q(\\beta) = p(\\beta \mid x)\\) (up to stochasticity).
+  In conditional inference, we infer $z$ in $p(z, \\beta
+  \mid x)$ while fixing inference over $\\beta$ using another
+  distribution $q(\\beta)$. `MAP` optimizes
+  $\mathbb{E}_{q(\\beta)} [ \log p(x, z, \\beta) ]$, leveraging
+  a single Monte Carlo sample, $\log p(x, z, \\beta^*)$, where
+  $\\beta^* \sim q(\\beta)$. This is a lower bound to the
+  marginal density $\log p(x, z)$, and it is exact if
+  $q(\\beta) = p(\\beta \mid x)$ (up to stochasticity).
   """
   def __init__(self, latent_vars=None, data=None):
     """

--- a/edward/inferences/metropolis_hastings.py
+++ b/edward/inferences/metropolis_hastings.py
@@ -21,25 +21,25 @@ class MetropolisHastings(MonteCarlo):
 
   #### Notes
 
-  In conditional inference, we infer \\(z\\) in \\(p(z, \\beta
-  \mid x)\\) while fixing inference over \\(\\beta\\) using another
-  distribution \\(q(\\beta)\\).
+  In conditional inference, we infer $z$ in $p(z, \\beta
+  \mid x)$ while fixing inference over $\\beta$ using another
+  distribution $q(\\beta)$.
   To calculate the acceptance ratio, `MetropolisHastings` uses an
   estimate of the marginal density,
 
   $p(x, z) = \mathbb{E}_{q(\\beta)} [ p(x, z, \\beta) ]
             \\approx p(x, z, \\beta^*)$
 
-  leveraging a single Monte Carlo sample, where \\(\\beta^* \sim
-  q(\\beta)\\). This is unbiased (and therefore asymptotically exact as a
-  pseudo-marginal method) if \\(q(\\beta) = p(\\beta \mid x)\\).
+  leveraging a single Monte Carlo sample, where $\\beta^* \sim
+  q(\\beta)$. This is unbiased (and therefore asymptotically exact as a
+  pseudo-marginal method) if $q(\\beta) = p(\\beta \mid x)$.
   """
   def __init__(self, latent_vars, proposal_vars, data=None):
     """
     Args:
       proposal_vars: dict of RandomVariable to RandomVariable.
         Collection of random variables to perform inference on; each is
-        binded to a proposal distribution \\(g(z' \mid z)\\).
+        binded to a proposal distribution $g(z' \mid z)$.
 
     #### Examples
 

--- a/edward/inferences/metropolis_hastings.py
+++ b/edward/inferences/metropolis_hastings.py
@@ -21,27 +21,25 @@ class MetropolisHastings(MonteCarlo):
 
   #### Notes
 
-  In conditional inference, we infer :math:`z` in :math:`p(z, \\beta
-  \mid x)` while fixing inference over :math:`\\beta` using another
-  distribution :math:`q(\\beta)`.
+  In conditional inference, we infer \\(z\\) in \\(p(z, \\beta
+  \mid x)\\) while fixing inference over \\(\\beta\\) using another
+  distribution \\(q(\\beta)\\).
   To calculate the acceptance ratio, `MetropolisHastings` uses an
   estimate of the marginal density,
 
-  .. math::
+  $p(x, z) = \mathbb{E}_{q(\\beta)} [ p(x, z, \\beta) ]
+            \\approx p(x, z, \\beta^*)$
 
-    p(x, z) = \mathbb{E}_{q(\\beta)} [ p(x, z, \\beta) ]
-            \\approx p(x, z, \\beta^*)
-
-  leveraging a single Monte Carlo sample, where :math:`\\beta^* \sim
-  q(\\beta)`. This is unbiased (and therefore asymptotically exact as a
-  pseudo-marginal method) if :math:`q(\\beta) = p(\\beta \mid x)`.
+  leveraging a single Monte Carlo sample, where \\(\\beta^* \sim
+  q(\\beta)\\). This is unbiased (and therefore asymptotically exact as a
+  pseudo-marginal method) if \\(q(\\beta) = p(\\beta \mid x)\\).
   """
   def __init__(self, latent_vars, proposal_vars, data=None):
     """
     Args:
       proposal_vars: dict of RandomVariable to RandomVariable.
         Collection of random variables to perform inference on; each is
-        binded to a proposal distribution :math:`g(z' \mid z)`.
+        binded to a proposal distribution \\(g(z' \mid z)\\).
 
     #### Examples
 
@@ -63,11 +61,10 @@ class MetropolisHastings(MonteCarlo):
     """Draw sample from proposal conditional on last sample. Then
     accept or reject the sample based on the ratio,
 
-    .. math::
-      \\text{ratio} =
+    $\\text{ratio} =
           \log p(x, z^{\\text{new}}) - \log p(x, z^{\\text{old}}) +
           \log g(z^{\\text{new}} \mid z^{\\text{old}}) -
-          \log g(z^{\\text{old}} \mid z^{\\text{new}})
+          \log g(z^{\\text{old}} \mid z^{\\text{new}})$
 
     #### Notes
 

--- a/edward/inferences/metropolis_hastings.py
+++ b/edward/inferences/metropolis_hastings.py
@@ -19,12 +19,12 @@ except Exception as e:
 class MetropolisHastings(MonteCarlo):
   """Metropolis-Hastings (Metropolis et al., 1953; Hastings, 1970).
 
-  Notes
-  -----
+  #### Notes
+
   In conditional inference, we infer :math:`z` in :math:`p(z, \\beta
   \mid x)` while fixing inference over :math:`\\beta` using another
   distribution :math:`q(\\beta)`.
-  To calculate the acceptance ratio, ``MetropolisHastings`` uses an
+  To calculate the acceptance ratio, `MetropolisHastings` uses an
   estimate of the marginal density,
 
   .. math::
@@ -38,21 +38,22 @@ class MetropolisHastings(MonteCarlo):
   """
   def __init__(self, latent_vars, proposal_vars, data=None):
     """
-    Parameters
-    ----------
-    proposal_vars : dict of RandomVariable to RandomVariable
-      Collection of random variables to perform inference on; each is
-      binded to a proposal distribution :math:`g(z' \mid z)`.
+    Args:
+      proposal_vars: dict of RandomVariable to RandomVariable.
+        Collection of random variables to perform inference on; each is
+        binded to a proposal distribution :math:`g(z' \mid z)`.
 
-    Examples
-    --------
-    >>> z = Normal(loc=0.0, scale=1.0)
-    >>> x = Normal(loc=tf.ones(10) * z, scale=1.0)
-    >>>
-    >>> qz = Empirical(tf.Variable(tf.zeros(500)))
-    >>> proposal_z = Normal(loc=z, scale=0.5)
-    >>> data = {x: np.array([0.0] * 10, dtype=np.float32)}
-    >>> inference = ed.MetropolisHastings({z: qz}, {z: proposal_z}, data)
+    #### Examples
+
+    ```python
+    z = Normal(loc=0.0, scale=1.0)
+    x = Normal(loc=tf.ones(10) * z, scale=1.0)
+
+    qz = Empirical(tf.Variable(tf.zeros(500)))
+    proposal_z = Normal(loc=z, scale=0.5)
+    data = {x: np.array([0.0] * 10, dtype=np.float32)}
+    inference = ed.MetropolisHastings({z: qz}, {z: proposal_z}, data)
+    ```
     """
     check_latent_vars(proposal_vars)
     self.proposal_vars = proposal_vars
@@ -68,10 +69,10 @@ class MetropolisHastings(MonteCarlo):
           \log g(z^{\\text{new}} \mid z^{\\text{old}}) -
           \log g(z^{\\text{old}} \mid z^{\\text{new}})
 
-    Notes
-    -----
+    #### Notes
+
     The updates assume each Empirical random variable is directly
-    parameterized by ``tf.Variable``s.
+    parameterized by `tf.Variable`s.
     """
     old_sample = {z: tf.gather(qz.params, tf.maximum(self.t - 1, 0))
                   for z, qz in six.iteritems(self.latent_vars)}
@@ -136,7 +137,7 @@ class MetropolisHastings(MonteCarlo):
     sample_values = tf.cond(accept, lambda: list(six.itervalues(new_sample)),
                             lambda: list(six.itervalues(old_sample)))
     if not isinstance(sample_values, list):
-      # ``tf.cond`` returns tf.Tensor if output is a list of size 1.
+      # `tf.cond` returns tf.Tensor if output is a list of size 1.
       sample_values = [sample_values]
 
     sample = {z: sample_value for z, sample_value in

--- a/edward/inferences/monte_carlo.py
+++ b/edward/inferences/monte_carlo.py
@@ -15,59 +15,62 @@ from edward.util import get_session
 @six.add_metaclass(abc.ABCMeta)
 class MonteCarlo(Inference):
   """Abstract base class for Monte Carlo. Specific Monte Carlo methods
-  inherit from ``MonteCarlo``, sharing methods in this class.
+  inherit from `MonteCarlo`, sharing methods in this class.
 
-  To build an algorithm inheriting from ``MonteCarlo``, one must at the
-  minimum implement ``build_update``: it determines how to assign
-  the samples in the ``Empirical`` approximations.
+  To build an algorithm inheriting from `MonteCarlo`, one must at the
+  minimum implement `build_update`: it determines how to assign
+  the samples in the `Empirical` approximations.
   """
   def __init__(self, latent_vars=None, data=None):
     """Initialization.
 
-    Parameters
-    ----------
-    latent_vars : list or dict, optional
-      Collection of random variables (of type ``RandomVariable`` or
-      ``tf.Tensor``) to perform inference on. If list, each random
-      variable will be approximated using a ``Empirical`` random
-      variable that is defined internally (with unconstrained
-      support). If dictionary, each value in the dictionary must be a
-      ``Empirical`` random variable.
-    data : dict, optional
-      Data dictionary which binds observed variables (of type
-      ``RandomVariable`` or ``tf.Tensor``) to their realizations (of
-      type ``tf.Tensor``). It can also bind placeholders (of type
-      ``tf.Tensor``) used in the model to their realizations.
+    Args:
+      latent_vars: list or dict, optional.
+        Collection of random variables (of type `RandomVariable` or
+        `tf.Tensor`) to perform inference on. If list, each random
+        variable will be approximated using a `Empirical` random
+        variable that is defined internally (with unconstrained
+        support). If dictionary, each value in the dictionary must be a
+        `Empirical` random variable.
+      data: dict, optional.
+        Data dictionary which binds observed variables (of type
+        `RandomVariable` or `tf.Tensor`) to their realizations (of
+        type `tf.Tensor`). It can also bind placeholders (of type
+        `tf.Tensor`) used in the model to their realizations.
 
-    Examples
-    --------
-    Most explicitly, ``MonteCarlo`` is specified via a dictionary:
+    #### Examples
 
-    >>> qpi = Empirical(params=tf.Variable(tf.zeros([T, K-1])))
-    >>> qmu = Empirical(params=tf.Variable(tf.zeros([T, K*D])))
-    >>> qsigma = Empirical(params=tf.Variable(tf.zeros([T, K*D])))
-    >>> ed.MonteCarlo({pi: qpi, mu: qmu, sigma: qsigma}, data)
+    Most explicitly, `MonteCarlo` is specified via a dictionary:
 
-    The inferred posterior is comprised of ``Empirical`` random
-    variables with ``T`` samples. We also automate the specification
-    of ``Empirical`` random variables. One can pass in a list of
+    ```python
+    qpi = Empirical(params=tf.Variable(tf.zeros([T, K-1])))
+    qmu = Empirical(params=tf.Variable(tf.zeros([T, K*D])))
+    qsigma = Empirical(params=tf.Variable(tf.zeros([T, K*D])))
+    ed.MonteCarlo({pi: qpi, mu: qmu, sigma: qsigma}, data)
+    ```
+
+    The inferred posterior is comprised of `Empirical` random
+    variables with `T` samples. We also automate the specification
+    of `Empirical` random variables. One can pass in a list of
     latent variables instead:
 
-    >>> ed.MonteCarlo([beta], data)
-    >>> ed.MonteCarlo([pi, mu, sigma], data)
+    ```python
+    ed.MonteCarlo([beta], data)
+    ed.MonteCarlo([pi, mu, sigma], data)
+    ```
 
-    It defaults to ``Empirical`` random variables with 10,000 samples for
+    It defaults to `Empirical` random variables with 10,000 samples for
     each dimension.
 
-    Notes
-    -----
-    The number of Monte Carlo iterations is set according to the
-    minimum of all ``Empirical`` sizes.
+    #### Notes
 
-    Initialization is assumed from ``params[0, :]``. This generalizes
+    The number of Monte Carlo iterations is set according to the
+    minimum of all `Empirical` sizes.
+
+    Initialization is assumed from `params[0, :]`. This generalizes
     initializing randomly and initializing from user input. Updates
     are along this outer dimension, where iteration t updates
-    ``params[t, :]`` in each ``Empirical`` random variable.
+    `params[t, :]` in each `Empirical` random variable.
 
     No warm-up is implemented. Users must run MCMC for a long period
     of time, then manually burn in the Empirical random variable.
@@ -107,22 +110,20 @@ class MonteCarlo(Inference):
   def update(self, feed_dict=None):
     """Run one iteration of sampling for Monte Carlo.
 
-    Parameters
-    ----------
-    feed_dict : dict, optional
-      Feed dictionary for a TensorFlow session run. It is used to feed
-      placeholders that are not fed during initialization.
+    Args:
+      feed_dict: dict, optional.
+        Feed dictionary for a TensorFlow session run. It is used to feed
+        placeholders that are not fed during initialization.
 
-    Returns
-    -------
-    dict
+    Returns:
+      dict.
       Dictionary of algorithm-specific information. In this case, the
       acceptance rate of samples since (and including) this iteration.
 
-    Notes
-    -----
-    We run the increment of ``t`` separately from other ops. Whether the
-    others op run with the ``t`` before incrementing or after incrementing
+    #### Notes
+
+    We run the increment of `t` separately from other ops. Whether the
+    others op run with the `t` before incrementing or after incrementing
     depends on which is run faster in the TensorFlow graph. Running it
     separately forces a consistent behavior.
     """
@@ -158,12 +159,11 @@ class MonteCarlo(Inference):
   @abc.abstractmethod
   def build_update(self):
     """Build update rules, returning an assign op for parameters in
-    the ``Empirical`` random variables.
+    the `Empirical` random variables.
 
-    Any derived class of ``MonteCarlo`` **must** implement this method.
+    Any derived class of `MonteCarlo` **must** implement this method.
 
-    Raises
-    ------
-    NotImplementedError
+    Raises:
+      NotImplementedError.
     """
     raise NotImplementedError()

--- a/edward/inferences/sghmc.py
+++ b/edward/inferences/sghmc.py
@@ -18,12 +18,12 @@ except Exception as e:
 class SGHMC(MonteCarlo):
   """Stochastic gradient Hamiltonian Monte Carlo (Chen et al., 2014).
 
-  Notes
-  -----
+  #### Notes
+
   In conditional inference, we infer :math:`z` in :math:`p(z, \\beta
   \mid x)` while fixing inference over :math:`\\beta` using another
   distribution :math:`q(\\beta)`.
-  ``SGHMC`` substitutes the model's log marginal density
+  `SGHMC` substitutes the model's log marginal density
 
   .. math::
 
@@ -36,25 +36,26 @@ class SGHMC(MonteCarlo):
   """
   def __init__(self, *args, **kwargs):
     """
-    Examples
-    --------
-    >>> z = Normal(loc=0.0, scale=1.0)
-    >>> x = Normal(loc=tf.ones(10) * z, scale=1.0)
+    #### Examples
+
+    ```python
+    z = Normal(loc=0.0, scale=1.0)
+    x = Normal(loc=tf.ones(10) * z, scale=1.0)
     >>>
-    >>> qz = Empirical(tf.Variable(tf.zeros(500)))
-    >>> data = {x: np.array([0.0] * 10, dtype=np.float32)}
-    >>> inference = ed.SGHMC({z: qz}, data)
+    qz = Empirical(tf.Variable(tf.zeros(500)))
+    data = {x: np.array([0.0] * 10, dtype=np.float32)}
+    inference = ed.SGHMC({z: qz}, data)
+    ```
     """
     super(SGHMC, self).__init__(*args, **kwargs)
 
   def initialize(self, step_size=0.25, friction=0.1, *args, **kwargs):
     """
-    Parameters
-    ----------
-    step_size : float, optional
-      Constant scale factor of learning rate.
-    friction : float, optional
-      Constant scale on the friction term in the Hamiltonian system.
+    Args:
+      step_size: float, optional.
+        Constant scale factor of learning rate.
+      friction: float, optional.
+        Constant scale on the friction term in the Hamiltonian system.
     """
     self.step_size = step_size
     self.friction = friction
@@ -108,10 +109,9 @@ class SGHMC(MonteCarlo):
     """Utility function to calculate model's log joint density,
     log p(x, z), for inputs z (and fixed data x).
 
-    Parameters
-    ----------
-    z_sample : dict
-      Latent variable keys to samples.
+    Args:
+      z_sample: dict.
+        Latent variable keys to samples.
     """
     scope = 'inference_' + str(id(self))
     # Form dictionary in order to replace conditioning on prior or

--- a/edward/inferences/sghmc.py
+++ b/edward/inferences/sghmc.py
@@ -20,19 +20,17 @@ class SGHMC(MonteCarlo):
 
   #### Notes
 
-  In conditional inference, we infer :math:`z` in :math:`p(z, \\beta
-  \mid x)` while fixing inference over :math:`\\beta` using another
-  distribution :math:`q(\\beta)`.
+  In conditional inference, we infer \\(z\\) in \\(p(z, \\beta
+  \mid x)\\) while fixing inference over \\(\\beta\\) using another
+  distribution \\(q(\\beta)\\).
   `SGHMC` substitutes the model's log marginal density
 
-  .. math::
+  $\log p(x, z) = \log \mathbb{E}_{q(\\beta)} [ p(x, z, \\beta) ]
+                \\approx \log p(x, z, \\beta^*)$
 
-    \log p(x, z) = \log \mathbb{E}_{q(\\beta)} [ p(x, z, \\beta) ]
-                \\approx \log p(x, z, \\beta^*)
-
-  leveraging a single Monte Carlo sample, where :math:`\\beta^* \sim
-  q(\\beta)`. This is unbiased (and therefore asymptotically exact as a
-  pseudo-marginal method) if :math:`q(\\beta) = p(\\beta \mid x)`.
+  leveraging a single Monte Carlo sample, where \\(\\beta^* \sim
+  q(\\beta)\\). This is unbiased (and therefore asymptotically exact as a
+  pseudo-marginal method) if \\(q(\\beta) = p(\\beta \mid x)\\).
   """
   def __init__(self, *args, **kwargs):
     """

--- a/edward/inferences/sghmc.py
+++ b/edward/inferences/sghmc.py
@@ -20,17 +20,17 @@ class SGHMC(MonteCarlo):
 
   #### Notes
 
-  In conditional inference, we infer \\(z\\) in \\(p(z, \\beta
-  \mid x)\\) while fixing inference over \\(\\beta\\) using another
-  distribution \\(q(\\beta)\\).
+  In conditional inference, we infer $z$ in $p(z, \\beta
+  \mid x)$ while fixing inference over $\\beta$ using another
+  distribution $q(\\beta)$.
   `SGHMC` substitutes the model's log marginal density
 
   $\log p(x, z) = \log \mathbb{E}_{q(\\beta)} [ p(x, z, \\beta) ]
                 \\approx \log p(x, z, \\beta^*)$
 
-  leveraging a single Monte Carlo sample, where \\(\\beta^* \sim
-  q(\\beta)\\). This is unbiased (and therefore asymptotically exact as a
-  pseudo-marginal method) if \\(q(\\beta) = p(\\beta \mid x)\\).
+  leveraging a single Monte Carlo sample, where $\\beta^* \sim
+  q(\\beta)$. This is unbiased (and therefore asymptotically exact as a
+  pseudo-marginal method) if $q(\\beta) = p(\\beta \mid x)$.
   """
   def __init__(self, *args, **kwargs):
     """

--- a/edward/inferences/sghmc.py
+++ b/edward/inferences/sghmc.py
@@ -39,7 +39,7 @@ class SGHMC(MonteCarlo):
     ```python
     z = Normal(loc=0.0, scale=1.0)
     x = Normal(loc=tf.ones(10) * z, scale=1.0)
-    >>>
+
     qz = Empirical(tf.Variable(tf.zeros(500)))
     data = {x: np.array([0.0] * 10, dtype=np.float32)}
     inference = ed.SGHMC({z: qz}, data)

--- a/edward/inferences/sgld.py
+++ b/edward/inferences/sgld.py
@@ -20,17 +20,17 @@ class SGLD(MonteCarlo):
 
   #### Notes
 
-  In conditional inference, we infer \\(z\\) in \\(p(z, \\beta
-  \mid x)\\) while fixing inference over \\(\\beta\\) using another
-  distribution \\(q(\\beta)\\).
+  In conditional inference, we infer $z$ in $p(z, \\beta
+  \mid x)$ while fixing inference over $\\beta$ using another
+  distribution $q(\\beta)$.
   `SGLD` substitutes the model's log marginal density
 
   $\log p(x, z) = \log \mathbb{E}_{q(\\beta)} [ p(x, z, \\beta) ]
                 \\approx \log p(x, z, \\beta^*)$
 
-  leveraging a single Monte Carlo sample, where \\(\\beta^* \sim
-  q(\\beta)\\). This is unbiased (and therefore asymptotically exact as a
-  pseudo-marginal method) if \\(q(\\beta) = p(\\beta \mid x)\\).
+  leveraging a single Monte Carlo sample, where $\\beta^* \sim
+  q(\\beta)$. This is unbiased (and therefore asymptotically exact as a
+  pseudo-marginal method) if $q(\\beta) = p(\\beta \mid x)$.
   """
   def __init__(self, *args, **kwargs):
     """

--- a/edward/inferences/sgld.py
+++ b/edward/inferences/sgld.py
@@ -18,12 +18,12 @@ except Exception as e:
 class SGLD(MonteCarlo):
   """Stochastic gradient Langevin dynamics (Welling and Teh, 2011).
 
-  Notes
-  -----
+  #### Notes
+
   In conditional inference, we infer :math:`z` in :math:`p(z, \\beta
   \mid x)` while fixing inference over :math:`\\beta` using another
   distribution :math:`q(\\beta)`.
-  ``SGLD`` substitutes the model's log marginal density
+  `SGLD` substitutes the model's log marginal density
 
   .. math::
 
@@ -36,23 +36,24 @@ class SGLD(MonteCarlo):
   """
   def __init__(self, *args, **kwargs):
     """
-    Examples
-    --------
-    >>> z = Normal(loc=0.0, scale=1.0)
-    >>> x = Normal(loc=tf.ones(10) * z, scale=1.0)
-    >>>
-    >>> qz = Empirical(tf.Variable(tf.zeros(500)))
-    >>> data = {x: np.array([0.0] * 10, dtype=np.float32)}
-    >>> inference = ed.SGLD({z: qz}, data)
+    #### Examples
+
+    ```python
+    z = Normal(loc=0.0, scale=1.0)
+    x = Normal(loc=tf.ones(10) * z, scale=1.0)
+
+    qz = Empirical(tf.Variable(tf.zeros(500)))
+    data = {x: np.array([0.0] * 10, dtype=np.float32)}
+    inference = ed.SGLD({z: qz}, data)
+    ```
     """
     super(SGLD, self).__init__(*args, **kwargs)
 
   def initialize(self, step_size=0.25, *args, **kwargs):
     """
-    Parameters
-    ----------
-    step_size : float, optional
-      Constant scale factor of learning rate.
+    Args:
+      step_size: float, optional.
+        Constant scale factor of learning rate.
     """
     self.step_size = step_size
     return super(SGLD, self).initialize(*args, **kwargs)
@@ -61,10 +62,10 @@ class SGLD(MonteCarlo):
     """Simulate Langevin dynamics using a discretized integrator. Its
     discretization error goes to zero as the learning rate decreases.
 
-    Notes
-    -----
+    #### Notes
+
     The updates assume each Empirical random variable is directly
-    parameterized by ``tf.Variable``s.
+    parameterized by `tf.Variable`s.
     """
     old_sample = {z: tf.gather(qz.params, tf.maximum(self.t - 1, 0))
                   for z, qz in six.iteritems(self.latent_vars)}
@@ -97,10 +98,9 @@ class SGLD(MonteCarlo):
     """Utility function to calculate model's log joint density,
     log p(x, z), for inputs z (and fixed data x).
 
-    Parameters
-    ----------
-    z_sample : dict
-      Latent variable keys to samples.
+    Args:
+      z_sample: dict.
+        Latent variable keys to samples.
     """
     scope = 'inference_' + str(id(self))
     # Form dictionary in order to replace conditioning on prior or

--- a/edward/inferences/sgld.py
+++ b/edward/inferences/sgld.py
@@ -20,19 +20,17 @@ class SGLD(MonteCarlo):
 
   #### Notes
 
-  In conditional inference, we infer :math:`z` in :math:`p(z, \\beta
-  \mid x)` while fixing inference over :math:`\\beta` using another
-  distribution :math:`q(\\beta)`.
+  In conditional inference, we infer \\(z\\) in \\(p(z, \\beta
+  \mid x)\\) while fixing inference over \\(\\beta\\) using another
+  distribution \\(q(\\beta)\\).
   `SGLD` substitutes the model's log marginal density
 
-  .. math::
+  $\log p(x, z) = \log \mathbb{E}_{q(\\beta)} [ p(x, z, \\beta) ]
+                \\approx \log p(x, z, \\beta^*)$
 
-    \log p(x, z) = \log \mathbb{E}_{q(\\beta)} [ p(x, z, \\beta) ]
-                \\approx \log p(x, z, \\beta^*)
-
-  leveraging a single Monte Carlo sample, where :math:`\\beta^* \sim
-  q(\\beta)`. This is unbiased (and therefore asymptotically exact as a
-  pseudo-marginal method) if :math:`q(\\beta) = p(\\beta \mid x)`.
+  leveraging a single Monte Carlo sample, where \\(\\beta^* \sim
+  q(\\beta)\\). This is unbiased (and therefore asymptotically exact as a
+  pseudo-marginal method) if \\(q(\\beta) = p(\\beta \mid x)\\).
   """
   def __init__(self, *args, **kwargs):
     """

--- a/edward/inferences/variational_inference.py
+++ b/edward/inferences/variational_inference.py
@@ -20,11 +20,11 @@ except ImportError:
 @six.add_metaclass(abc.ABCMeta)
 class VariationalInference(Inference):
   """Abstract base class for variational inference. Specific
-  variational inference methods inherit from ``VariationalInference``,
+  variational inference methods inherit from `VariationalInference`,
   sharing methods such as a default optimizer.
 
-  To build an algorithm inheriting from ``VariaitonalInference``, one
-  must at the minimum implement ``build_loss_and_gradients``: it
+  To build an algorithm inheriting from `VariaitonalInference`, one
+  must at the minimum implement `build_loss_and_gradients`: it
   determines the loss function and gradients to apply for a given
   optimizer.
   """
@@ -35,23 +35,22 @@ class VariationalInference(Inference):
                  global_step=None, *args, **kwargs):
     """Initialize variational inference.
 
-    Parameters
-    ----------
-    optimizer : str or tf.train.Optimizer, optional
-      A TensorFlow optimizer, to use for optimizing the variational
-      objective. Alternatively, one can pass in the name of a
-      TensorFlow optimizer, and default parameters for the optimizer
-      will be used.
-    var_list : list of tf.Variable, optional
-      List of TensorFlow variables to optimize over. Default is all
-      trainable variables that ``latent_vars`` and ``data`` depend on,
-      excluding those that are only used in conditionals in ``data``.
-    use_prettytensor : bool, optional
-      ``True`` if aim to use PrettyTensor optimizer (when using
-      PrettyTensor) or ``False`` if aim to use TensorFlow optimizer.
-      Defaults to TensorFlow.
-    global_step : tf.Variable, optional
-      A TensorFlow variable to hold the global step.
+    Args:
+      optimizer: str or tf.train.Optimizer, optional.
+        A TensorFlow optimizer, to use for optimizing the variational
+        objective. Alternatively, one can pass in the name of a
+        TensorFlow optimizer, and default parameters for the optimizer
+        will be used.
+      var_list: list of tf.Variable, optional.
+        List of TensorFlow variables to optimize over. Default is all
+        trainable variables that `latent_vars` and `data` depend on,
+        excluding those that are only used in conditionals in `data`.
+      use_prettytensor: bool, optional.
+        `True` if aim to use PrettyTensor optimizer (when using
+        PrettyTensor) or `False` if aim to use TensorFlow optimizer.
+        Defaults to TensorFlow.
+      global_step: tf.Variable, optional.
+        A TensorFlow variable to hold the global step.
     """
     super(VariationalInference, self).initialize(*args, **kwargs)
 
@@ -141,15 +140,13 @@ class VariationalInference(Inference):
   def update(self, feed_dict=None):
     """Run one iteration of optimizer for variational inference.
 
-    Parameters
-    ----------
-    feed_dict : dict, optional
-      Feed dictionary for a TensorFlow session run. It is used to feed
-      placeholders that are not fed during initialization.
+    Args:
+      feed_dict: dict, optional.
+        Feed dictionary for a TensorFlow session run. It is used to feed
+        placeholders that are not fed during initialization.
 
-    Returns
-    -------
-    dict
+    Returns;
+      dict.
       Dictionary of algorithm-specific information. In this case, the
       loss function value after one iteration.
     """
@@ -187,11 +184,10 @@ class VariationalInference(Inference):
     """Build loss function and its gradients. They will be leveraged
     in an optimizer to update the model and variational parameters.
 
-    Any derived class of ``VariationalInference`` **must** implement
+    Any derived class of `VariationalInference` **must** implement
     this method.
 
-    Raises
-    ------
-    NotImplementedError
+    Raises;
+      NotImplementedError.
     """
     raise NotImplementedError()

--- a/edward/inferences/wgan_inference.py
+++ b/edward/inferences/wgan_inference.py
@@ -24,34 +24,35 @@ class WGANInference(GANInference):
   """
   def __init__(self, *args, **kwargs):
     """
-    Examples
-    --------
-    >>> z = Normal(loc=tf.zeros([100, 10]), scale=tf.ones([100, 10]))
-    >>> x = generative_network(z)
-    >>>
-    >>> inference = ed.WGANInference({x: x_data}, discriminator)
+    #### Examples
 
-    Notes
-    -----
-    Argument-wise, the only difference from ``GANInference`` is
-    conceptual: the ``discriminator`` is better described as a test
-    function or critic. ``WGANInference`` continues to use
-    ``discriminator`` only to share methods and attributes with
-    ``GANInference``.
+    ```python
+    z = Normal(loc=tf.zeros([100, 10]), scale=tf.ones([100, 10]))
+    x = generative_network(z)
+
+    inference = ed.WGANInference({x: x_data}, discriminator)
+    ```
+
+    #### Notes
+
+    Argument-wise, the only difference from `GANInference` is
+    conceptual: the `discriminator` is better described as a test
+    function or critic. `WGANInference` continues to use
+    `discriminator` only to share methods and attributes with
+    `GANInference`.
     """
     super(WGANInference, self).__init__(*args, **kwargs)
 
   def initialize(self, penalty=10.0, clip=None, *args, **kwargs):
     """Initialize Wasserstein GAN inference.
 
-    Parameters
-    ----------
-    penalty : float, optional
-      Scalar value to enforce gradient penalty that ensures the
-      gradients have norm equal to 1 (Gulrajani et al., 2017). Set to
-      None (or 0.0) if using no penalty.
-    clip : float, optional
-      Value to clip weights by. Default is no clipping.
+    Args:
+      penalty: float, optional.
+        Scalar value to enforce gradient penalty that ensures the
+        gradients have norm equal to 1 (Gulrajani et al., 2017). Set to
+        None (or 0.0) if using no penalty.
+      clip: float, optional.
+        Value to clip weights by. Default is no clipping.
     """
     self.penalty = penalty
 

--- a/edward/models/dirichlet_process.py
+++ b/edward/models/dirichlet_process.py
@@ -15,11 +15,11 @@ except Exception as e:
 
 
 class distributions_DirichletProcess(Distribution):
-  """Dirichlet process \\(\alpha, H\\).
+  """Dirichlet process $\alpha, H$.
 
-  It has two parameters: a positive real value \\(\alpha\\), known
+  It has two parameters: a positive real value $\alpha$, known
   as the concentration parameter (`concentration`), and a base
-  distribution \\(H\\) (`base`).
+  distribution $H$ (`base`).
   """
   def __init__(self,
                concentration,

--- a/edward/models/dirichlet_process.py
+++ b/edward/models/dirichlet_process.py
@@ -15,11 +15,11 @@ except Exception as e:
 
 
 class distributions_DirichletProcess(Distribution):
-  """Dirichlet process :math:`\mathcal{DP}(\\alpha, H)`.
+  """Dirichlet process \\(\alpha, H\\).
 
-  It has two parameters: a positive real value :math:`\\alpha`, known
-  as the concentration parameter (``concentration``), and a base
-  distribution :math:`H` (``base``).
+  It has two parameters: a positive real value \\(\alpha\\), known
+  as the concentration parameter (`concentration`), and a base
+  distribution \\(H\\) (`base`).
   """
   def __init__(self,
                concentration,
@@ -29,25 +29,26 @@ class distributions_DirichletProcess(Distribution):
                name="DirichletProcess"):
     """Initialize a batch of Dirichlet processes.
 
-    Parameters
-    ----------
-    concentration : tf.Tensor
-      Concentration parameter. Must be positive real-valued. Its shape
-      determines the number of independent DPs (batch shape).
-    base : RandomVariable
-      Base distribution. Its shape determines the shape of an
-      individual DP (event shape).
+    Args:
+      concentration: tf.Tensor.
+        Concentration parameter. Must be positive real-valued. Its shape
+        determines the number of independent DPs (batch shape).
+      base: RandomVariable.
+        Base distribution. Its shape determines the shape of an
+        individual DP (event shape).
 
-    Examples
-    --------
-    >>> # scalar concentration parameter, scalar base distribution
-    >>> dp = DirichletProcess(0.1, Normal(loc=0.0, scale=1.0))
-    >>> assert dp.shape == ()
-    >>>
-    >>> # vector of concentration parameters, matrix of Exponentials
-    >>> dp = DirichletProcess(tf.constant([0.1, 0.4]),
+    #### Examples
+
+    ```python
+    # scalar concentration parameter, scalar base distribution
+    dp = DirichletProcess(0.1, Normal(loc=0.0, scale=1.0))
+    assert dp.shape == ()
+
+    # vector of concentration parameters, matrix of Exponentials
+    dp = DirichletProcess(tf.constant([0.1, 0.4]),
     ...                       Exponential(lam=tf.ones([5, 3])))
-    >>> assert dp.shape == (2, 5, 3)
+    assert dp.shape == (2, 5, 3)
+    ```
     """
     parameters = locals()
     with tf.name_scope(name, values=[concentration]):
@@ -120,24 +121,23 @@ class distributions_DirichletProcess(Distribution):
     return self.base.shape
 
   def _sample_n(self, n, seed=None):
-    """Sample ``n`` draws from the DP. Draws from the base
-    distribution are memoized across ``n`` and across calls to
-    ``sample()``.
+    """Sample `n` draws from the DP. Draws from the base
+    distribution are memoized across `n` and across calls to
+    `sample()`.
 
     Draws from the base distribution are not memoized across the batch
     shape, i.e., each independent DP in the batch shape has its own
     memoized samples.
 
-    Returns
-    -------
-    tf.Tensor
-      A ``tf.Tensor`` of shape ``[n] + batch_shape + event_shape``,
-      where ``n`` is the number of samples for each DP,
-      ``batch_shape`` is the number of independent DPs, and
-      ``event_shape`` is the shape of the base distribution.
+    Returns:
+      tf.Tensor.
+      A `tf.Tensor` of shape `[n] + batch_shape + event_shape`,
+      where `n` is the number of samples for each DP,
+      `batch_shape` is the number of independent DPs, and
+      `event_shape` is the shape of the base distribution.
 
-    Notes
-    -----
+    #### Notes
+
     The implementation has one inefficiency, which is that it draws
     (batch_shape,) samples from the base distribution when adding a
     new persistent state. Ideally, we would only draw new samples for
@@ -205,9 +205,9 @@ class distributions_DirichletProcess(Distribution):
     if len(bools.shape) <= 1:
       bools_tile = bools
     else:
-      # ``tf.where`` only index subsets when ``bools`` is at most a
-      # vector. In general, ``bools`` has shape (n, batch_shape).
-      # Therefore we tile ``bools`` to be of shape
+      # `tf.where` only index subsets when `bools` is at most a
+      # vector. In general, `bools` has shape (n, batch_shape).
+      # Therefore we tile `bools` to be of shape
       # (n, batch_shape, event_shape) in order to index per-element.
       bools_tile = tf.tile(tf.reshape(
           bools, [n] + batch_shape + [1] * len(event_shape)),

--- a/edward/models/dirichlet_process.py
+++ b/edward/models/dirichlet_process.py
@@ -15,9 +15,9 @@ except Exception as e:
 
 
 class distributions_DirichletProcess(Distribution):
-  """Dirichlet process $\alpha, H$.
+  """Dirichlet process $\mathcal{DP}(\\alpha, H)$.
 
-  It has two parameters: a positive real value $\alpha$, known
+  It has two parameters: a positive real value $\\alpha$, known
   as the concentration parameter (`concentration`), and a base
   distribution $H$ (`base`).
   """

--- a/edward/models/empirical.py
+++ b/edward/models/empirical.py
@@ -20,23 +20,24 @@ class distributions_Empirical(Distribution):
                validate_args=False,
                allow_nan_stats=True,
                name="Empirical"):
-    """Initialize an ``Empirical`` random variable.
+    """Initialize an `Empirical` random variable.
 
-    Parameters
-    ----------
-    params : tf.Tensor
+    Args:
+      params: tf.Tensor.
       Collection of samples. Its outer (left-most) dimension
       determines the number of samples.
 
-    Examples
-    --------
-    >>> # 100 samples of a scalar
-    >>> x = Empirical(params=tf.zeros(100))
-    >>> assert x.shape == ()
-    >>>
-    >>> # 5 samples of a 2 x 3 matrix
-    >>> dp = Empirical(params=tf.zeros([5, 2, 3]))
-    >>> assert x.shape == (2, 3)
+    #### Examples
+
+    ```python
+    # 100 samples of a scalar
+    x = Empirical(params=tf.zeros(100))
+    assert x.shape == ()
+
+    # 5 samples of a 2 x 3 matrix
+    dp = Empirical(params=tf.zeros([5, 2, 3]))
+    assert x.shape == (2, 3)
+    ```
     """
     parameters = locals()
     with tf.name_scope(name, values=[params]):

--- a/edward/models/param_mixture.py
+++ b/edward/models/param_mixture.py
@@ -30,36 +30,37 @@ class distributions_ParamMixture(Distribution):
                name="ParamMixture"):
     """Initialize a batch of mixture random variables.
 
-    Parameters
-    ----------
-    mixing_weights : tf.Tensor
-      (Normalized) weights whose inner (right-most) dimension matches
-      the number of components.
-    component_params : dict
-      Parameters of the per-component distributions.
-    component_dist : RandomVariable
-      Distribution of each component. The outer (left-most) dimension
-      of its batch shape when instantiated determines the number of
-      components.
+    Args:
+      mixing_weights: tf.Tensor.
+        (Normalized) weights whose inner (right-most) dimension matches
+        the number of components.
+      component_params: dict.
+        Parameters of the per-component distributions.
+      component_dist: RandomVariable.
+        Distribution of each component. The outer (left-most) dimension
+        of its batch shape when instantiated determines the number of
+        components.
 
-    Notes
-    -----
-    Given ``ParamMixture``'s ``sample_shape``, ``batch_shape``, and
-    ``event_shape``, its ``components`` has shape
-    ``sample_shape + [num_components] + batch_shape + event_shape``,
-    and its ``cat`` has shape ``sample_shape + batch_shape``.
+    #### Notes
 
-    Examples
-    --------
-    >>> probs = tf.ones(5) / 5.0
-    >>> params = {'mu': tf.zeros(5), 'sigma': tf.ones(5)}
-    >>> x = ParamMixture(probs, params, Normal)
-    >>> assert x.shape == ()
+    Given `ParamMixture`'s `sample_shape`, `batch_shape`, and
+    `event_shape`, its `components` has shape
+    `sample_shape + [num_components] + batch_shape + event_shape`,
+    and its `cat` has shape `sample_shape + batch_shape`.
+
+    #### Examples
+
+    ```python
+    probs = tf.ones(5) / 5.0
+    params = {'mu': tf.zeros(5), 'sigma': tf.ones(5)}
+    x = ParamMixture(probs, params, Normal)
+    assert x.shape == ()
     >>>
-    >>> probs = tf.ones([2, 5]) / 5.0
-    >>> params = {'p': tf.zeros([5, 2]) + 0.8}
-    >>> x = ParamMixture(probs, params, Bernoulli)
-    >>> assert x.shape == (2,)
+    probs = tf.ones([2, 5]) / 5.0
+    params = {'p': tf.zeros([5, 2]) + 0.8}
+    x = ParamMixture(probs, params, Bernoulli)
+    assert x.shape == (2,)
+    ```
     """
     parameters = locals()
     parameters.pop("self")

--- a/edward/models/param_mixture.py
+++ b/edward/models/param_mixture.py
@@ -55,7 +55,7 @@ class distributions_ParamMixture(Distribution):
     params = {'mu': tf.zeros(5), 'sigma': tf.ones(5)}
     x = ParamMixture(probs, params, Normal)
     assert x.shape == ()
-    >>>
+
     probs = tf.ones([2, 5]) / 5.0
     params = {'p': tf.zeros([5, 2]) + 0.8}
     x = ParamMixture(probs, params, Bernoulli)

--- a/edward/models/point_mass.py
+++ b/edward/models/point_mass.py
@@ -24,22 +24,23 @@ class distributions_PointMass(Distribution):
                validate_args=False,
                allow_nan_stats=True,
                name="PointMass"):
-    """Initialize a ``PointMass`` random variable.
+    """Initialize a `PointMass` random variable.
 
-    Parameters
-    ----------
-    params : tf.Tensor
-      The location with all probability mass.
+    Args:
+      params: tf.Tensor.
+        The location with all probability mass.
 
-    Examples
-    --------
-    >>> # scalar
-    >>> x = PointMass(params=28.3)
-    >>> assert x.shape == ()
-    >>>
-    >>> # 5 x 2 x 3 tensor
-    >>> dp = PointMass(params=tf.zeros([5, 2, 3]))
-    >>> assert x.shape == (5, 2, 3)
+    #### Examples
+
+    ```python
+    # scalar
+    x = PointMass(params=28.3)
+    assert x.shape == ()
+
+    # 5 x 2 x 3 tensor
+    dp = PointMass(params=tf.zeros([5, 2, 3]))
+    assert x.shape == (5, 2, 3)
+    ```
     """
     parameters = locals()
     with tf.name_scope(name, values=[params]):

--- a/edward/models/random_variable.py
+++ b/edward/models/random_variable.py
@@ -26,63 +26,64 @@ class RandomVariable(object):
 
   The random variable's shape is given by
 
-  ``sample_shape + batch_shape + event_shape``,
+  `sample_shape + batch_shape + event_shape`,
 
-  where ``sample_shape`` is an optional argument representing the
+  where `sample_shape` is an optional argument representing the
   dimensions of samples drawn from the distribution (default is
-  a scalar); ``batch_shape`` is the number of independent random variables
-  (determined by the shape of its parameters); and ``event_shape`` is
-  the shape of one draw from the distribution (e.g., ``Normal`` has a
-  scalar ``event_shape``; ``Dirichlet`` has a vector ``event_shape``).
+  a scalar); `batch_shape` is the number of independent random variables
+  (determined by the shape of its parameters); and `event_shape` is
+  the shape of one draw from the distribution (e.g., `Normal` has a
+  scalar `event_shape`; `Dirichlet` has a vector `event_shape`).
 
-  Notes
-  -----
-  ``RandomVariable`` assumes use in a multiple inheritance setting. The
-  child class must first inherit ``RandomVariable``, then second inherit a
-  class in ``tf.contrib.distributions``. With Python's method resolution
+  #### Notes
+
+  `RandomVariable` assumes use in a multiple inheritance setting. The
+  child class must first inherit `RandomVariable`, then second inherit a
+  class in `tf.contrib.distributions`. With Python's method resolution
   order, this implies the following during initialization (using
-  ``distributions.Bernoulli`` as an example):
+  `distributions.Bernoulli` as an example):
 
-  1. Start the ``__init__()`` of the child class, which passes all
-     ``*args, **kwargs`` to ``RandomVariable``.
-  2. This in turn passes all ``*args, **kwargs`` to
-     ``distributions.Bernoulli``, completing the ``__init__()`` of
-     ``distributions.Bernoulli``.
-  3. Complete the ``__init__()`` of ``RandomVariable``, which calls
-     ``self.sample()``, relying on the method from
-     ``distributions.Bernoulli``.
-  4. Complete the ``__init__()`` of the child class.
+  1. Start the `__init__()` of the child class, which passes all
+     `*args, **kwargs` to `RandomVariable`.
+  2. This in turn passes all `*args, **kwargs` to
+     `distributions.Bernoulli`, completing the `__init__()` of
+     `distributions.Bernoulli`.
+  3. Complete the `__init__()` of `RandomVariable`, which calls
+     `self.sample()`, relying on the method from
+     `distributions.Bernoulli`.
+  4. Complete the `__init__()` of the child class.
 
-  Methods from both ``RandomVariable`` and ``distributions.Bernoulli``
+  Methods from both `RandomVariable` and `distributions.Bernoulli`
   populate the namespace of the child class. Methods from
-  ``RandomVariable`` will take higher priority if there are conflicts.
+  `RandomVariable` will take higher priority if there are conflicts.
 
-  Examples
-  --------
-  >>> p = tf.constant(0.5)
-  >>> x = Bernoulli(p)
-  >>>
-  >>> z1 = tf.constant([[1.0, -0.8], [0.3, -1.0]])
-  >>> z2 = tf.constant([[0.9, 0.2], [2.0, -0.1]])
-  >>> x = Bernoulli(logits=tf.matmul(z1, z2))
-  >>>
-  >>> mu = Normal(tf.constant(0.0), tf.constant(1.0))
-  >>> x = Normal(mu, tf.constant(1.0))
+  #### Examples
+
+  ```python
+  p = tf.constant(0.5)
+  x = Bernoulli(p)
+
+  z1 = tf.constant([[1.0, -0.8], [0.3, -1.0]])
+  z2 = tf.constant([[0.9, 0.2], [2.0, -0.1]])
+  x = Bernoulli(logits=tf.matmul(z1, z2))
+
+  mu = Normal(tf.constant(0.0), tf.constant(1.0))
+  x = Normal(mu, tf.constant(1.0))
+  ```
   """
   def __init__(self, *args, **kwargs):
     """
-    Parameters
-    ----------
-    sample_shape : tf.TensorShape, optional
-      Shape of samples to draw from the random variable.
-    value : tf.Tensor, optional
-      Fixed tensor to associate with random variable. Must have shape
-      ``sample_shape + batch_shape + event_shape``.
-    collections : list, optional
-      Optional list of graph collections keys. The random variable is
-      added to these collections. Defaults to ["random_variables"].
-    *args, **kwargs
-      Passed into parent ``__init__``.
+    Args:
+      sample_shape: tf.TensorShape, optional.
+        Shape of samples to draw from the random variable.
+      value: tf.Tensor, optional.
+        Fixed tensor to associate with random variable. Must have shape
+        `sample_shape + batch_shape + event_shape`.
+      collections: list, optional.
+        Optional list of graph collections keys. The random variable is
+        added to these collections. Defaults to ["random_variables"].
+      *args, **kwargs:
+        Passed into parent `__init__`.
     """
     # pop and store RandomVariable-specific parameters in _kwargs
     sample_shape = kwargs.pop('sample_shape', ())
@@ -142,7 +143,7 @@ class RandomVariable(object):
   @property
   def unique_name(self):
     """Name of random variable with its unique scoping name. Use
-    ``name`` to just get the name of the random variable."""
+    `name` to just get the name of the random variable."""
     return self._unique_name
 
   def __str__(self):
@@ -281,24 +282,25 @@ class RandomVariable(object):
     containing this variable has been launched. If no session is
     passed, the default session is used.
 
-    Parameters
-    ----------
-    session : tf.BaseSession, optional
-      The ``tf.Session`` to use to evaluate this random variable. If
-      none, the default session is used.
-    feed_dict : dict, optional
-      A dictionary that maps ``tf.Tensor`` objects to feed values. See
-      ``tf.Session.run()`` for a description of the valid feed values.
+    Args:
+      session: tf.BaseSession, optional.
+        The `tf.Session` to use to evaluate this random variable. If
+        none, the default session is used.
+      feed_dict: dict, optional.
+        A dictionary that maps `tf.Tensor` objects to feed values. See
+        `tf.Session.run()` for a description of the valid feed values.
 
-    Examples
-    --------
-    >>> x = Normal(0.0, 1.0)
-    >>> with tf.Session() as sess:
-    >>>   # Usage passing the session explicitly.
-    >>>   print(x.eval(sess))
-    >>>   # Usage with the default session.  The 'with' block
-    >>>   # above makes 'sess' the default session.
-    >>>   print(x.eval())
+    #### Examples
+
+    ```python
+    x = Normal(0.0, 1.0)
+    with tf.Session() as sess:
+      # Usage passing the session explicitly.
+      print(x.eval(sess))
+      # Usage with the default session.  The 'with' block
+      # above makes 'sess' the default session.
+      print(x.eval())
+    ```
     """
     return self.value().eval(session=session, feed_dict=feed_dict)
 

--- a/edward/util/graphs.py
+++ b/edward/util/graphs.py
@@ -28,9 +28,8 @@ def get_session():
   If the session is not already defined, then the function will create
   a global session.
 
-  Returns
-  -------
-  _ED_SESSION : tf.InteractiveSession
+  Returns:
+    _ED_SESSION: tf.InteractiveSession.
   """
   global _ED_SESSION
   if tf.get_default_session() is None:
@@ -47,9 +46,8 @@ def get_session():
 def random_variables():
   """Return all random variables in the TensorFlow graph.
 
-  Returns
-  -------
-  list of RandomVariable
+  Returns:
+    list of RandomVariable.
   """
   return tf.get_collection(RANDOM_VARIABLE_COLLECTION)
 
@@ -57,10 +55,9 @@ def random_variables():
 def set_seed(x):
   """Set seed for both NumPy and TensorFlow.
 
-  Parameters
-  ----------
-  x : int, float
-    seed
+  Args:
+    x: int, float.
+      seed
   """
   node_names = list(six.iterkeys(tf.get_default_graph()._nodes_by_name))
   if len(node_names) > 0 and node_names != ['keras_learning_phase']:

--- a/edward/util/progbar.py
+++ b/edward/util/progbar.py
@@ -13,17 +13,16 @@ class Progbar(object):
   def __init__(self, target, width=30, interval=0.01, verbose=1):
     """(Yet another) progress bar.
 
-    Parameters
-    ----------
-    target : int
-      Total number of steps expected.
-    width : int, optional
-      Width of progress bar.
-    interval : float, optional
-      Minimum time (in seconds) for progress bar to be displayed
-      during updates.
-    verbose : int, optional
-      Level of verbosity. 0 suppresses output; 1 is default.
+    Args:
+      target: int.
+        Total number of steps expected.
+      width: int, optional.
+        Width of progress bar.
+      interval: float, optional.
+        Minimum time (in seconds) for progress bar to be displayed
+        during updates.
+      verbose: int, optional.
+        Level of verbosity. 0 suppresses output; 1 is default.
     """
     self.target = target
     self.width = width
@@ -37,21 +36,20 @@ class Progbar(object):
     self.seen_so_far = 0
 
   def update(self, current, values=None, force=False):
-    """Update progress bar, and print to standard output if ``force``
-    is True, or the last update was completed longer than ``interval``
-    amount of time ago, or ``current`` >= ``target``.
+    """Update progress bar, and print to standard output if `force`
+    is True, or the last update was completed longer than `interval`
+    amount of time ago, or `current` >= `target`.
 
     The written output is the progress bar and all unique values.
 
-    Parameters
-    ----------
-    current : int
-      Index of current step.
-    values : dict of str to float, optional
-      Dict of name by value-for-last-step. The progress bar
-      will display averages for these values.
-    force : bool, optional
-      Whether to force visual progress update.
+    Args:
+      current: int.
+        Index of current step.
+      values: dict of str to float, optional.
+        Dict of name by value-for-last-step. The progress bar
+        will display averages for these values.
+      force: bool, optional.
+        Whether to force visual progress update.
     """
     if values is None:
       values = {}

--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -100,55 +100,54 @@ def copy(org_instance, dict_swap=None, scope="copied",
   always reused and not copied. In addition, `tf.Operation`s with
   operation-level seeds are copied with a new operation-level seed.
 
-  Parameters
-  ----------
-  org_instance : RandomVariable, tf.Operation, tf.Tensor, or tf.Variable
-    Node to add in graph with replaced ancestors.
-  dict_swap : dict, optional
-    Random variables, variables, tensors, or operations to swap with.
-    Its keys are what `org_instance` may depend on, and its values are
-    the corresponding object (not necessarily of the same class
-    instance, but must have the same type, e.g., float32) that is used
-    in exchange.
-  scope : str, optional
-    A scope for the new node(s). This is used to avoid name
-    conflicts with the original node(s).
-  replace_itself : bool, optional
-    Whether to replace `org_instance` itself if it exists in
-    `dict_swap`. (This is used for the recursion.)
-  copy_q : bool, optional
-    Whether to copy the replaced tensors too (if not already
-    copied within the new scope). Otherwise will reuse them.
+  Args:
+    org_instance: RandomVariable, tf.Operation, tf.Tensor, or tf.Variable.
+      Node to add in graph with replaced ancestors.
+    dict_swap: dict, optional.
+      Random variables, variables, tensors, or operations to swap with.
+      Its keys are what `org_instance` may depend on, and its values are
+      the corresponding object (not necessarily of the same class
+      instance, but must have the same type, e.g., float32) that is used
+      in exchange.
+    scope: str, optional.
+      A scope for the new node(s). This is used to avoid name
+      conflicts with the original node(s).
+    replace_itself: bool, optional
+      Whether to replace `org_instance` itself if it exists in
+      `dict_swap`. (This is used for the recursion.)
+    copy_q: bool, optional>
+      Whether to copy the replaced tensors too (if not already
+      copied within the new scope). Otherwise will reuse them.
 
-  Returns
-  -------
-  RandomVariable, tf.Variable, tf.Tensor, or tf.Operation
+  Returns:
+    RandomVariable, tf.Variable, tf.Tensor, or tf.Operation.
     The copied node.
 
-  Raises
-  ------
-  TypeError
+  Raises:
+    TypeError.
     If `org_instance` is not one of the above types.
 
-  Examples
-  --------
-  >>> x = tf.constant(2.0)
-  >>> y = tf.constant(3.0)
-  >>> z = x * y
-  >>>
-  >>> qx = tf.constant(4.0)
-  >>> # The TensorFlow graph is currently
-  >>> # `x` -> `z` <- y`, `qx`
-  >>>
-  >>> # This adds a subgraph with newly copied nodes,
-  >>> # `qx` -> `copied/z` <- `copied/y`
-  >>> z_new = ed.copy(z, {x: qx})
-  >>>
-  >>> sess = tf.Session()
-  >>> sess.run(z)
+  #### Examples
+
+  ```python
+  x = tf.constant(2.0)
+  y = tf.constant(3.0)
+  z = x * y
+
+  qx = tf.constant(4.0)
+  # The TensorFlow graph is currently
+  # `x` -> `z` <- y`, `qx`
+
+  # This adds a subgraph with newly copied nodes,
+  # `qx` -> `copied/z` <- `copied/y`
+  z_new = ed.copy(z, {x: qx})
+
+  sess = tf.Session()
+  sess.run(z)
   6.0
-  >>> sess.run(z_new)
+  sess.run(z_new)
   12.0
+  ```
   """
   if not isinstance(org_instance,
                     (RandomVariable, tf.Operation, tf.Tensor, tf.Variable)):
@@ -366,26 +365,25 @@ def copy(org_instance, dict_swap=None, scope="copied",
 def get_ancestors(x, collection=None):
   """Get ancestor random variables of input.
 
-  Parameters
-  ----------
-  x : RandomVariable or tf.Tensor
-    Query node to find ancestors of.
-  collection : list of RandomVariable, optional
-    The collection of random variables to check with respect to;
-    defaults to all random variables in the graph.
+  Args:
+    x: RandomVariable or tf.Tensor.
+      Query node to find ancestors of.
+    collection: list of RandomVariable, optional.
+      The collection of random variables to check with respect to;
+      defaults to all random variables in the graph.
 
-  Returns
-  -------
-  list of RandomVariable
+  Returns:
+    list of RandomVariable.
     Ancestor random variables of x.
 
-  Examples
-  --------
-  >>> a = Normal(0.0, 1.0)
-  >>> b = Normal(a, 1.0)
-  >>> c = Normal(0.0, 1.0)
-  >>> d = Normal(b * c, 1.0)
-  >>> assert set(ed.get_ancestors(d)) == set([a, b, c])
+  #### Examples
+  ```python
+  a = Normal(0.0, 1.0)
+  b = Normal(a, 1.0)
+  c = Normal(0.0, 1.0)
+  d = Normal(b * c, 1.0)
+  assert set(ed.get_ancestors(d)) == set([a, b, c])
+  ```
   """
   if collection is None:
     collection = random_variables()
@@ -419,27 +417,27 @@ def get_blanket(x, collection=None):
   """Get Markov blanket of input, which consists of its parents, its
   children, and the other parents of its children.
 
-  Parameters
-  ----------
-  x : RandomVariable or tf.Tensor
-    Query node to find Markov blanket of.
-  collection : list of RandomVariable, optional
-    The collection of random variables to check with respect to;
-    defaults to all random variables in the graph.
+  Args:
+    x: RandomVariable or tf.Tensor.
+      Query node to find Markov blanket of.
+    collection: list of RandomVariable, optional.
+      The collection of random variables to check with respect to;
+      defaults to all random variables in the graph.
 
-  Returns
-  -------
-  list of RandomVariable
+  Returns:
+    list of RandomVariable.
     Markov blanket of x.
 
-  Examples
-  --------
-  >>> a = Normal(0.0, 1.0)
-  >>> b = Normal(0.0, 1.0)
-  >>> c = Normal(a * b, 1.0)
-  >>> d = Normal(0.0, 1.0)
-  >>> e = Normal(c * d, 1.0)
-  >>> assert set(ed.get_blanket(c)) == set([a, b, d, e])
+  #### Examples
+
+  ```python
+  a = Normal(0.0, 1.0)
+  b = Normal(0.0, 1.0)
+  c = Normal(a * b, 1.0)
+  d = Normal(0.0, 1.0)
+  e = Normal(c * d, 1.0)
+  assert set(ed.get_blanket(c)) == set([a, b, d, e])
+  ```
   """
   output = set()
   output.update(get_parents(x, collection))
@@ -455,26 +453,26 @@ def get_blanket(x, collection=None):
 def get_children(x, collection=None):
   """Get child random variables of input.
 
-  Parameters
-  ----------
-  x : RandomVariable or tf.Tensor
-    Query node to find children of.
-  collection : list of RandomVariable, optional
-    The collection of random variables to check with respect to;
-    defaults to all random variables in the graph.
+  Args:
+    x: RandomVariable or tf.Tensor>
+      Query node to find children of.
+    collection: list of RandomVariable, optional>
+      The collection of random variables to check with respect to;
+      defaults to all random variables in the graph.
 
-  Returns
-  -------
-  list of RandomVariable
+  Returns:
+    list of RandomVariable.
     Child random variables of x.
 
-  Examples
-  --------
-  >>> a = Normal(0.0, 1.0)
-  >>> b = Normal(a, 1.0)
-  >>> c = Normal(a, 1.0)
-  >>> d = Normal(c, 1.0)
-  >>> assert set(ed.get_children(a)) == set([b, c])
+  #### Examples
+
+  ```python
+  a = Normal(0.0, 1.0)
+  b = Normal(a, 1.0)
+  c = Normal(a, 1.0)
+  d = Normal(c, 1.0)
+  assert set(ed.get_children(a)) == set([b, c])
+  ```
   """
   if collection is None:
     collection = random_variables()
@@ -508,26 +506,26 @@ def get_children(x, collection=None):
 def get_descendants(x, collection=None):
   """Get descendant random variables of input.
 
-  Parameters
-  ----------
-  x : RandomVariable or tf.Tensor
-    Query node to find descendants of.
-  collection : list of RandomVariable, optional
-    The collection of random variables to check with respect to;
-    defaults to all random variables in the graph.
+  Args:
+    x: RandomVariable or tf.Tensor.
+      Query node to find descendants of.
+    collection: list of RandomVariable, optional.
+      The collection of random variables to check with respect to;
+      defaults to all random variables in the graph.
 
-  Returns
-  -------
-  list of RandomVariable
+  Returns:
+    list of RandomVariable.
     Descendant random variables of x.
 
-  Examples
-  --------
-  >>> a = Normal(0.0, 1.0)
-  >>> b = Normal(a, 1.0)
-  >>> c = Normal(a, 1.0)
-  >>> d = Normal(c, 1.0)
-  >>> assert set(ed.get_descendants(a)) == set([b, c, d])
+  #### Examples
+
+  ```python
+  a = Normal(0.0, 1.0)
+  b = Normal(a, 1.0)
+  c = Normal(a, 1.0)
+  d = Normal(c, 1.0)
+  assert set(ed.get_descendants(a)) == set([b, c, d])
+  ```
   """
   if collection is None:
     collection = random_variables()
@@ -561,26 +559,26 @@ def get_descendants(x, collection=None):
 def get_parents(x, collection=None):
   """Get parent random variables of input.
 
-  Parameters
-  ----------
-  x : RandomVariable or tf.Tensor
-    Query node to find parents of.
-  collection : list of RandomVariable, optional
-    The collection of random variables to check with respect to;
-    defaults to all random variables in the graph.
+  Args:
+    x: RandomVariable or tf.Tensor.
+      Query node to find parents of.
+    collection: list of RandomVariable, optional.
+      The collection of random variables to check with respect to;
+      defaults to all random variables in the graph.
 
-  Returns
-  -------
-  list of RandomVariable
+  Returns:
+    list of RandomVariable.
     Parent random variables of x.
 
-  Examples
-  --------
-  >>> a = Normal(0.0, 1.0)
-  >>> b = Normal(a, 1.0)
-  >>> c = Normal(0.0, 1.0)
-  >>> d = Normal(b * c, 1.0)
-  >>> assert set(ed.get_parents(d)) == set([b, c])
+  #### Examples
+
+  ```python
+  a = Normal(0.0, 1.0)
+  b = Normal(a, 1.0)
+  c = Normal(0.0, 1.0)
+  d = Normal(b * c, 1.0)
+  assert set(ed.get_parents(d)) == set([b, c])
+  ```
   """
   if collection is None:
     collection = random_variables()
@@ -613,25 +611,25 @@ def get_parents(x, collection=None):
 def get_siblings(x, collection=None):
   """Get sibling random variables of input.
 
-  Parameters
-  ----------
-  x : RandomVariable or tf.Tensor
-    Query node to find siblings of.
-  collection : list of RandomVariable, optional
-    The collection of random variables to check with respect to;
-    defaults to all random variables in the graph.
+  Args:
+    x: RandomVariable or tf.Tensor.
+      Query node to find siblings of.
+    collection: list of RandomVariable, optional.
+      The collection of random variables to check with respect to;
+      defaults to all random variables in the graph.
 
-  Returns
-  -------
-  list of RandomVariable
+  Returns:
+    list of RandomVariable.
     Sibling random variables of x.
 
-  Examples
-  --------
-  >>> a = Normal(0.0, 1.0)
-  >>> b = Normal(a, 1.0)
-  >>> c = Normal(a, 1.0)
-  >>> assert ed.get_siblings(b) == [c]
+  #### Examples
+
+  ```python
+  a = Normal(0.0, 1.0)
+  b = Normal(a, 1.0)
+  c = Normal(a, 1.0)
+  assert ed.get_siblings(b) == [c]
+  ```
   """
   parents = get_parents(x, collection)
   siblings = set()
@@ -645,25 +643,25 @@ def get_siblings(x, collection=None):
 def get_variables(x, collection=None):
   """Get parent TensorFlow variables of input.
 
-  Parameters
-  ----------
-  x : RandomVariable or tf.Tensor
-    Query node to find parents of.
-  collection : list of tf.Variable, optional
-    The collection of variables to check with respect to; defaults to
-    all variables in the graph.
+  Args:
+    x: RandomVariable or tf.Tensor.
+      Query node to find parents of.
+    collection: list of tf.Variable, optional.
+      The collection of variables to check with respect to; defaults to
+      all variables in the graph.
 
-  Returns
-  -------
-  list of tf.Variable
+  Returns:
+    list of tf.Variable.
     TensorFlow variables that x depends on.
 
-  Examples
-  --------
-  >>> a = tf.Variable(0.0)
-  >>> b = tf.Variable(0.0)
-  >>> c = Normal(a * b, 1.0)
-  >>> assert set(ed.get_variables(c)) == set([a, b])
+  #### Examples
+
+  ```python
+  a = tf.Variable(0.0)
+  b = tf.Variable(0.0)
+  c = Normal(a * b, 1.0)
+  assert set(ed.get_variables(c)) == set([a, b])
+  ```
   """
   if collection is None:
     collection = tf.global_variables()

--- a/edward/util/tensorflow.py
+++ b/edward/util/tensorflow.py
@@ -202,18 +202,18 @@ def to_simplex(x):
 
 def get_control_variate_coef(f, h):
   """Returns scalar used by control variates method for variance reduction in
-  MCMC methods.
+  Monte Carlo methods.
 
-  If we have a statistic $m$ unbiased estimator of $\mu$ and
+  If we have a statistic $m$ as an unbiased estimator of $\mu$ and
   and another statistic $t$ which is an unbiased estimator of
-  $\tau$ then $m^* = m + c(t - \tau)$ is also an unbiased
+  $\\tau$ then $m^* = m + c(t - \\tau)$ is also an unbiased
   estimator of $\mu$ for any coefficient $c$.
 
   This function calculates the optimal coefficient
 
-  $\c^* = \frac{Cov(m,t)}{Var(t)}$
+  $c^* = \\frac{\\text{Cov}(m,t)}{\\text{Var}(t)}$
 
-  for minimizing the variance of $`m^*$.
+  for minimizing the variance of $m^*$.
 
   Args:
     f: tf.Tensor.

--- a/edward/util/tensorflow.py
+++ b/edward/util/tensorflow.py
@@ -204,17 +204,16 @@ def get_control_variate_coef(f, h):
   """Returns scalar used by control variates method for variance reduction in
   MCMC methods.
 
-  If we have a statistic :math:`m` unbiased estimator of :math:`\mu` and
-  and another statistic :math:`t` which is an unbiased estimator of
-  :math:`\tau` then :math:`m^* = m + c(t - \tau)` is also an unbiased
-  estimator of :math:`\mu' for any coefficient :math:`c`.
+  If we have a statistic \\(m\\) unbiased estimator of \\(\mu\\) and
+  and another statistic \\(t\\) which is an unbiased estimator of
+  \\(\tau\\) then \\(m^* = m + c(t - \tau)\\) is also an unbiased
+  estimator of \\(\mu\\) for any coefficient \\(c\\).
 
   This function calculates the optimal coefficient
-  .. math::
 
-    \c^* = \frac{Cov(m,t)}{Var(t)}
+  $\c^* = \frac{Cov(m,t)}{Var(t)}$
 
-  for minimizing the variance of :math:`m^*`.
+  for minimizing the variance of \\(`m^*\\).
 
   Args:
     f: tf.Tensor.

--- a/edward/util/tensorflow.py
+++ b/edward/util/tensorflow.py
@@ -46,7 +46,7 @@ def dot(x, y):
 
 
 def logit(x):
-  """Evaluate \\(\log(x / (1 - x))\\) elementwise.
+  """Evaluate $\log(x / (1 - x))$ elementwise.
 
   Args:
     x: tf.Tensor.
@@ -58,7 +58,7 @@ def logit(x):
 
   Raises:
     InvalidArgumentError.
-    If the input is not between \\((0,1)\\) elementwise.
+    If the input is not between $(0,1)$ elementwise.
   """
   x = tf.convert_to_tensor(x)
   dependencies = [tf.assert_positive(x),
@@ -75,7 +75,7 @@ def rbf(X, X2=None, lengthscale=1.0, variance=1.0):
   $k(x, x') = \sigma^2 \exp\Big(
       -\\frac{1}{2} \sum_{d=1}^D \\frac{1}{\ell_d^2} (x_d - x'_d)^2 \Big)$
 
-  for output variance \\(\sigma^2\\) and lengthscale \\(\ell^2\\).
+  for output variance $\sigma^2$ and lengthscale $\ell^2$.
 
   The kernel is evaluated over all pairs of rows, `k(X[i, ], X2[j, ])`.
   If `X2` is not specified, then it evaluates over all pairs
@@ -204,16 +204,16 @@ def get_control_variate_coef(f, h):
   """Returns scalar used by control variates method for variance reduction in
   MCMC methods.
 
-  If we have a statistic \\(m\\) unbiased estimator of \\(\mu\\) and
-  and another statistic \\(t\\) which is an unbiased estimator of
-  \\(\tau\\) then \\(m^* = m + c(t - \tau)\\) is also an unbiased
-  estimator of \\(\mu\\) for any coefficient \\(c\\).
+  If we have a statistic $m$ unbiased estimator of $\mu$ and
+  and another statistic $t$ which is an unbiased estimator of
+  $\tau$ then $m^* = m + c(t - \tau)$ is also an unbiased
+  estimator of $\mu$ for any coefficient $c$.
 
   This function calculates the optimal coefficient
 
   $\c^* = \frac{Cov(m,t)}{Var(t)}$
 
-  for minimizing the variance of \\(`m^*\\).
+  for minimizing the variance of $`m^*$.
 
   Args:
     f: tf.Tensor.

--- a/edward/util/tensorflow.py
+++ b/edward/util/tensorflow.py
@@ -10,25 +10,22 @@ from tensorflow.python.ops import control_flow_ops
 def dot(x, y):
   """Compute dot product between a 2-D tensor and a 1-D tensor.
 
-  If x is a ``[M x N]`` matrix, then y is a ``M``-vector.
+  If x is a `[M x N]` matrix, then y is a `M`-vector.
 
-  If x is a ``M``-vector, then y is a ``[M x N]`` matrix.
+  If x is a `M`-vector, then y is a `[M x N]` matrix.
 
-  Parameters
-  ----------
-  x : tf.Tensor
-    A 1-D or 2-D tensor (see above).
-  y : tf.Tensor
-    A 1-D or 2-D tensor (see above).
+  Args:
+    x: tf.Tensor.
+      A 1-D or 2-D tensor (see above).
+    y: tf.Tensor.
+      A 1-D or 2-D tensor (see above).
 
-  Returns
-  -------
-  tf.Tensor
-    A 1-D tensor of length ``N``.
+  Returns:
+    tf.Tensor.
+    A 1-D tensor of length `N`.
 
-  Raises
-  ------
-  InvalidArgumentError
+  Raises:
+    InvalidArgumentError.
     If the inputs have Inf or NaN values.
   """
   x = tf.convert_to_tensor(x)
@@ -49,22 +46,19 @@ def dot(x, y):
 
 
 def logit(x):
-  """Evaluate :math:`\log(x / (1 - x))` elementwise.
+  """Evaluate \\(\log(x / (1 - x))\\) elementwise.
 
-  Parameters
-  ----------
-  x : tf.Tensor
-    A n-D tensor.
+  Args:
+    x: tf.Tensor.
+      A n-D tensor.
 
-  Returns
-  -------
-  tf.Tensor
+  Returns:
+    tf.Tensor.
     A tensor of same shape as input.
 
-  Raises
-  ------
-  InvalidArgumentError
-    If the input is not between :math:`(0,1)` elementwise.
+  Raises:
+    InvalidArgumentError.
+    If the input is not between \\((0,1)\\) elementwise.
   """
   x = tf.convert_to_tensor(x)
   dependencies = [tf.assert_positive(x),
@@ -78,34 +72,33 @@ def rbf(X, X2=None, lengthscale=1.0, variance=1.0):
   """Radial basis function kernel, also known as the squared
   exponential or exponentiated quadratic. It is defined as
 
-  .. math::
+  $k(x, x') = \sigma^2 \exp\Big(
+      -\\frac{1}{2} \sum_{d=1}^D \\frac{1}{\ell_d^2} (x_d - x'_d)^2 \Big)$
 
-    k(x, x') = \\sigma^2 \exp\Big(
-        -\frac{1}{2} \sum_{d=1}^D \frac{1}{\\ell_d^2} (x_d - x'_d)^2 \Big)
+  for output variance \\(\sigma^2\\) and lengthscale \\(\ell^2\\).
 
-  for output variance :math:`\\sigma^2` and lengthscale :math:`\\ell^2`.
-
-  The kernel is evaluated over all pairs of rows, ``k(X[i, ], X2[j, ])``.
-  If ``X2`` is not specified, then it evaluates over all pairs
-  of rows in ``X``, ``k(X[i, ], X[j, ])``. The output is a matrix
+  The kernel is evaluated over all pairs of rows, `k(X[i, ], X2[j, ])`.
+  If `X2` is not specified, then it evaluates over all pairs
+  of rows in `X`, `k(X[i, ], X[j, ])`. The output is a matrix
   where each entry (i, j) is the kernel over the ith and jth rows.
 
-  Parameters
-  ----------
-  X : tf.Tensor
-    N x D matrix of N data points each with D features.
-  X2 : tf.Tensor, optional
-    N x D matrix of N data points each with D features.
-  lengthscale : tf.Tensor, optional
-    Lengthscale parameter, a positive scalar or D-dimensional vector.
-  variance : tf.Tensor, optional
-    Output variance parameter, a positive scalar.
+  Args:
+    X: tf.Tensor.
+      N x D matrix of N data points each with D features.
+    X2: tf.Tensor, optional.
+      N x D matrix of N data points each with D features.
+    lengthscale: tf.Tensor, optional.
+      Lengthscale parameter, a positive scalar or D-dimensional vector.
+    variance: tf.Tensor, optional.
+      Output variance parameter, a positive scalar.
 
-  Examples
-  --------
-  >>> X = tf.random_normal([100, 5])
-  >>> K = ed.rbf(X)
-  >>> assert K.shape == (100, 100)
+  #### Examples
+
+  ```python
+  X = tf.random_normal([100, 5])
+  K = ed.rbf(X)
+  assert K.shape == (100, 100)
+  ```
   """
   lengthscale = tf.convert_to_tensor(lengthscale)
   variance = tf.convert_to_tensor(variance)
@@ -134,19 +127,17 @@ def rbf(X, X2=None, lengthscale=1.0, variance=1.0):
 def reduce_logmeanexp(input_tensor, axis=None, keep_dims=False):
   """Computes log(mean(exp(elements across dimensions of a tensor))).
 
-  Parameters
-  ----------
-  input_tensor : tf.Tensor
-    The tensor to reduce. Should have numeric type.
-  axis : int or list of int, optional
-    The dimensions to reduce. If `None` (the default), reduces all
-    dimensions.
-  keep_dims : bool, optional
-    If true, retains reduced dimensions with length 1.
+  Args:
+    input_tensor: tf.Tensor.
+      The tensor to reduce. Should have numeric type.
+    axis: int or list of int, optional.
+      The dimensions to reduce. If `None` (the default), reduces all
+      dimensions.
+    keep_dims: bool, optional.
+      If true, retains reduced dimensions with length 1.
 
-  Returns
-  -------
-  tf.Tensor
+  Returns:
+    tf.Tensor.
     The reduced tensor.
   """
   logsumexp = tf.reduce_logsumexp(input_tensor, axis, keep_dims)
@@ -161,27 +152,24 @@ def reduce_logmeanexp(input_tensor, axis=None, keep_dims=False):
 
 
 def to_simplex(x):
-  """Transform real vector of length ``(K-1)`` to a simplex of dimension ``K``
+  """Transform real vector of length `(K-1)` to a simplex of dimension `K`
   using a backward stick breaking construction.
 
-  Parameters
-  ----------
-  x : tf.Tensor
-    A 1-D or 2-D tensor.
+  Args:
+    x: tf.Tensor.
+      A 1-D or 2-D tensor.
 
-  Returns
-  -------
-  tf.Tensor
+  Returns:
+    tf.Tensor.
     A tensor of same shape as input but with last dimension of
-    size ``K``.
+    size `K`.
 
-  Raises
-  ------
-  InvalidArgumentError
+  Raises:
+    InvalidArgumentError.
     If the input has Inf or NaN values.
 
-  Notes
-  -----
+  #### Notes
+
   x as a 3-D or higher tensor is not guaranteed to be supported.
   """
   x = tf.cast(x, dtype=tf.float32)
@@ -228,16 +216,14 @@ def get_control_variate_coef(f, h):
 
   for minimizing the variance of :math:`m^*`.
 
-  Parameters
-  ----------
-  f : tf.Tensor
-    A 1-D tensor.
-  h : tf.Tensor
-    A 1-D tensor.
+  Args:
+    f: tf.Tensor.
+      A 1-D tensor.
+    h: tf.Tensor.
+      A 1-D tensor.
 
-  Returns
-  -------
-  tf.Tensor
+  Returns:
+    tf.Tensor.
     A 0 rank tensor
   """
   f_mu = tf.reduce_mean(f)


### PR DESCRIPTION
This is a necessary step for our docstring parser which builds on TensorFlow's. It's also generally useful to stick to one convention. Since we adopt TensorFlow standards for many other things (e.g., style guide, unit tests), we should do so with docstrings too.

Related to #681.