### PR TITLE
fixed normalization

### DIFF
--- a/docs/tex/tutorials/klpq.tex
+++ b/docs/tex/tutorials/klpq.tex
@@ -85,7 +85,7 @@ The basic procedure follows these steps:
     \sum_{s=1}^{S}
     \frac{p(\mathbf{z}_s \mid \mathbf{x})}{q(\mathbf{z}_s\;;\;\lambda)}
   \end{align*}
-  \item compute the weighted mean.
+  \item compute the weighted sum.
 \end{enumerate}
 The key insight is that we can use the joint $p(\mathbf{x},\mathbf{z})$ instead of the posterior
 when estimating the normalized importance weights

--- a/docs/tex/tutorials/klpq.tex
+++ b/docs/tex/tutorials/klpq.tex
@@ -122,7 +122,6 @@ estimate
   )
   &=
   -
-  \frac{1}{S}
   \sum_{s=1}^S
   w_s
   \nabla_\lambda\; \log q(\mathbf{z}_s\;;\;\lambda).

--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -66,7 +66,7 @@ class KLpq(VariationalInference):
 
     The loss function can be estimated as
 
-    $\\frac{1}{S} \sum_{s=1}^S [
+    $\sum_{s=1}^S [
       w_{\\text{norm}}(z^s; \lambda) (\log p(x, z^s) - \log q(z^s; \lambda) ],$
 
     where for $z^s \sim q(z; \lambda)$,
@@ -79,7 +79,7 @@ class KLpq(VariationalInference):
 
     This provides a gradient,
 
-    $- \\frac{1}{S} \sum_{s=1}^S [
+    $- \sum_{s=1}^S [
       w_{\\text{norm}}(z^s; \lambda) \\nabla_{\lambda} \log q(z^s; \lambda) ].$
     """
     p_log_prob = [0.0] * self.n_samples

--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -126,13 +126,13 @@ class KLpq(VariationalInference):
     log_w = p_log_prob - q_log_prob
     log_w_norm = log_w - tf.reduce_logsumexp(log_w)
     w_norm = tf.exp(log_w_norm)
-    loss = tf.reduce_mean(w_norm * log_w)
+    loss = tf.reduce_sum(w_norm * log_w)
 
     q_rvs = list(six.itervalues(self.latent_vars))
     q_vars = [v for v in var_list
               if len(get_descendants(tf.convert_to_tensor(v), q_rvs)) != 0]
     q_grads = tf.gradients(
-        -tf.reduce_mean(q_log_prob * tf.stop_gradient(w_norm)),
+        -tf.reduce_sum(q_log_prob * tf.stop_gradient(w_norm)),
         q_vars)
     p_vars = [v for v in var_list if v not in q_vars]
     p_grads = tf.gradients(-loss, p_vars)


### PR DESCRIPTION
This small first contribution addresses the following issue.  https://github.com/blei-lab/edward/issues/752

In the computation of the loss function and gradients in KLpq.py, tensorflow.mean has been replaced by tensorflow.sum.  This removes a normalization which was unnecessary because the weights have already been normalized.