### PR TITLE
Explicitly track constrained and unconstrained versions of transformed variables

### DIFF
--- a/edward/inferences/hmc.py
+++ b/edward/inferences/hmc.py
@@ -73,13 +73,25 @@ class HMC(MonteCarlo):
     The updates assume each Empirical random variable is directly
     parameterized by `tf.Variable`s.
     """
-    old_sample = {z: tf.gather(qz.params, tf.maximum(self.t - 1, 0))
-                  for z, qz in six.iteritems(self.latent_vars)}
+
+    # Gather the initial state, transformed to unconstrained space.
+    try:
+      self.latent_vars_unconstrained
+    except:
+      raise ValueError("This implementation of HMC requires that all "
+                       "variables have unconstrained support. Please "
+                       "initialize with auto_transform=True to ensure "
+                       "this. (if your variables already have unconstrained "
+                       "support then doing this is a no-op).")
+    old_sample = {z_unconstrained:
+                  tf.gather(qz_unconstrained.params, tf.maximum(self.t - 1, 0))
+                  for z_unconstrained, qz_unconstrained in
+                  six.iteritems(self.latent_vars_unconstrained)}
     old_sample = OrderedDict(old_sample)
 
     # Sample momentum.
     old_r_sample = OrderedDict()
-    for z, qz in six.iteritems(self.latent_vars):
+    for z, qz in six.iteritems(self.latent_vars_unconstrained):
       event_shape = qz.event_shape
       normal = Normal(loc=tf.zeros(event_shape, dtype=qz.dtype),
                       scale=tf.ones(event_shape, dtype=qz.dtype))
@@ -87,7 +99,8 @@ class HMC(MonteCarlo):
 
     # Simulate Hamiltonian dynamics.
     new_sample, new_r_sample = leapfrog(old_sample, old_r_sample,
-                                        self.step_size, self._log_joint,
+                                        self.step_size,
+                                        self._log_joint_unconstrained,
                                         self.n_steps)
 
     # Calculate acceptance ratio.
@@ -95,8 +108,8 @@ class HMC(MonteCarlo):
                            for r in six.itervalues(old_r_sample)])
     ratio -= tf.reduce_sum([0.5 * tf.reduce_sum(tf.square(r))
                             for r in six.itervalues(new_r_sample)])
-    ratio += self._log_joint(new_sample)
-    ratio -= self._log_joint(old_sample)
+    ratio += self._log_joint_unconstrained(new_sample)
+    ratio -= self._log_joint_unconstrained(old_sample)
 
     # Accept or reject sample.
     u = Uniform(low=tf.constant(0.0, dtype=ratio.dtype),
@@ -108,18 +121,50 @@ class HMC(MonteCarlo):
       # `tf.cond` returns tf.Tensor if output is a list of size 1.
       sample_values = [sample_values]
 
-    sample = {z: sample_value for z, sample_value in
+    sample = {z_unconstrained: sample_value for
+              z_unconstrained, sample_value in
               zip(six.iterkeys(new_sample), sample_values)}
 
     # Update Empirical random variables.
     assign_ops = []
-    for z, qz in six.iteritems(self.latent_vars):
-      variable = qz.get_variables()[0]
-      assign_ops.append(tf.scatter_update(variable, self.t, sample[z]))
+    for z_unconstrained, qz_unconstrained in six.iteritems(
+        self.latent_vars_unconstrained):
+      variable = qz_unconstrained.get_variables()[0]
+      assign_ops.append(tf.scatter_update(
+          variable, self.t, sample[z_unconstrained]))
 
     # Increment n_accept (if accepted).
     assign_ops.append(self.n_accept.assign_add(tf.where(accept, 1, 0)))
     return tf.group(*assign_ops)
+
+  def _log_joint_unconstrained(self, z_sample):
+    """
+    Given a sample in unconstrained latent space, transform it back into 
+    the original space, and compute the log joint density with appropriate
+    Jacobian correction.
+    """
+
+    unconstrained_to_z = {v: k for (k, v) in self.transformations.items()}
+
+    # transform all samples back into the original (potentially
+    # constrained) space.
+    z_sample_transformed = {}
+    log_det_jacobian = 0.0
+    for z_unconstrained, qz_unconstrained in z_sample.items():
+      z = (unconstrained_to_z[z_unconstrained] 
+           if z_unconstrained in unconstrained_to_z 
+           else z_unconstrained)
+
+      try:
+        bij = self.transformations[z].bijector
+        z_sample_transformed[z] = bij.inverse(qz_unconstrained)
+        log_det_jacobian += tf.reduce_sum(
+          bij.inverse_log_det_jacobian(qz_unconstrained))
+      except: # if z not in self.transformations, 
+              # or is not a TransformedDist w/ bijector
+        z_sample_transformed[z] = qz_unconstrained
+
+    return self._log_joint(z_sample_transformed) + log_det_jacobian
 
   def _log_joint(self, z_sample):
     """Utility function to calculate model's log joint density,
