### PR TITLE
Fixed hard-coded type cast that causes runtime error

### DIFF
--- a/edward/criticisms/evaluate.py
+++ b/edward/criticisms/evaluate.py
@@ -119,7 +119,7 @@ def evaluate(metrics, data, n_samples=500, output_key=None):
       # Average over realizations of their probabilities, then predict
       # via argmax over probabilities.
       probs = [sess.run(output_key.probs, feed_dict) for _ in range(n_samples)]
-      probs = tf.add_n(probs) / tf.cast(n_samples, tf.float32)
+      probs = tf.add_n(probs) / tf.cast(n_samples, probs[0].dtype)
       if isinstance(output_key, binary_discrete):
         # make random prediction whenever probs is exactly 0.5
         random = tf.random_uniform(shape=tf.shape(probs))
@@ -129,8 +129,8 @@ def evaluate(metrics, data, n_samples=500, output_key=None):
     else:
       # Monte Carlo estimate the mean of the posterior predictive.
       y_pred = [sess.run(output_key, feed_dict) for _ in range(n_samples)]
-      y_pred = tf.cast(tf.add_n(y_pred), tf.float32) / \
-          tf.cast(n_samples, tf.float32)
+      y_pred = tf.cast(tf.add_n(y_pred), y_pred[0].dtype) / \
+          tf.cast(n_samples, y_pred[0].dtype)
 
   # Evaluate y_true (according to y_pred if supervised) for all metrics.
   evaluations = []
@@ -179,7 +179,7 @@ def evaluate(metrics, data, n_samples=500, output_key=None):
       # Monte Carlo estimate the log-density of the posterior predictive.
       tensor = tf.reduce_mean(output_key.log_prob(y_true))
       log_pred = [sess.run(tensor, feed_dict) for _ in range(n_samples)]
-      log_pred = tf.add_n(log_pred) / tf.cast(n_samples, tf.float32)
+      log_pred = tf.add_n(log_pred) / tf.cast(n_samples, tensor.dtype)
       evaluations += [log_pred]
     else:
       raise NotImplementedError("Metric is not implemented: {}".format(metric))


### PR DESCRIPTION
Changed from hard-coded type cast to tf.float32 to casting to the type of the underlying tensor in log_lik evaluation. Code that causes an error before the fix:

```python
from __future__ import absolute_import
from __future__ import division
from __future__ import print_function

import edward as ed
import numpy as np
import tensorflow as tf

from edward.models import Normal
ed.set_seed(42)
def build_toy_dataset(N, w):
  D = len(w)
  x = np.random.normal(0.0, 2.0, size=(N, D))
  y = np.dot(x, w) + np.random.normal(0.0, 0.01, size=N)
  return x, y

N = 40  # number of data points
D = 10  # number of features

default_type = tf.float64

w_true = np.random.randn(D) * 0.5
X_train, y_train = build_toy_dataset(N, w_true)
X_test, y_test = build_toy_dataset(N, w_true)
X = tf.placeholder(default_type, [N, D])
w = Normal(loc=tf.zeros(D, dtype=default_type), scale=tf.ones(D, dtype=default_type))
b = Normal(loc=tf.zeros(1, dtype=default_type), scale=tf.ones(1, dtype=default_type))
y = Normal(loc=ed.dot(X, w) + b, scale=tf.ones(N, dtype=default_type))
qw = Normal(loc=tf.Variable(tf.random_normal([D], dtype=default_type)),
            scale=tf.nn.softplus(tf.Variable(tf.random_normal([D], dtype=default_type))))
qb = Normal(loc=tf.Variable(tf.random_normal([1], dtype=default_type)),
            scale=tf.nn.softplus(tf.Variable(tf.random_normal([1], dtype=default_type))))
inference = ed.KLqp({w: qw, b: qb}, data={X: X_train, y: y_train})
inference.run(n_samples=5, n_iter=250, logdir='log')
y_post = ed.copy(y, {w: qw, b: qb})
np.exp(ed.evaluate('log_likelihood', data={X: X_test, y_post: y_test}))
```