### PR TITLE
Minor improvements to ed.KLqp and ed.KLpq

### DIFF
--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -135,6 +135,6 @@ class KLpq(VariationalInference):
         -tf.reduce_mean(q_log_prob * tf.stop_gradient(w_norm)),
         q_vars)
     p_vars = [v for v in var_list if v not in q_vars]
-    p_grads = tf.gradients(loss, p_vars)
+    p_grads = tf.gradients(-loss, p_vars)
     grads_and_vars = list(zip(q_grads, q_vars)) + list(zip(p_grads, p_vars))
     return loss, grads_and_vars

--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -128,7 +128,7 @@ class KLpq(VariationalInference):
     w_norm = tf.exp(log_w_norm)
     loss = tf.reduce_mean(w_norm * log_w)
 
-    q_rvs = list(six.itervalues(inference.latent_vars))
+    q_rvs = list(six.itervalues(self.latent_vars))
     q_vars = [v for v in var_list
               if len(get_descendants(tf.convert_to_tensor(v), q_rvs)) != 0]
     q_grads = tf.gradients(

--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -7,7 +7,7 @@ import tensorflow as tf
 
 from edward.inferences.variational_inference import VariationalInference
 from edward.models import RandomVariable
-from edward.util import copy
+from edward.util import copy, get_descendants
 
 
 class KLpq(VariationalInference):
@@ -126,10 +126,15 @@ class KLpq(VariationalInference):
     log_w = p_log_prob - q_log_prob
     log_w_norm = log_w - tf.reduce_logsumexp(log_w)
     w_norm = tf.exp(log_w_norm)
-
     loss = tf.reduce_mean(w_norm * log_w)
-    grads = tf.gradients(
+
+    q_rvs = list(six.itervalues(inference.latent_vars))
+    q_vars = [v for v in var_list
+              if len(get_descendants(tf.convert_to_tensor(v), q_rvs)) != 0]
+    q_grads = tf.gradients(
         -tf.reduce_mean(q_log_prob * tf.stop_gradient(w_norm)),
-        var_list)
-    grads_and_vars = list(zip(grads, var_list))
+        q_vars)
+    p_vars = [v for v in var_list if v not in q_vars]
+    p_grads = tf.gradients(loss, p_vars)
+    grads_and_vars = list(zip(q_grads, q_vars)) + list(zip(p_grads, p_vars))
     return loss, grads_and_vars

--- a/edward/inferences/klqp.py
+++ b/edward/inferences/klqp.py
@@ -7,7 +7,7 @@ import tensorflow as tf
 
 from edward.inferences.variational_inference import VariationalInference
 from edward.models import RandomVariable
-from edward.util import copy
+from edward.util import copy, get_descendants
 
 try:
   from edward.models import Normal
@@ -628,7 +628,7 @@ def build_score_kl_loss_and_gradients(inference, var_list):
             if len(get_descendants(tf.convert_to_tensor(v), q_rvs)) != 0]
   q_grads = tf.gradients(
       -(tf.reduce_mean(q_log_prob * tf.stop_gradient(p_log_lik)) - kl_penalty),
-      var_list)
+      q_vars)
   p_vars = [v for v in var_list if v not in q_vars]
   p_grads = tf.gradients(loss, p_vars)
   grads_and_vars = list(zip(q_grads, q_vars)) + list(zip(p_grads, p_vars))
@@ -702,7 +702,7 @@ def build_score_entropy_loss_and_gradients(inference, var_list):
   q_grads = tf.gradients(
       -(tf.reduce_mean(q_log_prob * tf.stop_gradient(p_log_prob)) +
           q_entropy),
-      var_list)
+      q_vars)
   p_vars = [v for v in var_list if v not in q_vars]
   p_grads = tf.gradients(loss, p_vars)
   grads_and_vars = list(zip(q_grads, q_vars)) + list(zip(p_grads, p_vars))

--- a/edward/inferences/variational_inference.py
+++ b/edward/inferences/variational_inference.py
@@ -55,9 +55,7 @@ class VariationalInference(Inference):
       var_list = set()
       trainables = tf.trainable_variables()
       for z, qz in six.iteritems(self.latent_vars):
-        if isinstance(z, RandomVariable):
-          var_list.update(get_variables(z, collection=trainables))
-
+        var_list.update(get_variables(z, collection=trainables))
         var_list.update(get_variables(qz, collection=trainables))
 
       for x, qx in six.iteritems(self.data):

