### PR TITLE
[WIP] More robustly check inputs to inference algorithms

### DIFF
--- a/edward/inferences/bigan_inference.py
+++ b/edward/inferences/bigan_inference.py
@@ -41,6 +41,13 @@ class BiGANInference(GANInference):
   ```
   """
   def __init__(self, latent_vars, data, discriminator):
+    if len(key) != 1:
+      raise TypeError("latent_vars must have exactly one key.")
+    if len([key for key in six.iterkeys(data)
+            if not isinstance(key, tf.Tensor) or (isinstance(key,
+            tf.Tensor) and not "Placeholder" in key.op.type)]) != 1:
+      raise TypeError("data must have exactly one key that is not a "
+                      "`tf.placeholder`.")
     if not callable(discriminator):
       raise TypeError("discriminator must be a callable function.")
 
@@ -49,6 +56,7 @@ class BiGANInference(GANInference):
     super(GANInference, self).__init__(latent_vars, data)
 
   def build_loss_and_gradients(self, var_list):
+    # TODO
     x_true = list(six.itervalues(self.data))[0]
     x_fake = list(six.iterkeys(self.data))[0]
 

--- a/edward/inferences/gan_inference.py
+++ b/edward/inferences/gan_inference.py
@@ -46,13 +46,18 @@ class GANInference(VariationalInference):
       data: dict.
         Data dictionary which binds observed variables (of type
         `RandomVariable` or `tf.Tensor`) to their realizations (of
-        type `tf.Tensor`).  It can also bind placeholders (of type
+        type `tf.Tensor`). It can also bind placeholders (of type
         `tf.Tensor`) used in the model to their realizations.
       discriminator: function.
         Function (with parameters) to discriminate samples. It should
         output logit probabilities (real-valued) and not probabilities
         in $[0, 1]$.
     """
+    if len([key for key in six.iterkeys(data)
+            if not isinstance(key, tf.Tensor) or (isinstance(key,
+            tf.Tensor) and not "Placeholder" in key.op.type)]) != 1:
+      raise TypeError("data must have exactly one key that is not a "
+                      "`tf.placeholder`.")
     if not callable(discriminator):
       raise TypeError("discriminator must be a callable function.")
 
@@ -111,6 +116,7 @@ class GANInference(VariationalInference):
       self.summarize = tf.summary.merge_all(key=self._summary_key)
 
   def build_loss_and_gradients(self, var_list):
+    # TODO
     x_true = list(six.itervalues(self.data))[0]
     x_fake = list(six.iterkeys(self.data))[0]
     with tf.variable_scope("Disc"):

--- a/edward/inferences/gibbs.py
+++ b/edward/inferences/gibbs.py
@@ -49,6 +49,7 @@ class Gibbs(MonteCarlo):
 
     self.proposal_vars = proposal_vars
     super(Gibbs, self).__init__(latent_vars, data)
+    # TODO what to need here?
 
   def initialize(self, scan_order='random', *args, **kwargs):
     """Initialize inference algorithm. It initializes hyperparameters

--- a/edward/inferences/hmc.py
+++ b/edward/inferences/hmc.py
@@ -46,6 +46,9 @@ class HMC(MonteCarlo):
   """
   def __init__(self, *args, **kwargs):
     super(HMC, self).__init__(*args, **kwargs)
+    # TODO
+    check_latent_vars_densities(latent_vars)
+    check_data_densities(data)
 
   def initialize(self, step_size=0.25, n_steps=2, *args, **kwargs):
     """Initialize inference algorithm. It initializes hyperparameters

--- a/edward/inferences/implicit_klqp.py
+++ b/edward/inferences/implicit_klqp.py
@@ -79,6 +79,8 @@ class ImplicitKLqp(GANInference):
     self.global_vars = global_vars
     # call grandparent's method; avoid parent (GANInference)
     super(GANInference, self).__init__(latent_vars, data)
+    # TODO
+    check_latent_vars_densities(global_vars)
 
   def initialize(self, ratio_loss='log', *args, **kwargs):
     """Initialize inference algorithm. It initializes hyperparameters

--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -43,6 +43,9 @@ class KLpq(VariationalInference):
   """
   def __init__(self, *args, **kwargs):
     super(KLpq, self).__init__(*args, **kwargs)
+    # TODO
+    check_latent_vars_densities(latent_vars)
+    check_data_densities(data)
 
   def initialize(self, n_samples=1, *args, **kwargs):
     """Initialize inference algorithm. It initializes hyperparameters

--- a/edward/inferences/klqp.py
+++ b/edward/inferences/klqp.py
@@ -49,6 +49,9 @@ class KLqp(VariationalInference):
   """
   def __init__(self, *args, **kwargs):
     super(KLqp, self).__init__(*args, **kwargs)
+    # TODO
+    check_latent_vars_densities(latent_vars)
+    check_data_densities(data)
 
   def initialize(self, n_samples=1, kl_scaling=None, *args, **kwargs):
     """Initialize inference algorithm. It initializes hyperparameters
@@ -137,6 +140,7 @@ class ReparameterizationKLqp(VariationalInference):
   """
   def __init__(self, *args, **kwargs):
     super(ReparameterizationKLqp, self).__init__(*args, **kwargs)
+    # TODO
 
   def initialize(self, n_samples=1, *args, **kwargs):
     """Initialize inference algorithm. It initializes hyperparameters

--- a/edward/inferences/map.py
+++ b/edward/inferences/map.py
@@ -108,6 +108,9 @@ class MAP(VariationalInference):
                           "PointMass random variables.")
 
     super(MAP, self).__init__(latent_vars, data)
+    # TODO
+    check_latent_vars_densities(latent_vars)
+    check_data_densities(data)
 
   def build_loss_and_gradients(self, var_list):
     """Build loss function. Its automatic differentiation

--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -59,6 +59,24 @@ def check_data(data):
       raise TypeError("Data key has an invalid type: {}".format(type(key)))
 
 
+def check_data_densities(latent_vars):
+  """Check that dictionary is collection of ed.RandomVariable
+  key-value pairs with `_log_prob` implemented."""
+  for key, value in six.iteritems(dictionary):
+    valid_key = (isinstance(key, tf.Tensor) and "Placeholder" in key.op.type) or \
+        (isinstance(key, RandomVariable) and hasattr(key, '_log_prob'))
+    if not valid_key:
+      raise TypeError("Dictionary key must be a ed.RandomVariable with "
+                      "the `_log_prob` method implemented")
+    elif not isinstance(value, RandomVariable) or not hasattr(value, '_log_prob'):
+      raise TypeError("Dictionary value must be a ed.RandomVariable with "
+                      "the `_log_prob` method implemented")
+  for key in six.iterkeys(data):
+    if isinstance(key, tf.Tensor) and not "Placeholder" in key.op.type:
+      raise TypeError("Data key must be a ed.RandomVariable object or "
+                      "tf.placeholder object.")
+
+
 def check_latent_vars(latent_vars):
   """Check that the latent variable dictionary passed during inference and
   criticism is valid.
@@ -79,6 +97,18 @@ def check_latent_vars(latent_vars):
     elif key.dtype != value.dtype:
       raise TypeError("Key-value pair in latent_vars does not have same "
                       "dtype: {}, {}".format(key.dtype, value.dtype))
+
+
+def check_latent_vars_densities(latent_vars):
+  """Check that dictionary is collection of ed.RandomVariable
+  key-value pairs with `_log_prob` implemented."""
+  for key, value in six.iteritems(dictionary):
+    if not isinstance(key, RandomVariable) or not hasattr(key, '_log_prob'):
+      raise TypeError("Dictionary key must be a ed.RandomVariable with "
+                      "the `_log_prob` method implemented")
+    elif not isinstance(value, RandomVariable) or not hasattr(value, '_log_prob'):
+      raise TypeError("Dictionary value must be a ed.RandomVariable with "
+                      "the `_log_prob` method implemented")
 
 
 def _copy_default(x, *args, **kwargs):


### PR DESCRIPTION
For example, we raise an error when instantiating an inference object that assumes explicit densities and the passed-in objects don't have a `_log_prob` method.

I was working on this until I started to wonder if we should continue doing this. Maybe we should throw away most of our static checking (#188, #198, #213) and follow the spirit of duck typing.