### PR TITLE
Remove call to private method _set_device(), which may change.

### DIFF
--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -347,8 +347,6 @@ def copy(org_instance, dict_swap=None, scope="copied",
                             "Ignoring colocation property.",
                             name, colocation_op.name, new_op.device,
                             colocation_op.device)
-          else:
-            new_op._set_device(colocation_op.device)
 
       all_colocation_groups = sorted(set(all_colocation_groups))
       new_op.node_def.attr["_class"].CopyFrom(attr_value_pb2.AttrValue(


### PR DESCRIPTION
I'm told that the behavior of this method may change in the not-too-distant future, so we shouldn't be calling it directly if it can be avoided.

I don't really understand what this code is doing, so I just deleted it. That doesn't seem to break any tests, but it probably isn't ideal. @dustinvtran, can you take a look?