--- a/examples/beta_bernoulli.py
+++ b/examples/beta_bernoulli.py
@@ -18,7 +18,7 @@ x_data = np.array([0, 1, 0, 0, 0, 0, 0, 0, 0, 1])
 
 # MODEL
 p = Beta(1.0, 1.0)
-x = Bernoulli(tf.ones(10) * p)
+x = Bernoulli(probs=p, sample_shape=10)
 
 # INFERENCE
 qp_a = tf.nn.softplus(tf.Variable(tf.random_normal([])))
@@ -27,3 +27,5 @@ qp = Beta(qp_a, qp_b)
 
 inference = ed.KLqp({p: qp}, data={x: x_data})
 inference.run(n_iter=500)
+
+print("Posterior mean of probability: {}".format(qp.mean().eval()))

--- a/examples/beta_bernoulli_conjugate.py
+++ b/examples/beta_bernoulli_conjugate.py
@@ -19,18 +19,18 @@ ed.set_seed(42)
 x_data = np.array([0, 1, 0, 0, 0, 0, 0, 0, 0, 1])
 
 # MODEL
-pi = Beta(1.0, 1.0)
-x = Bernoulli(probs=pi, sample_shape=10)
+p = Beta(1.0, 1.0)
+x = Bernoulli(probs=p, sample_shape=10)
 
 # COMPLETE CONDITIONAL
-pi_cond = ed.complete_conditional(pi)
+p_cond = ed.complete_conditional(p)
 
 sess = ed.get_session()
 tf.global_variables_initializer().run()
 
-print('p(pi | x) type:', pi_cond.parameters['name'])
+print('p(probs | x) type:', p_cond.parameters['name'])
 param_vals = sess.run({key: val for
-                       key, val in six.iteritems(pi_cond.parameters)
+                       key, val in six.iteritems(p_cond.parameters)
                        if isinstance(val, tf.Tensor)}, {x: x_data})
 print('parameters:')
 for key, val in six.iteritems(param_vals):

--- a/examples/beta_bernoulli_map.py
+++ b/examples/beta_bernoulli_map.py
@@ -18,7 +18,7 @@ x_data = np.array([0, 1, 0, 0, 0, 0, 0, 0, 0, 1])
 
 # MODEL
 p = Beta(1.0, 1.0)
-x = Bernoulli(tf.ones(10) * p)
+x = Bernoulli(probs=p, sample_shape=10)
 
 # INFERENCE
 qp_params = tf.sigmoid(tf.Variable(tf.random_normal([])))
@@ -26,3 +26,5 @@ qp = PointMass(params=qp_params)
 
 inference = ed.MAP({p: qp}, data={x: x_data})
 inference.run(n_iter=50)
+
+print("Fitted probability: {}".format(qp.eval()))

--- a/examples/beta_bernoulli_mh.py
+++ b/examples/beta_bernoulli_mh.py
@@ -18,7 +18,7 @@ x_data = np.array([0, 1, 0, 0, 0, 0, 0, 0, 0, 1])
 
 # MODEL
 p = Beta(1.0, 1.0)
-x = Bernoulli(tf.ones(10) * p)
+x = Bernoulli(probs=p, sample_shape=10)
 
 # INFERENCE
 qp = Empirical(params=tf.Variable(tf.zeros([1000]) + 0.5))

--- a/examples/beta_bernoulli_ppc.py
+++ b/examples/beta_bernoulli_ppc.py
@@ -18,7 +18,7 @@ x_data = np.array([0, 1, 0, 0, 0, 0, 0, 0, 0, 1])
 
 # MODEL
 p = Beta(1.0, 1.0)
-x = Bernoulli(tf.ones(10) * p)
+x = Bernoulli(probs=p, sample_shape=10)
 
 # INFERENCE
 qp_a = tf.nn.softplus(tf.Variable(tf.random_normal([])))

--- a/tests/test-inferences/test_klpq.py
+++ b/tests/test-inferences/test_klpq.py
@@ -6,29 +6,54 @@ import edward as ed
 import numpy as np
 import tensorflow as tf
 
-from edward.models import Normal
+from edward.models import Bernoulli, Normal
 
 
 class test_klpq_class(tf.test.TestCase):
 
-  def test_normalnormal_run(self):
+  def _test_normal_normal(self, Inference, *args, **kwargs):
     with self.test_session() as sess:
       x_data = np.array([0.0] * 50, dtype=np.float32)
 
       mu = Normal(loc=0.0, scale=1.0)
