### PR TITLE
Add automated transformations to all inference

### DIFF
--- a/edward/inferences/gibbs.py
+++ b/edward/inferences/gibbs.py
@@ -64,6 +64,7 @@ class Gibbs(MonteCarlo):
     """
     self.scan_order = scan_order
     self.feed_dict = {}
+    kwargs['auto_transform'] = False
     return super(Gibbs, self).initialize(*args, **kwargs)
 
   def update(self, feed_dict=None):

--- a/edward/inferences/gibbs.py
+++ b/edward/inferences/gibbs.py
@@ -16,6 +16,10 @@ from edward.util import check_latent_vars, get_session
 class Gibbs(MonteCarlo):
   """Gibbs sampling [@geman1984stochastic].
 
+  Note `Gibbs` assumes the proposal distribution has the same
+  support as the prior. The `auto_transform` attribute in
+  the method `initialize()` is not applicable.
+
   #### Examples
 
   ```python

--- a/edward/inferences/hmc.py
+++ b/edward/inferences/hmc.py
@@ -115,7 +115,13 @@ class HMC(MonteCarlo):
     assign_ops = []
     for z, qz in six.iteritems(self.latent_vars):
       variable = qz.get_variables()[0]
-      assign_ops.append(tf.scatter_update(variable, self.t, sample[z]))
+      qz_sample = sample[z]
+      if (hasattr(z, 'bijector') and hasattr(z, 'support') and
+              z.support in ('real', 'multivariate_real')):
+        # If z is an automatically unconstrained distribution,
+        # transform samples back to original (constrained) space.
+        qz_sample = z.bijector.inverse(qz_sample)
+      assign_ops.append(tf.scatter_update(variable, self.t, qz_sample))
 
     # Increment n_accept (if accepted).
     assign_ops.append(self.n_accept.assign_add(tf.where(accept, 1, 0)))

--- a/edward/inferences/inference.py
+++ b/edward/inferences/inference.py
@@ -218,19 +218,10 @@ class Inference(object):
       latent_vars = self.latent_vars.copy()
       self.latent_vars = {}
       for z, qz in six.iteritems(latent_vars):
-        try:
-          if z.support != qz.support:
-            z_transform = transform(z)
-            if qz.support == 'point':
-              from tensorflow.contrib.distributions import bijectors
-              qz_transform = transform(qz, bijectors.Invert(z_transform.bijector))
-              self.latent_vars[z] = qz_transform
-            else:
-              qz_transform = transform(qz)
-              self.latent_vars[z_transform] = qz_transform
-          else:
-            self.latent_vars[z] = qz
-        except AttributeError:
+        if hasattr(z, 'support') and hasattr(qz, 'support') and \
+                z.support != qz.support and qz.support != 'point':
+          self.latent_vars[transform(z)] = transform(qz)
+        else:
           self.latent_vars[z] = qz
 
     if logdir is not None:

--- a/edward/inferences/inference.py
+++ b/edward/inferences/inference.py
@@ -220,7 +220,14 @@ class Inference(object):
       for z, qz in six.iteritems(latent_vars):
         try:
           if z.support != qz.support:
-            self.latent_vars[transform(z)] = transform(qz)
+            z_transform = transform(z)
+            if qz.support == 'point':
+              from tensorflow.contrib.distributions import bijectors
+              qz_transform = transform(qz, bijectors.Invert(z_transform.bijector))
+              self.latent_vars[z] = qz_transform
+            else:
+              qz_transform = transform(qz)
+              self.latent_vars[z_transform] = qz_transform
           else:
             self.latent_vars[z] = qz
         except AttributeError:

--- a/edward/inferences/inference.py
+++ b/edward/inferences/inference.py
@@ -223,7 +223,10 @@ class Inference(object):
       for z, qz in six.iteritems(latent_vars):
         if hasattr(z, 'support') and hasattr(qz, 'support') and \
                 z.support != qz.support and qz.support != 'point':
-          self.latent_vars[transform(z)] = transform(qz)
+          if qz.support == 'points':  # don't transform empirical approx's
+            self.latent_vars[transform(z)] = qz
+          else:
+            self.latent_vars[transform(z)] = transform(qz)
         else:
           self.latent_vars[z] = qz
 

--- a/edward/inferences/inference.py
+++ b/edward/inferences/inference.py
@@ -217,16 +217,23 @@ class Inference(object):
 
     self.scale = scale
 
+    # Set of all latent variables binded to their transformation on
+    # the unconstrained space (if any).
+    self.transformations = {}
     if auto_transform:
       latent_vars = self.latent_vars.copy()
       self.latent_vars = {}
       for z, qz in six.iteritems(latent_vars):
         if hasattr(z, 'support') and hasattr(qz, 'support') and \
                 z.support != qz.support and qz.support != 'point':
+          z_transform = transform(z)
+          self.transformations[z] = z_transform
           if qz.support == 'points':  # don't transform empirical approx's
-            self.latent_vars[transform(z)] = qz
+            self.latent_vars[z_transform] = qz
           else:
-            self.latent_vars[transform(z)] = transform(qz)
+            qz_transform = transform(qz)
+            self.latent_vars[z_transform] = qz_transform
+            self.transformations[qz] = qz_transform
         else:
           self.latent_vars[z] = qz
       del latent_vars

--- a/edward/inferences/inference.py
+++ b/edward/inferences/inference.py
@@ -178,7 +178,10 @@ class Inference(object):
         applying masks on a random variable.
       auto_transform: bool, optional.
         Whether to automatically transform continuous latent variables
-        of unequal support to be on the unconstrained space.
+        of unequal support to be on the unconstrained space. It is
+        only applied if the argument is `True`, the latent variable
+        pair are `ed.RandomVariable`s with the `support` attribute,
+        the supports are both continuous and unequal.
       logdir: str, optional.
         Directory where event file will be written. For details,
         see `tf.summary.FileWriter`. Default is to log nothing.

--- a/edward/inferences/inference.py
+++ b/edward/inferences/inference.py
@@ -229,6 +229,7 @@ class Inference(object):
             self.latent_vars[transform(z)] = transform(qz)
         else:
           self.latent_vars[z] = qz
+      del latent_vars
 
     if logdir is not None:
       self.logging = True

--- a/edward/inferences/laplace.py
+++ b/edward/inferences/laplace.py
@@ -8,6 +8,7 @@ import tensorflow as tf
 from edward.inferences.map import MAP
 from edward.models import PointMass, RandomVariable
 from edward.util import get_session, get_variables
+from edward.util import copy, transform
 
 try:
   from edward.models import \
@@ -35,6 +36,17 @@ class Laplace(MAP):
   the variables but it does not require a potentially expensive
   matrix inversion.
 
+  Random variables with both scalar batch and event shape are not
+  supported as `tf.hessians` is currently not applicable to scalars.
+
+  Note that `Laplace` finds the location parameter of the normal
+  approximation using `MAP`, which is performed on the latent
+  variable's original (constrained) support. The scale parameter
+  is calculated by evaluating the Hessian of $-\log p(x, z)$ in the
+  constrained space and under the mode. This implies the Laplace
+  approximation always has real support even if the target
+  distribution has constrained support.
+
   #### Examples
 
   ```python
