### PR TITLE
Swap utf-8 progbar character for ASCII

### DIFF
--- a/edward/util/progbar.py
+++ b/edward/util/progbar.py
@@ -77,7 +77,7 @@ class Progbar(object):
       bar += ' '
       prog_width = int(self.width * float(current) / self.target)
       if prog_width > 0:
-        bar += ('█' * prog_width)
+        bar += ('*' * prog_width)
 
       bar += (' ' * (self.width - prog_width))
       sys.stdout.write(bar)


### PR DESCRIPTION
In terminal work. printing Unicode characters can be problematic. In particular, using a Unicode character for the progressbar causes encoding errors if the environment is not set up properly:

```
UnicodeEncodeError: 'ascii' codec can't encode character '\u2588' in position 15: ordinal not in range(128)
```

This patch changes the progress bar character to be ASCII, so that we have less to worry about when running Edward.