-      x = Normal(loc=tf.ones(50) * mu, scale=1.0)
+      x = Normal(loc=mu, scale=1.0, sample_shape=50)
 
       qmu_loc = tf.Variable(tf.random_normal([]))
       qmu_scale = tf.nn.softplus(tf.Variable(tf.random_normal([])))
       qmu = Normal(loc=qmu_loc, scale=qmu_scale)
 
       # analytic solution: N(loc=0.0, scale=\sqrt{1/51}=0.140)
-      inference = ed.KLpq({mu: qmu}, data={x: x_data})
-      inference.run(n_samples=25, n_iter=100)
+      inference = Inference({mu: qmu}, data={x: x_data})
+      inference.run(*args, **kwargs)
 
       self.assertAllClose(qmu.mean().eval(), 0, rtol=1e-1, atol=1e-1)
       self.assertAllClose(qmu.stddev().eval(), np.sqrt(1 / 51),
                           rtol=1e-1, atol=1e-1)
+
+      variables = tf.get_collection(
+          tf.GraphKeys.GLOBAL_VARIABLES, scope='optimizer')
+      old_t, old_variables = sess.run([inference.t, variables])
+      self.assertEqual(old_t, inference.n_iter)
+      sess.run(inference.reset)
+      new_t, new_variables = sess.run([inference.t, variables])
+      self.assertEqual(new_t, 0)
+      self.assertNotEqual(old_variables, new_variables)
+
+  def _test_model_parameter(self, Inference, *args, **kwargs):
+    with self.test_session() as sess:
+      x_data = np.array([0, 1, 0, 0, 0, 0, 0, 0, 0, 1])
+
+      p = tf.sigmoid(tf.Variable(0.5))
+      x = Bernoulli(probs=p, sample_shape=10)
+
+      inference = Inference({}, data={x: x_data})
+      inference.run(*args, **kwargs)
+
+      self.assertAllClose(p.eval(), 0.2, rtol=5e-2, atol=5e-2)
+
+  def test_klpq(self):
+    self._test_normal_normal(ed.KLpq, n_samples=25, n_iter=100)
+    self._test_model_parameter(ed.KLpq, n_iter=50)
 
 if __name__ == '__main__':
   ed.set_seed(42)

--- a/tests/test-inferences/test_klqp.py
+++ b/tests/test-inferences/test_klqp.py
@@ -6,12 +6,12 @@ import edward as ed
 import numpy as np
 import tensorflow as tf
 
-from edward.models import Normal
+from edward.models import Bernoulli, Normal
 
 
 class test_klqp_class(tf.test.TestCase):
 
-  def _test(self, Inference, *args, **kwargs):
+  def _test_normal_normal(self, Inference, *args, **kwargs):
     with self.test_session() as sess:
       x_data = np.array([0.0] * 50, dtype=np.float32)
 
@@ -39,26 +39,45 @@ class test_klqp_class(tf.test.TestCase):
       self.assertEqual(new_t, 0)
       self.assertNotEqual(old_variables, new_variables)
 
+  def _test_model_parameter(self, Inference, *args, **kwargs):
+    with self.test_session() as sess:
+      x_data = np.array([0, 1, 0, 0, 0, 0, 0, 0, 0, 1])
+
+      p = tf.sigmoid(tf.Variable(0.5))
+      x = Bernoulli(probs=p, sample_shape=10)
+
+      inference = Inference({}, data={x: x_data})
+      inference.run(*args, **kwargs)
+
+      self.assertAllClose(p.eval(), 0.2, rtol=5e-2, atol=5e-2)
+
   def test_klqp(self):
-    self._test(ed.KLqp, n_iter=5000)
+    self._test_normal_normal(ed.KLqp, n_iter=5000)
+    self._test_model_parameter(ed.KLqp, n_iter=50)
 
   def test_reparameterization_entropy_klqp(self):
-    self._test(ed.ReparameterizationEntropyKLqp, n_iter=5000)
+    self._test_normal_normal(ed.ReparameterizationEntropyKLqp, n_iter=5000)
+    self._test_model_parameter(ed.ReparameterizationEntropyKLqp, n_iter=50)
 
   def test_reparameterization_klqp(self):
-    self._test(ed.ReparameterizationKLqp, n_iter=5000)
+    self._test_normal_normal(ed.ReparameterizationKLqp, n_iter=5000)
+    self._test_model_parameter(ed.ReparameterizationKLqp, n_iter=50)
 
   def test_reparameterization_kl_klqp(self):