@@ -58,17 +70,29 @@ class Laplace(MAP):
         Collection of random variables to perform inference on. If list,
         each random variable will be implictly optimized using a
         `MultivariateNormalTriL` random variable that is defined
-        internally (with unconstrained support). If dictionary, each
-        random variable must be a `MultivariateNormalDiag`,
+        internally with unconstrained support and is initialized using
+        standard normal draws. If dictionary, each random
+        variable must be a `MultivariateNormalDiag`,
         `MultivariateNormalTriL`, or `Normal` random variable.
     """
     if isinstance(latent_vars, list):
       with tf.variable_scope(None, default_name="posterior"):
-        latent_vars = {rv: MultivariateNormalTriL(
-            loc=tf.Variable(tf.random_normal(rv.batch_shape)),
-            scale_tril=tf.Variable(tf.random_normal(
-                rv.batch_shape.concatenate(rv.batch_shape[-1]))))
-            for rv in latent_vars}
+        latent_vars_dict = {}
+        for z in latent_vars:
+          # Define location to have constrained support and
+          # unconstrained free parameters.
+          batch_event_shape = z.batch_shape.concatenate(z.event_shape)
+          loc = tf.Variable(tf.random_normal(batch_event_shape))
+          if hasattr(z, 'support'):
+            z_transform = transform(z)
+            if hasattr(z_transform, 'bijector'):
+              loc = z_transform.bijector.inverse(loc)
+          scale_tril = tf.Variable(tf.random_normal(
+              batch_event_shape.concatenate(batch_event_shape[-1])))
+          qz = MultivariateNormalTriL(loc=loc, scale_tril=scale_tril)
+          latent_vars_dict[z] = qz
+        latent_vars = latent_vars_dict
+        del latent_vars_dict
     elif isinstance(latent_vars, dict):
       for qz in six.itervalues(latent_vars):
         if not isinstance(
@@ -81,9 +105,9 @@ class Laplace(MAP):
     super(MAP, self).__init__(latent_vars, data)
 
   def initialize(self, *args, **kwargs):
-    # Store latent variables in a temporary attribute; MAP will
+    # Store latent variables in a temporary object; MAP will
     # optimize `PointMass` random variables, which subsequently
-    # optimizes mean parameters of the normal approximations.
+    # optimizes location parameters of the normal approximations.
     latent_vars_normal = self.latent_vars.copy()
     self.latent_vars = {z: PointMass(params=qz.loc)
                         for z, qz in six.iteritems(latent_vars_normal)}

--- a/edward/inferences/map.py
+++ b/edward/inferences/map.py
@@ -60,9 +60,10 @@ class MAP(VariationalInference):
   ed.MAP([pi, mu, sigma], data)
   ```
 
-  Currently, `MAP` can only instantiate `PointMass` random variables
-  with unconstrained support. To constrain their support, one must
-  manually pass in the `PointMass` family.
+  Like other `Inference` classes, `MAP` optimizes over latent
+  variables with constrained continuous support by transforming them
+  to the unconstrained space. The optimized point mass approximations
+  are the points transformed back to the original (constrained) space.
   """
   def __init__(self, latent_vars=None, data=None):
     """Create an inference algorithm.
@@ -71,10 +72,10 @@ class MAP(VariationalInference):
       latent_vars: list of RandomVariable or
                    dict of RandomVariable to RandomVariable.
         Collection of random variables to perform inference on. If
-        list, each random variable will be implictly optimized
-        using a `PointMass` random variable that is defined
-        internally (with unconstrained support). If dictionary, each
-        value in the dictionary must be a `PointMass` random variable.
+        list, each random variable will be implictly optimized using a
+        `PointMass` random variable that is defined internally. If
+        dictionary, each value in the dictionary must be a `PointMass`
+        random variable.
     """
     if isinstance(latent_vars, list):
       with tf.variable_scope(None, default_name="posterior"):

