### PR TITLE
Fix broken link on data API page

### DIFF
--- a/docs/tex/api/data.tex
+++ b/docs/tex/api/data.tex
@@ -63,5 +63,4 @@ Represent the data as TensorFlow tensors, where the tensors are the
 output of data readers. During inference, each update will be
 automatically evaluated over new batch tensors represented through
 the data readers. As an example, see the
-\href{https://github.com/blei-lab/edward/blob/master/tests/test-inferences/test_data.py}
-{data unit test}.
+\href{https://github.com/blei-lab/edward/blob/master/tests/test-inferences/test_inference_data.py}{data unit test}.


### PR DESCRIPTION
* Change file name in link from "test_data.py" to
  "test_inference_data.py". test_data.py no longer exists

* Closes Issue #709 "Hyperlink to data unit test 404s"