### PR TITLE
Speed up time to import edward

### DIFF
--- a/edward/criticisms/ppc_plots.py
+++ b/edward/criticisms/ppc_plots.py
@@ -2,11 +2,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-try:
-  import seaborn as sns
-except ImportError:
-  pass
-
 
 def ppc_density_plot(y, y_rep):
   """Create 1D kernel density plot comparing data to samples from posterior.
@@ -20,6 +15,7 @@ def ppc_density_plot(y, y_rep):
   Returns:
     matplotlib axes
   """
+  import seaborn as sns
   ax = sns.kdeplot(y, color="maroon")
 
   n = y_rep.shape[0]
@@ -54,6 +50,7 @@ def ppc_stat_hist_plot(y_stats, yrep_stats, stat_name=None, **kwargs):
   Returns:
     matplotlib axes.
   """
+  import seaborn as sns
   ax = sns.distplot(yrep_stats, kde=False, label=r'$T(y_{rep})$', **kwargs)
 
   max_value = ax.get_ylim()[1]

--- a/edward/inferences/variational_inference.py
+++ b/edward/inferences/variational_inference.py
@@ -11,11 +11,6 @@ from edward.inferences.inference import Inference
 from edward.models import RandomVariable
 from edward.util import get_session, get_variables
 
-try:
-  import prettytensor as pt
-except ImportError:
-  pass
-
 
 @six.add_metaclass(abc.ABCMeta)
 class VariationalInference(Inference):
@@ -127,6 +122,7 @@ class VariationalInference(Inference):
         self.train = optimizer.apply_gradients(grads_and_vars,
                                                global_step=global_step)
       else:
+        import prettytensor as pt
         # Note PrettyTensor optimizer does not accept manual updates;
         # it autodiffs the loss directly.
         self.train = pt.apply_optimizer(optimizer, losses=[self.loss],

--- a/edward/util/graphs.py
+++ b/edward/util/graphs.py
@@ -9,18 +9,6 @@ import tensorflow as tf
 
 from edward.models.random_variable import _RANDOM_VARIABLE_COLLECTION
 
-save_stderr = sys.stderr
-
-try:
-  import os
-  sys.stderr = open(os.devnull, 'w')  # suppress keras import
-  from keras import backend as K
-  sys.stderr = save_stderr
-  have_keras = True
-except ImportError:
-  sys.stderr = save_stderr
-  have_keras = False
-
 
 def get_session():
   """Get the globally defined TensorFlow session.
@@ -37,6 +25,16 @@ def get_session():
   else:
     _ED_SESSION = tf.get_default_session()
 
+  save_stderr = sys.stderr
+  try:
+    import os
+    sys.stderr = open(os.devnull, 'w')  # suppress keras import
+    from keras import backend as K
+    sys.stderr = save_stderr
+    have_keras = True
+  except ImportError:
+    sys.stderr = save_stderr
+    have_keras = False
   if have_keras:
     K.set_session(_ED_SESSION)
 


### PR DESCRIPTION
A few tricks:
+ Time to import Edward is lower bounded by the total time to import `numpy`, `six`, `tensorflow`, and `tensorflow.contrib`. On my local machine, this is ~2.20s. Edward takes ~2.78s so there is room for improvement.
+ I made all optional packages dynamically imported. On my local machine, this shaves roughly half a second, to ~2.220s. This is basically the lower bound.
+ I experimented with changing `from edward.... import *` in `__init__.py` files to importing specific objects. I did not notice any improvement.

I wrote a simple benchmark to check before/after:
```bash
total=0
for i in {1..25}; do
    time=$(python -c 'import time; start=time.time(); import edward as ed; print(time.time() - start)');
    total=$((total + time));
done
average=$((total / 25))
echo $average
```
Lower bound:
```bash
for i in {1..25}; do
    time=$(python -c 'import time; start=time.time(); import numpy as np; import six; import tensorflow as tf; import tensorflow.contrib; print(time.time() - start)');
    total=$((total + time));
done
average=$((total / 25))
echo $average
```