--- a/edward/inferences/metropolis_hastings.py
+++ b/edward/inferences/metropolis_hastings.py
@@ -62,6 +62,10 @@ class MetropolisHastings(MonteCarlo):
     self.proposal_vars = proposal_vars
     super(MetropolisHastings, self).__init__(latent_vars, data)
 
+  def initialize(self, *args, **kwargs):
+    kwargs['auto_transform'] = False
+    return super(MetropolisHastings, self).initialize(*args, **kwargs)
+
   def build_update(self):
     """Draw sample from proposal conditional on last sample. Then
     accept or reject the sample based on the ratio,

--- a/edward/inferences/metropolis_hastings.py
+++ b/edward/inferences/metropolis_hastings.py
@@ -34,6 +34,10 @@ class MetropolisHastings(MonteCarlo):
   q(\\beta)$. This is unbiased (and therefore asymptotically exact as a
   pseudo-marginal method) if $q(\\beta) = p(\\beta \mid x)$.
 
+  `MetropolisHastings` assumes the proposal distribution has the same
+  support as the prior. The `auto_transform` attribute in
+  the method `initialize()` is not applicable.
+
   #### Examples
 
   ```python

--- a/edward/inferences/monte_carlo.py
+++ b/edward/inferences/monte_carlo.py
@@ -77,9 +77,9 @@ class MonteCarlo(Inference):
     """
     if isinstance(latent_vars, list):
       with tf.variable_scope(None, default_name="posterior"):
