### PR TITLE
Regularization for BiGAN, KLpq, GAN and WGAN inferences

### DIFF
--- a/edward/inferences/bigan_inference.py
+++ b/edward/inferences/bigan_inference.py
@@ -31,6 +31,9 @@ class BiGANInference(GANInference):
   encoder and decoder parameters can be accessed with the variable scope
   "Gen".
 
+  The objective function also adds to itself a summation over all tensors
+  in the `REGULARIZATION_LOSSES` collection.
+
   #### Examples
 
   ```python
@@ -71,8 +74,11 @@ class BiGANInference(GANInference):
         tf.nn.sigmoid_cross_entropy_with_logits(
             labels=tf.ones_like(d_xtzf), logits=d_xtzf)
 
-    loss_d = tf.reduce_mean(loss_d)
-    loss = tf.reduce_mean(loss)
+    reg_terms_d = tf.losses.get_regularization_losses(scope="Disc")
+    reg_terms = tf.losses.get_regularization_losses(scope="Gen")
+
+    loss_d = tf.reduce_mean(loss_d) + tf.reduce_sum(reg_terms_d)
+    loss = tf.reduce_mean(loss) + tf.reduce_sum(reg_terms)
 
     var_list_d = tf.get_collection(
         tf.GraphKeys.TRAINABLE_VARIABLES, scope="Disc")

--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -45,6 +45,9 @@ class KLpq(VariationalInference):
 
   where $z^{(s)} \sim q(z; \lambda)$ and$\\beta^{(s)}
   \sim q(\\beta)$.
+
+  The objective function also adds to itself a summation over all
+  tensors in the `REGULARIZATION_LOSSES` collection.
   """
   def __init__(self, latent_vars=None, data=None):
     """Create an inference algorithm.
@@ -151,23 +154,26 @@ class KLpq(VariationalInference):
 
     p_log_prob = tf.stack(p_log_prob)
     q_log_prob = tf.stack(q_log_prob)
+    reg_penalty = tf.reduce_sum(tf.losses.get_regularization_losses())
 
     if self.logging:
       tf.summary.scalar("loss/p_log_prob", tf.reduce_mean(p_log_prob),
                         collections=[self._summary_key])
       tf.summary.scalar("loss/q_log_prob", tf.reduce_mean(q_log_prob),
                         collections=[self._summary_key])
+      tf.summary.scalar("loss/reg_penalty", reg_penalty,
+                        collections=[self._summary_key])
 
     log_w = p_log_prob - q_log_prob
     log_w_norm = log_w - tf.reduce_logsumexp(log_w)
     w_norm = tf.exp(log_w_norm)
-    loss = tf.reduce_sum(w_norm * log_w)
+    loss = tf.reduce_sum(w_norm * log_w) - reg_penalty
 
     q_rvs = list(six.itervalues(self.latent_vars))
     q_vars = [v for v in var_list
               if len(get_descendants(tf.convert_to_tensor(v), q_rvs)) != 0]
     q_grads = tf.gradients(
-        -tf.reduce_sum(q_log_prob * tf.stop_gradient(w_norm)),
+        -(tf.reduce_sum(q_log_prob * tf.stop_gradient(w_norm)) - reg_penalty),
         q_vars)
     p_vars = [v for v in var_list if v not in q_vars]
     p_grads = tf.gradients(-loss, p_vars)


### PR DESCRIPTION
Adds regularization in the loss functions for BiGAN, KLpq, GAN and WGAN inferences. This makes further progress towards fixing #529.
  