@@ -133,6 +178,7 @@ class HMC(MonteCarlo):
     # Form dictionary in order to replace conditioning on prior or
     # observed variable with conditioning on a specific value.
     dict_swap = z_sample.copy()
+
     for x, qx in six.iteritems(self.data):
       if isinstance(x, RandomVariable):
         if isinstance(qx, RandomVariable):

--- a/tests/inferences/test_inference_auto_transform.py
+++ b/tests/inferences/test_inference_auto_transform.py
@@ -107,7 +107,7 @@ class test_inference_auto_transform_class(tf.test.TestCase):
 
       # Check approximation on constrained space has same mode as
       # target distribution.
-      qx = inference.latent_vars[x]      
+      qx = inference.latent_vars[x]
       stats = sess.run([x.mode(), qx.mean()])
       self.assertAllClose(stats[0], stats[1], rtol=1e-5, atol=1e-5)
 
@@ -127,7 +127,7 @@ class test_inference_auto_transform_class(tf.test.TestCase):
 
       # Check approximation on constrained space has same moments as
       # target distribution.
-      n_samples = 10000      
+      n_samples = 10000
       x_unconstrained = inference.transformations[x]
       qx_constrained_params = x_unconstrained.bijector.inverse(qx.params)
       x_mean, x_var = tf.nn.moments(x.sample(n_samples), 0)
@@ -144,8 +144,7 @@ class test_inference_auto_transform_class(tf.test.TestCase):
       x.support = 'nonnegative'
 
       inference = ed.HMC([x])
-      inference.initialize(auto_transform=True, 
-                           step_size=0.8)
+      inference.initialize(auto_transform=True, step_size=0.8)
       tf.global_variables_initializer().run()
       for _ in range(inference.n_iter):
         info_dict = inference.update()

--- a/tests/inferences/test_inference_auto_transform.py
+++ b/tests/inferences/test_inference_auto_transform.py
@@ -7,7 +7,7 @@ import numpy as np
 import tensorflow as tf
 
 from edward.models import (Empirical, Gamma, Normal, PointMass,
-                           TransformedDistribution)
+                           TransformedDistribution, Beta, Bernoulli)
 from edward.util import transform
 from tensorflow.contrib.distributions import bijectors
 
@@ -107,7 +107,7 @@ class test_inference_auto_transform_class(tf.test.TestCase):
 
       # Check approximation on constrained space has same mode as
       # target distribution.
-      qx = inference.latent_vars[x]
+      qx = inference.latent_vars[x]      
       stats = sess.run([x.mode(), qx.mean()])
       self.assertAllClose(stats[0], stats[1], rtol=1e-5, atol=1e-5)
 
@@ -127,11 +127,11 @@ class test_inference_auto_transform_class(tf.test.TestCase):
 
       # Check approximation on constrained space has same moments as
       # target distribution.
-      n_samples = 10000
+      n_samples = 10000      
       x_unconstrained = inference.transformations[x]
-      qx_constrained = Empirical(x_unconstrained.bijector.inverse(qx.params))
+      qx_constrained_params = x_unconstrained.bijector.inverse(qx.params)
       x_mean, x_var = tf.nn.moments(x.sample(n_samples), 0)
-      qx_mean, qx_var = tf.nn.moments(qx_constrained.params[500:], 0)
+      qx_mean, qx_var = tf.nn.moments(qx_constrained_params[500:], 0)
       stats = sess.run([x_mean, qx_mean, x_var, qx_var])
       self.assertAllClose(stats[0], stats[1], rtol=1e-1, atol=1e-1)
       self.assertAllClose(stats[2], stats[3], rtol=1e-1, atol=1e-1)
@@ -144,7 +144,8 @@ class test_inference_auto_transform_class(tf.test.TestCase):
       x.support = 'nonnegative'
 
       inference = ed.HMC([x])
-      inference.initialize(auto_transform=True, step_size=0.8)
+      inference.initialize(auto_transform=True, 
+                           step_size=0.8)
       tf.global_variables_initializer().run()
       for _ in range(inference.n_iter):
         info_dict = inference.update()
@@ -152,15 +153,67 @@ class test_inference_auto_transform_class(tf.test.TestCase):
 
       # Check approximation on constrained space has same moments as
       # target distribution.