-        latent_vars = {rv: Empirical(params=tf.Variable(
-            tf.zeros([1e4] + rv.batch_shape.as_list())))
-            for rv in latent_vars}
+        latent_vars = {z: Empirical(params=tf.Variable(tf.zeros(
+            [1e4] + z.batch_shape.concatenate(z.event_shape).as_list())))
+            for z in latent_vars}
     elif isinstance(latent_vars, dict):
       for qz in six.itervalues(latent_vars):
         if not isinstance(qz, Empirical):

--- a/edward/inferences/sghmc.py
+++ b/edward/inferences/sghmc.py
@@ -95,7 +95,13 @@ class SGHMC(MonteCarlo):
     assign_ops = []
     for z, qz in six.iteritems(self.latent_vars):
       variable = qz.get_variables()[0]
-      assign_ops.append(tf.scatter_update(variable, self.t, sample[z]))
+      qz_sample = sample[z]
+      if (hasattr(z, 'bijector') and hasattr(z, 'support') and
+              z.support in ('real', 'multivariate_real')):
+        # If z is an automatically unconstrained distribution,
+        # transform samples back to original (constrained) space.
+        qz_sample = z.bijector.inverse(qz_sample)
+      assign_ops.append(tf.scatter_update(variable, self.t, qz_sample))
       assign_ops.append(tf.assign(self.v[z], v_sample[z]).op)
 
     # Increment n_accept.

--- a/edward/inferences/sgld.py
+++ b/edward/inferences/sgld.py
@@ -87,7 +87,13 @@ class SGLD(MonteCarlo):
     assign_ops = []
     for z, qz in six.iteritems(self.latent_vars):
       variable = qz.get_variables()[0]
-      assign_ops.append(tf.scatter_update(variable, self.t, sample[z]))
+      qz_sample = sample[z]
+      if (hasattr(z, 'bijector') and hasattr(z, 'support') and
+              z.support in ('real', 'multivariate_real')):
+        # If z is an automatically unconstrained distribution,
+        # transform samples back to original (constrained) space.
+        qz_sample = z.bijector.inverse(qz_sample)
+      assign_ops.append(tf.scatter_update(variable, self.t, qz_sample))
 
     # Increment n_accept.
     assign_ops.append(self.n_accept.assign_add(1))

--- a/edward/models/empirical.py
+++ b/edward/models/empirical.py
@@ -120,5 +120,6 @@ _candidate = distributions_Empirical
 __init__.__doc__ = _candidate.__init__.__doc__
 _globals = globals()
 _params = {'__doc__': _candidate.__doc__,
-           '__init__': __init__}
+           '__init__': __init__,
+           'support': 'points'}
 _globals[_name] = type(_name, (RandomVariable, _candidate), _params)

--- a/edward/models/point_mass.py
+++ b/edward/models/point_mass.py
@@ -105,5 +105,6 @@ _candidate = distributions_PointMass
 __init__.__doc__ = _candidate.__init__.__doc__
 _globals = globals()
 _params = {'__doc__': _candidate.__doc__,
-           '__init__': __init__}
+           '__init__': __init__,
+           'support': 'point'}
 _globals[_name] = type(_name, (RandomVariable, _candidate), _params)

--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -757,14 +757,19 @@ def transform(x, *args, **kwargs):
 
   if support == '01':
     bij = bijectors.Invert(bijectors.Sigmoid())
+    new_support = 'real'
   elif support == 'nonnegative':
     bij = bijectors.Invert(bijectors.Softplus())
+    new_support = 'real'
   elif support == 'simplex':
     bij = bijectors.Invert(bijectors.SoftmaxCentered(event_ndims=1))