-    self._test(ed.ReparameterizationKLKLqp, n_iter=5000)
+    self._test_normal_normal(ed.ReparameterizationKLKLqp, n_iter=5000)
+    self._test_model_parameter(ed.ReparameterizationKLKLqp, n_iter=50)
 
   def test_score_entropy_klqp(self):
-    self._test(ed.ScoreEntropyKLqp, n_samples=5, n_iter=5000)
+    self._test_normal_normal(ed.ScoreEntropyKLqp, n_samples=5, n_iter=5000)
+    self._test_model_parameter(ed.ScoreEntropyKLqp, n_iter=50)
 
   def test_score_klqp(self):
-    self._test(ed.ScoreKLqp, n_samples=5, n_iter=5000)
+    self._test_normal_normal(ed.ScoreKLqp, n_samples=5, n_iter=5000)
+    self._test_model_parameter(ed.ScoreKLqp, n_iter=50)
 
   def test_score_kl_klqp(self):
-    self._test(ed.ScoreKLKLqp, n_samples=5, n_iter=5000)
+    self._test_normal_normal(ed.ScoreKLKLqp, n_samples=5, n_iter=5000)
+    self._test_model_parameter(ed.ScoreKLKLqp, n_iter=50)
 
 if __name__ == '__main__':
   ed.set_seed(42)

--- a/tests/test-inferences/test_klqp.py
+++ b/tests/test-inferences/test_klqp.py
@@ -11,21 +11,20 @@ from edward.models import Normal
 
 class test_klqp_class(tf.test.TestCase):
 
-  def test_normalnormal_run(self):
+  def _test(self, Inference, *args, **kwargs):
     with self.test_session() as sess:
       x_data = np.array([0.0] * 50, dtype=np.float32)
 
       mu = Normal(loc=0.0, scale=1.0)
-      x = Normal(loc=tf.ones(50) * mu, scale=1.0)
+      x = Normal(loc=mu, scale=1.0, sample_shape=50)
 
       qmu_loc = tf.Variable(tf.random_normal([]))
       qmu_scale = tf.nn.softplus(tf.Variable(tf.random_normal([])))
       qmu = Normal(loc=qmu_loc, scale=qmu_scale)
 
       # analytic solution: N(loc=0.0, scale=\sqrt{1/51}=0.140)
-      n_iter = 5000
-      inference = ed.KLqp({mu: qmu}, data={x: x_data})
-      inference.run(n_iter=n_iter)
+      inference = Inference({mu: qmu}, data={x: x_data})
+      inference.run(*args, **kwargs)
 
       self.assertAllClose(qmu.mean().eval(), 0, rtol=1e-1, atol=1e-1)
       self.assertAllClose(qmu.stddev().eval(), np.sqrt(1 / 51),
@@ -34,11 +33,32 @@ class test_klqp_class(tf.test.TestCase):
       variables = tf.get_collection(
           tf.GraphKeys.GLOBAL_VARIABLES, scope='optimizer')
       old_t, old_variables = sess.run([inference.t, variables])
-      self.assertEqual(old_t, n_iter)
+      self.assertEqual(old_t, inference.n_iter)
       sess.run(inference.reset)
       new_t, new_variables = sess.run([inference.t, variables])
       self.assertEqual(new_t, 0)
       self.assertNotEqual(old_variables, new_variables)
+
+  def test_klqp(self):
+    self._test(ed.KLqp, n_iter=5000)
+
+  def test_reparameterization_entropy_klqp(self):
+    self._test(ed.ReparameterizationEntropyKLqp, n_iter=5000)
+
+  def test_reparameterization_klqp(self):
+    self._test(ed.ReparameterizationKLqp, n_iter=5000)
+
+  def test_reparameterization_kl_klqp(self):
+    self._test(ed.ReparameterizationKLKLqp, n_iter=5000)
+
+  def test_score_entropy_klqp(self):
+    self._test(ed.ScoreEntropyKLqp, n_samples=5, n_iter=5000)
+
+  def test_score_klqp(self):
+    self._test(ed.ScoreKLqp, n_samples=5, n_iter=5000)
+
+  def test_score_kl_klqp(self):
+    self._test(ed.ScoreKLKLqp, n_samples=5, n_iter=5000)
 
 if __name__ == '__main__':
   ed.set_seed(42)


### PR DESCRIPTION
This pull requests adds a number of minor improvements to `ed.KLqp`:

+ `kl_scaling` argument is generalized from float to any broadcastable tensor with the KL terms.
+ Like reparameterization methods, score function methods are extended to enable automatic model parameter gradients in the EM style.
+ Fixed bug with entropy loss functions.
+ Tests.