### PR TITLE
Fix ordering bug in ed.copy

### DIFF
--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -217,7 +217,7 @@ def copy(org_instance, dict_swap=None, scope="copied",
   # copied first (from parent -> child) before any deterministic
   # operations that depend on them.
   if not replace_itself and \
-      isinstance(org_instance, (RandomVariable, tf.Tensor, tf.Variable)):
+          isinstance(org_instance, (RandomVariable, tf.Tensor, tf.Variable)):
     for v in get_parents(org_instance):
       # 'False' forces the top-most random variables to be copied
       # first. This may be slow: suppose x[1] -> ...  -> x[T] and we

--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -213,17 +213,17 @@ def copy(org_instance, dict_swap=None, scope="copied",
     except:
       pass
 
-  # Preserve ordering of random variable copies. Random variables are
-  # always copied first (in parent -> child ordering) before any
-  # deterministic operations that depend on them.
+  # Preserve ordering of random variables. Random variables are always
+  # copied first (from parent -> child) before any deterministic
+  # operations that depend on them.
   if not replace_itself and \
       isinstance(org_instance, (RandomVariable, tf.Tensor, tf.Variable)):
     for v in get_parents(org_instance):
       # 'False' forces the top-most random variables to be copied
-      # first at all times. This may be slow: suppose x[1] -> ...
-      # -> x[T] and we call copy(x[T]). get_parents finds x[t-1] and
-      # calls copy again; this leads to calling get_parents and copy
-      # recursively on T many random variables.
+      # first. This may be slow: suppose x[1] -> ...  -> x[T] and we
+      # call copy(x[T]). get_parents finds x[t-1] and calls copy
+      # again; this leads to calling get_parents and copy on T many
+      # random variables.
       copy(v, dict_swap, scope, False, copy_q)
 
   if isinstance(org_instance, RandomVariable):

--- a/tests/test-util/test_copy.py
+++ b/tests/test-util/test_copy.py
@@ -11,6 +11,33 @@ from edward.models import Bernoulli, Categorical, Mixture, Normal
 
 class test_copy_class(tf.test.TestCase):
 
+  def test_scope(self):
+    with self.test_session():
+      x = tf.constant(2.0)
+      x_new = ed.copy(x, scope='new_scope')
+      self.assertTrue(x_new.name.startswith('new_scope'))
+
+  def test_replace_itself(self):
+    with self.test_session():
+      x = tf.constant(2.0)
+      y = tf.constant(3.0)
+      x_new = ed.copy(x, {x: y}, replace_itself=False)
+      self.assertEqual(x_new.eval(), 2.0)
+      x_new = ed.copy(x, {x: y}, replace_itself=True)
+      self.assertEqual(x_new.eval(), 3.0)
+
+  def test_copy_q(self):
+    with self.test_session() as sess:
+      x = tf.constant(2.0)
+      y = tf.random_normal([])
+      x_new = ed.copy(x, {x: y}, replace_itself=True, copy_q=False)
+      x_new_val, y_val = sess.run([x_new, y])
+      self.assertEqual(x_new_val, y_val)
+      x_new = ed.copy(x, {x: y}, replace_itself=True, copy_q=True)
+      x_new_val, x_val, y_val = sess.run([x_new, x, y])
+      self.assertNotEqual(x_new_val, x_val)
+      self.assertNotEqual(x_new_val, y_val)
+
   def test_placeholder(self):
     with self.test_session() as sess:
       x = tf.placeholder(tf.float32, name="CustomName")

--- a/tests/test-util/test_copy.py
+++ b/tests/test-util/test_copy.py
@@ -38,6 +38,16 @@ class test_copy_class(tf.test.TestCase):
       self.assertNotEqual(x_new_val, x_val)
       self.assertNotEqual(x_new_val, y_val)
 
+  def test_copy_parent_rvs(self):
+    with self.test_session() as sess:
+      x = Normal(0.0, 1.0)
+      y = tf.constant(3.0)
+      z = x * y
+      z_new = ed.copy(z, scope='no_copy_parent_rvs', copy_parent_rvs=False)
+      self.assertEqual(len(ed.random_variables()), 1)
+      z_new = ed.copy(z, scope='copy_parent_rvs', copy_parent_rvs=True)
+      self.assertEqual(len(ed.random_variables()), 2)
+
   def test_placeholder(self):
     with self.test_session() as sess:
       x = tf.placeholder(tf.float32, name="CustomName")


### PR DESCRIPTION
Consider
```python
x = Normal(0.0, 1.0, name="x")
y = tf.nn.relu(x, name="y")
ed.copy(y)
ed.copy(x)  # fails
```
This fails because `ed.copy` copies all the tensors `y` depends on, but never creates the random variable `copied/x`. `copied/x` is then attempted to be made on the second call to `ed.copy` but it fails because certain tensors already exist in `copied/x`'s creation. (In special cases, this can work such as when y is a random variable, but not a random variable parameterized by a deterministic function of x.)

Fixes #744.