+    new_support = 'multivariate_real'
   elif support in ('real', 'multivariate_real'):
     return x
   else:
     msg = "'transform' does not handle supports of type '{}'".format(support)
     raise NotImplementedError(msg)
 
-  return TransformedDistribution(x, bij, *args, **kwargs)
+  new_x = TransformedDistribution(x, bij, *args, **kwargs)
+  new_x.support = new_support
+  return new_x

--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -761,7 +761,7 @@ def transform(x, *args, **kwargs):
     bij = bijectors.Invert(bijectors.Softplus())
   elif support == 'simplex':
     bij = bijectors.Invert(bijectors.SoftmaxCentered(event_ndims=1))
-  elif support == 'real' or support == 'multivariate_real':
+  elif support in ('real', 'multivariate_real'):
     return x
   else:
     msg = "'transform' does not handle supports of type '{}'".format(support)

--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -753,7 +753,7 @@ def transform(x, *args, **kwargs):
   except AttributeError as e:
     msg = """'{}' object has no 'support'
              so cannot be transformed.""".format(type(x).__name__)
-    raise ValueError(msg)
+    raise AttributeError(msg)
 
   if support == '01':
     bij = bijectors.Invert(bijectors.Sigmoid())
@@ -768,7 +768,7 @@ def transform(x, *args, **kwargs):
     return x
   else:
     msg = "'transform' does not handle supports of type '{}'".format(support)
-    raise NotImplementedError(msg)
+    raise ValueError(msg)
 
   new_x = TransformedDistribution(x, bij, *args, **kwargs)
   new_x.support = new_support

--- a/tests/inferences/test_inference_auto_transform.py
+++ b/tests/inferences/test_inference_auto_transform.py
@@ -6,8 +6,8 @@ import edward as ed
 import numpy as np
 import tensorflow as tf
 
-from edward.models import (Empirical, Gamma, Normal, PointMass,
-    TransformedDistribution)
+from edward.models import (
+    Empirical, Gamma, Normal, PointMass, TransformedDistribution)
 
 
 class test_inference_auto_transform_class(tf.test.TestCase):

--- a/tests/inferences/test_inference_auto_transform.py
+++ b/tests/inferences/test_inference_auto_transform.py
@@ -6,28 +6,68 @@ import edward as ed
 import numpy as np
 import tensorflow as tf
 
-from edward.models import Gamma, Normal
+from edward.models import Gamma, Normal, PointMass, TransformedDistribution
 
 
 class test_inference_auto_transform_class(tf.test.TestCase):
 
   def test_auto_transform_true(self):
-    with self.test_session():
-      x = Gamma(2.0, 2.0)
+    with self.test_session() as sess:
+      # Match normal || softplus-inverse-normal distribution with
+      # automated transformation on latter (assuming it is softplus).
+      x = TransformedDistribution(
+          distribution=Normal(0.0, 0.5),
+          bijector=tf.contrib.distributions.bijectors.Softplus())
+      x.support = 'nonnegative'
       qx = Normal(loc=tf.Variable(tf.random_normal([])),
                   scale=tf.nn.softplus(tf.Variable(tf.random_normal([]))))
 
       inference = ed.KLqp({x: qx})
-      inference.initialize(auto_transform=True, n_samples=5, n_iter=150)
+      inference.initialize(auto_transform=True, n_samples=5, n_iter=1000)
       tf.global_variables_initializer().run()
       for _ in range(inference.n_iter):
         info_dict = inference.update()
 
+      # Check variational approximation on constrained space has same
+      # mean and variance as target distribution.
+      n_samples = 10000
+      x_mean, x_var = tf.nn.moments(x.sample(n_samples), 0)
+      qx_transformed = TransformedDistribution(
+          distribution=qx,
+          bijector=tf.contrib.distributions.bijectors.Softplus())
+      qx_mean, qx_var = tf.nn.moments(qx_transformed.sample(n_samples), 0)
+      stats = sess.run([x_mean, qx_mean, x_var, qx_var])
       self.assertAllClose(info_dict['loss'], 0.0, rtol=0.2, atol=0.2)