-      n_samples = 10000
-      x_unconstrained = inference.transformations[x]
-      qx = inference.latent_vars[x_unconstrained]
-      qx_constrained = Empirical(x_unconstrained.bijector.inverse(qx.params))
+      n_samples = 1000
+      qx_constrained = inference.latent_vars[x]
       x_mean, x_var = tf.nn.moments(x.sample(n_samples), 0)
       qx_mean, qx_var = tf.nn.moments(qx_constrained.params[500:], 0)
       stats = sess.run([x_mean, qx_mean, x_var, qx_var])
       self.assertAllClose(stats[0], stats[1], rtol=1e-1, atol=1e-1)
       self.assertAllClose(stats[2], stats[3], rtol=1e-1, atol=1e-1)
+
+  def test_hmc_betabernoulli(self):
+    """Do we correctly handle dependencies of transformed variables?"""
+
+    with self.test_session() as sess:
+      # model
+      z = Beta(1., 1., name="z")
+      xs = Bernoulli(probs=z, sample_shape=10)
+      x_obs = np.asarray([0, 0, 1, 1, 0, 0, 0, 0, 0, 1], dtype=np.int32)
+
+      # inference
+      qz_samples = tf.Variable(tf.random_uniform(shape=(1000,)))
+      qz = ed.models.Empirical(params=qz_samples, name="z_posterior")
+      inference_hmc = ed.inferences.HMC({z: qz}, data={xs: x_obs})
+      inference_hmc.run(step_size=1.0, n_steps=5, auto_transform=True)
+
+      # check that inferred posterior mean/variance is close to
+      # that of the exact Beta posterior
+      z_unconstrained = inference_hmc.transformations[z]
+      qz_constrained = z_unconstrained.bijector.inverse(qz_samples)
+      qz_mean, qz_var = sess.run(tf.nn.moments(qz_constrained, 0))
+
+      true_posterior = Beta(1. + np.sum(x_obs), 1. + np.sum(1-x_obs))      
+      pz_mean, pz_var = sess.run((true_posterior.mean(),
+                                  true_posterior.variance()))
+      self.assertAllClose(qz_mean, pz_mean, rtol=5e-2, atol=5e-2)
+      self.assertAllClose(qz_var, pz_var, rtol=1e-2, atol=1e-2)
+
+  def test_klqp_betabernoulli(self):
+    with self.test_session() as sess:
+      # model
+      z = Beta(1., 1., name="z")
+      xs = Bernoulli(probs=z, sample_shape=10)
+      x_obs = np.asarray([0, 0, 1, 1, 0, 0, 0, 0, 0, 1], dtype=np.int32)
+
+      # inference
+      qz_mean = tf.get_variable("qz_mean",
+                                initializer=tf.random_normal(()))
+      qz_std = tf.nn.softplus(tf.get_variable(name="qz_prestd",
+                                              initializer=tf.random_normal(())))
+      qz_unconstrained = ed.models.Normal(loc=qz_mean, scale=qz_std, name="z_posterior")
+
+      inference_klqp = ed.inferences.KLqp({z: qz_unconstrained}, data={xs: x_obs})
+      inference_klqp.run(n_iter=500, auto_transform=True)
+
+      z_unconstrained = inference_klqp.transformations[z]
+      qz_constrained = z_unconstrained.bijector.inverse(qz_unconstrained.sample(1000))
+      qz_mean, qz_var = sess.run(tf.nn.moments(qz_constrained, 0))
+
+      true_posterior = Beta(np.sum(x_obs) + 1., np.sum(1-x_obs) + 1.)
+      pz_mean, pz_var = sess.run((true_posterior.mean(),
+                                  true_posterior.variance()))
+      self.assertAllClose(qz_mean, pz_mean, rtol=5e-2, atol=5e-2)
+      self.assertAllClose(qz_var, pz_var, rtol=1e-2, atol=1e-2)
 
 if __name__ == '__main__':
   ed.set_seed(124125)


### PR DESCRIPTION
This is a proposed fix to https://github.com/blei-lab/edward/issues/807 (Automated transformations break log_joint computation). It:

- modifies the `auto_transform` section of `inference.initialize` to maintain two dicts with clear semantics: `latent_vars` maps the original `z`s to `qz`s with matching support (possibly constructed as a transformation of an unconstrained `qz`), while `latent_vars_unconstrained` guarantees to contain versions of the `z`s and `qz`s supported over an unconstrained space. This ensures that any inference method that looks at `latent_vars` to compute a log joint will correctly substitute `z`s with `qzs` in the same space. 
- Updates HMC to wrap the `log_joint` computation by explicitly transforming back into the original (potentially constrained) latent space. I believe HMC needs special attention to work in the unconstrained space because it directly accesses `qz.params`; other inference methods that just treat `qz` as a Distribution (eg variational methods such as KLqp) should automatically do the right thing when given a `qz` having constrained support matching `z`. 
- Adds test cases for a simple beta-bernoulli model with automated transformations using HMC and KLqp.