+      self.assertAllClose(stats[0], stats[1], rtol=1e-2, atol=1e-2)
+      self.assertAllClose(stats[2], stats[3], rtol=1e-2, atol=1e-2)
+
+  def test_map(self):
+    with self.test_session() as sess:
+      x = Gamma(2.0, 0.5)
+      qx = PointMass(tf.Variable(0.5))
+
+      inference = ed.MAP({x: qx})
+      inference.initialize(auto_transform=True, n_iter=1000)
+      tf.global_variables_initializer().run()
+      for _ in range(inference.n_iter):
+        info_dict = inference.update()
+
+      # Check point estimate on constrained space has same
+      # mode as target distribution.
+      qx_transformed = TransformedDistribution(
+          distribution=qx,
+          bijector=tf.contrib.distributions.bijectors.Softplus())
+      stats = sess.run([x.mode(), qx_transformed])
+      self.assertAllClose(stats[0], stats[1], rtol=1e-5, atol=1e-5)
 
   def test_auto_transform_false(self):
     with self.test_session():
-      x = Gamma(2.0, 2.0)
+      # Match normal || softplus-inverse-normal distribution without
+      # automated transformation; it should fail.
+      x = TransformedDistribution(
+          distribution=Normal(0.0, 0.5),
+          bijector=tf.contrib.distributions.bijectors.Softplus())
+      x.support = 'nonnegative'
       qx = Normal(loc=tf.Variable(tf.random_normal([])),
                   scale=tf.nn.softplus(tf.Variable(tf.random_normal([]))))
 

--- a/tests/inferences/test_inference_auto_transform.py
+++ b/tests/inferences/test_inference_auto_transform.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import edward as ed
+import numpy as np
+import tensorflow as tf
+
+from edward.models import Gamma, Normal
+
+
+class test_inference_auto_transform_class(tf.test.TestCase):
+
+  def test_auto_transform_true(self):
+    with self.test_session():
+      x = Gamma(2.0, 2.0)
+      qx = Normal(loc=tf.Variable(tf.random_normal([])),
+                  scale=tf.nn.softplus(tf.Variable(tf.random_normal([]))))
+
+      inference = ed.KLqp({x: qx})
+      inference.initialize(auto_transform=True, n_samples=5, n_iter=150)
+      tf.global_variables_initializer().run()
+      for _ in range(inference.n_iter):
+        info_dict = inference.update()
+
+      self.assertAllClose(info_dict['loss'], 0.0, rtol=0.2, atol=0.2)
+
+  def test_auto_transform_false(self):
+    with self.test_session():
+      x = Gamma(2.0, 2.0)
+      qx = Normal(loc=tf.Variable(tf.random_normal([])),
+                  scale=tf.nn.softplus(tf.Variable(tf.random_normal([]))))
+
+      inference = ed.KLqp({x: qx})
+      inference.initialize(auto_transform=False, n_samples=5, n_iter=150)
+      tf.global_variables_initializer().run()
+      for _ in range(inference.n_iter):
+        info_dict = inference.update()
+
+      self.assertAllEqual(info_dict['loss'], np.nan)
+
+if __name__ == '__main__':
+  ed.set_seed(124125)
+  tf.test.main()

--- a/tests/inferences/test_inference_auto_transform.py
+++ b/tests/inferences/test_inference_auto_transform.py
@@ -67,7 +67,7 @@ class test_inference_auto_transform_class(tf.test.TestCase):
       qx = PointMass(tf.nn.softplus(tf.Variable(0.5)))
 
       inference = ed.MAP({x: qx})
-      inference.initialize(auto_transform=True, n_iter=1000)
+      inference.initialize(auto_transform=True, n_iter=500)
       tf.global_variables_initializer().run()
       for _ in range(inference.n_iter):
         info_dict = inference.update()
@@ -82,7 +82,7 @@ class test_inference_auto_transform_class(tf.test.TestCase):
       x = Gamma(2.0, 0.5)
 
       inference = ed.MAP([x])
-      inference.initialize(auto_transform=True, n_iter=1000)
+      inference.initialize(auto_transform=True, n_iter=500)
       tf.global_variables_initializer().run()
       for _ in range(inference.n_iter):
         info_dict = inference.update()
@@ -91,6 +91,23 @@ class test_inference_auto_transform_class(tf.test.TestCase):
       # target distribution.
       qx = inference.latent_vars[x]
       stats = sess.run([x.mode(), qx])
+      self.assertAllClose(stats[0], stats[1], rtol=1e-5, atol=1e-5)
+
+  def test_laplace_default(self):
+    with self.test_session() as sess:
+      x = Gamma([2.0], [0.5])
+
+      inference = ed.Laplace([x])
+      optimizer = tf.train.AdamOptimizer(0.2)
+      inference.initialize(auto_transform=True, n_iter=500)
+      tf.global_variables_initializer().run()
+      for _ in range(inference.n_iter):
+        info_dict = inference.update()
+
+      # Check approximation on constrained space has same mode as
+      # target distribution.
+      qx = inference.latent_vars[x]
+      stats = sess.run([x.mode(), qx.mean()])
       self.assertAllClose(stats[0], stats[1], rtol=1e-5, atol=1e-5)
 
   def test_hmc_custom(self):

--- a/tests/util/test_transform.py
+++ b/tests/util/test_transform.py
@@ -7,8 +7,9 @@ import numpy as np
 import tensorflow as tf
 
 from collections import namedtuple
-from edward.models import (Beta, Dirichlet, Gamma, MultivariateNormalDiag,
-                           Normal, Poisson, TransformedDistribution)
+from edward.models import (
+    Beta, Dirichlet, DirichletProcess, Gamma, MultivariateNormalDiag,
+    Normal, Poisson, TransformedDistribution)
 from tensorflow.contrib.distributions import bijectors
 
 
@@ -75,7 +76,7 @@ class test_transform_class(tf.test.TestCase):
 
   def test_no_support(self):
     with self.test_session():
-      x = Poisson(1.0)
+      x = DirichletProcess(1.0, Normal(0.0, 1.0))
       with self.assertRaises(AttributeError):
         y = ed.transform(x)
 

--- a/tests/util/test_transform.py
+++ b/tests/util/test_transform.py
@@ -8,7 +8,7 @@ import tensorflow as tf
 
 from collections import namedtuple
 from edward.models import (Beta, Dirichlet, Gamma, MultivariateNormalDiag,
-                           Normal, PointMass, TransformedDistribution)
+                           Normal, Poisson, TransformedDistribution)
 from tensorflow.contrib.distributions import bijectors
 
 
@@ -75,15 +75,15 @@ class test_transform_class(tf.test.TestCase):
 
   def test_no_support(self):
     with self.test_session():
-      x = PointMass(1.0)
-      with self.assertRaises(ValueError):
+      x = Poisson(1.0)
+      with self.assertRaises(AttributeError):
         y = ed.transform(x)
 
   def test_unhandled_support(self):
     with self.test_session():
       FakeRV = namedtuple('FakeRV', ['support'])
       x = FakeRV(support='rational')
-      with self.assertRaises(NotImplementedError):
+      with self.assertRaises(ValueError):
         y = ed.transform(x)
 
 if __name__ == '__main__':


### PR DESCRIPTION
todos
+ [x] How do we handle discrete support in inference?
  + (For now, we don't do anything as discrete variables don't have the `support` attribute.)
+ [x] How do we store transformed vs original vars? especially to obtain constrained approximations (softplus-normal) when user defines unconstrained approximations (normal)
  + We use an additional member `self.transformations`.
+ [x] How does the implementation work for pointmass when doing MAP and normal when doing Laplace?
  + MAP optimizes over constrained support with unconstrained free parameters. Normal does the same and calculates the Hessian over the constrained log-density on the constrained mode.
+ [x] How does the implementation work for empirical when doing monte carlo algs?
  + Monte Carlo algs restricted to real support like HMC run a Markov chain on the unconstrained space and write samples in Empirical's via their constrained space.
+ [ ] Automated transformations tutorial