### PR TITLE
Added check and test for n_samples in klpq, klqp

### DIFF
--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -91,6 +91,8 @@ class KLpq(VariationalInference):
         Number of samples from variational model for calculating
         stochastic gradients.
     """
+    if n_samples <= 0:
+	raise ValueError("n_samples should be greater than zero: {}".format(n_samples))
     self.n_samples = n_samples
     return super(KLpq, self).initialize(*args, **kwargs)
 

--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -93,7 +93,7 @@ class KLpq(VariationalInference):
     """
     if n_samples <= 0:
       raise ValueError(
-           "n_samples should be greater than zero: {}".format(n_samples))
+          "n_samples should be greater than zero: {}".format(n_samples))
     self.n_samples = n_samples
     return super(KLpq, self).initialize(*args, **kwargs)
 

--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -92,7 +92,7 @@ class KLpq(VariationalInference):
         stochastic gradients.
     """
     if n_samples <= 0:
-	raise ValueError("n_samples should be greater than zero: {}".format(n_samples))
+        raise ValueError("n_samples should be greater than zero: {}".format(n_samples))
     self.n_samples = n_samples
     return super(KLpq, self).initialize(*args, **kwargs)
 

--- a/edward/inferences/klpq.py
+++ b/edward/inferences/klpq.py
@@ -92,7 +92,8 @@ class KLpq(VariationalInference):
         stochastic gradients.
     """
     if n_samples <= 0:
-        raise ValueError("n_samples should be greater than zero: {}".format(n_samples))
+      raise ValueError(
+           "n_samples should be greater than zero: {}".format(n_samples))
     self.n_samples = n_samples
     return super(KLpq, self).initialize(*args, **kwargs)
 

--- a/edward/inferences/klqp.py
+++ b/edward/inferences/klqp.py
@@ -104,6 +104,9 @@ class KLqp(VariationalInference):
     """
     if kl_scaling is None:
       kl_scaling = {}
+    if n_samples <= 0:
+      raise ValueError(
+          "n_samples should be greater than zero: {}".format(n_samples))
 
     self.n_samples = n_samples
     self.kl_scaling = kl_scaling
@@ -213,6 +216,9 @@ class ReparameterizationKLqp(VariationalInference):
         Number of samples from variational model for calculating
         stochastic gradients.
     """
+    if n_samples <= 0:
+      raise ValueError(
+          "n_samples should be greater than zero: {}".format(n_samples))
     self.n_samples = n_samples
     return super(ReparameterizationKLqp, self).initialize(*args, **kwargs)
 
@@ -285,6 +291,9 @@ class ReparameterizationKLKLqp(VariationalInference):
     """
     if kl_scaling is None:
       kl_scaling = {}
+    if n_samples <= 0:
+      raise ValueError(
+          "n_samples should be greater than zero: {}".format(n_samples))
 
     self.n_samples = n_samples
     self.kl_scaling = kl_scaling
@@ -347,6 +356,9 @@ class ReparameterizationEntropyKLqp(VariationalInference):
         Number of samples from variational model for calculating
         stochastic gradients.
     """
+    if n_samples <= 0:
+      raise ValueError(
+          "n_samples should be greater than zero: {}".format(n_samples))
     self.n_samples = n_samples
     return super(ReparameterizationEntropyKLqp, self).initialize(
         *args, **kwargs)
@@ -408,6 +420,9 @@ class ScoreKLqp(VariationalInference):
         Number of samples from variational model for calculating
         stochastic gradients.
     """
+    if n_samples <= 0:
+      raise ValueError(
+          "n_samples should be greater than zero: {}".format(n_samples))
     self.n_samples = n_samples
     return super(ScoreKLqp, self).initialize(*args, **kwargs)
 
@@ -480,7 +495,9 @@ class ScoreKLKLqp(VariationalInference):
     """
     if kl_scaling is None:
       kl_scaling = {}
-
+    if n_samples <= 0:
+      raise ValueError(
+          "n_samples should be greater than zero: {}".format(n_samples))
     self.n_samples = n_samples
     self.kl_scaling = kl_scaling
     return super(ScoreKLKLqp, self).initialize(*args, **kwargs)
@@ -542,6 +559,9 @@ class ScoreEntropyKLqp(VariationalInference):
         Number of samples from variational model for calculating
         stochastic gradients.
     """
+    if n_samples <= 0:
+      raise ValueError(
+          "n_samples should be greater than zero: {}".format(n_samples))
     self.n_samples = n_samples
     return super(ScoreEntropyKLqp, self).initialize(*args, **kwargs)
 
@@ -609,6 +629,9 @@ class ScoreRBKLqp(VariationalInference):
         Number of samples from variational model for calculating
         stochastic gradients.
     """
+    if n_samples <= 0:
+      raise ValueError(
+          "n_samples should be greater than zero: {}".format(n_samples))
     self.n_samples = n_samples
     return super(ScoreRBKLqp, self).initialize(*args, **kwargs)
 

--- a/tests/inferences/klpq_test.py
+++ b/tests/inferences/klpq_test.py
@@ -64,6 +64,10 @@ class test_klpq_class(tf.test.TestCase):
     self._test_normal_normal(ed.KLpq, default=True, n_samples=25, n_iter=100)
     self._test_model_parameter(ed.KLpq, n_iter=50)
 
+  def test_klpq_nsamples_check(self):
+    with self.assertRaisesRegexp(ValueError, "n_samples should be greater than zero: 0"):
+	self._test_normal_normal(ed.KLpq, default=True, n_samples=0, n_iter=10)
+
 if __name__ == '__main__':
   ed.set_seed(42)
   tf.test.main()

--- a/tests/inferences/klpq_test.py
+++ b/tests/inferences/klpq_test.py
@@ -65,8 +65,9 @@ class test_klpq_class(tf.test.TestCase):
     self._test_model_parameter(ed.KLpq, n_iter=50)
 
   def test_klpq_nsamples_check(self):
-    with self.assertRaisesRegexp(ValueError, "n_samples should be greater than zero: 0"):
-	self._test_normal_normal(ed.KLpq, default=True, n_samples=0, n_iter=10)
+    with self.assertRaisesRegexp(ValueError,
+                                 "n_samples should be greater than zero: 0"):
+      self._test_normal_normal(ed.KLpq, default=True, n_samples=0, n_iter=10)
 
 if __name__ == '__main__':
   ed.set_seed(42)

--- a/tests/inferences/klqp_test.py
+++ b/tests/inferences/klqp_test.py
@@ -60,6 +60,18 @@ class test_klqp_class(tf.test.TestCase):
     self._test_normal_normal(ed.KLqp, default=True, n_iter=5000)
     self._test_model_parameter(ed.KLqp, n_iter=50)
 
+  def test_klqp_nsamples_check(self):
+    with self.assertRaisesRegexp(ValueError,
+                                 "n_samples should be greater than zero: 0"):
+      self._test_normal_normal(ed.KLqp, default=True, n_samples=0, n_iter=10)
+      self._test_normal_normal(ed.ReparameterizationEntropyKLqp, default=True, n_samples=0, n_iter=10)
+      self._test_normal_normal(ed.ReparameterizationKLqp, default=True, n_samples=0, n_iter=10)
+      self._test_normal_normal(ed.ReparameterizationKLKLqp, default=True, n_samples=0, n_iter=10)
+      self._test_normal_normal(ed.ScoreEntropyKLqp, default=True, n_samples=0, n_iter=10)
+      self._test_normal_normal(ed.ScoreKLqp, default=True, n_samples=0, n_iter=10)
+      self._test_normal_normal(ed.ScoreKLKLqp, default=True, n_samples=0, n_iter=10)
+      self._test_normal_normal(ed.ScoreRBKLqp, default=True, n_samples=0, n_iter=10)
+
   def test_reparameterization_entropy_klqp(self):
     self._test_normal_normal(
         ed.ReparameterizationEntropyKLqp, default=False, n_iter=5000)

--- a/tests/inferences/klqp_test.py
+++ b/tests/inferences/klqp_test.py
@@ -64,20 +64,20 @@ class test_klqp_class(tf.test.TestCase):
     with self.assertRaisesRegexp(ValueError,
                                  "n_samples should be greater than zero: 0"):
       self._test_normal_normal(ed.KLqp, default=True, n_samples=0, n_iter=10)
-      self._test_normal_normal(
-          ed.ReparameterizationEntropyKLqp, default=True, n_samples=0, n_iter=10)
-      self._test_normal_normal(
-          ed.ReparameterizationKLqp, default=True, n_samples=0, n_iter=10)
-      self._test_normal_normal(
-          ed.ReparameterizationKLKLqp, default=True, n_samples=0, n_iter=10)
-      self._test_normal_normal(
-          ed.ScoreEntropyKLqp, default=True, n_samples=0, n_iter=10)
-      self._test_normal_normal(
-          ed.ScoreKLqp, default=True, n_samples=0, n_iter=10)
-      self._test_normal_normal(
-          ed.ScoreKLKLqp, default=True, n_samples=0, n_iter=10)
-      self._test_normal_normal(
-          ed.ScoreRBKLqp, default=True, n_samples=0, n_iter=10)
+      self._test_normal_normal(ed.ReparameterizationEntropyKLqp,
+          default=True, n_samples=0, n_iter=10)
+      self._test_normal_normal(ed.ReparameterizationKLqp,
+          default=True, n_samples=0, n_iter=10)
+      self._test_normal_normal(ed.ReparameterizationKLKLqp,
+          default=True, n_samples=0, n_iter=10)
+      self._test_normal_normal(ed.ScoreEntropyKLqp,
+          default=True, n_samples=0, n_iter=10)
+      self._test_normal_normal(ed.ScoreKLqp,
+          default=True, n_samples=0, n_iter=10)
+      self._test_normal_normal(ed.ScoreKLKLqp,
+          default=True, n_samples=0, n_iter=10)
+      self._test_normal_normal(ed.ScoreRBKLqp,
+          default=True, n_samples=0, n_iter=10)
 
   def test_reparameterization_entropy_klqp(self):
     self._test_normal_normal(

--- a/tests/inferences/klqp_test.py
+++ b/tests/inferences/klqp_test.py
@@ -65,19 +65,19 @@ class test_klqp_class(tf.test.TestCase):
                                  "n_samples should be greater than zero: 0"):
       self._test_normal_normal(ed.KLqp, default=True, n_samples=0, n_iter=10)
       self._test_normal_normal(ed.ReparameterizationEntropyKLqp,
-          default=True, n_samples=0, n_iter=10)
+                               default=True, n_samples=0, n_iter=10)
       self._test_normal_normal(ed.ReparameterizationKLqp,
-          default=True, n_samples=0, n_iter=10)
+                               default=True, n_samples=0, n_iter=10)
       self._test_normal_normal(ed.ReparameterizationKLKLqp,
-          default=True, n_samples=0, n_iter=10)
+                               default=True, n_samples=0, n_iter=10)
       self._test_normal_normal(ed.ScoreEntropyKLqp,
-          default=True, n_samples=0, n_iter=10)
+                               default=True, n_samples=0, n_iter=10)
       self._test_normal_normal(ed.ScoreKLqp,
-          default=True, n_samples=0, n_iter=10)
+                               default=True, n_samples=0, n_iter=10)
       self._test_normal_normal(ed.ScoreKLKLqp,
-          default=True, n_samples=0, n_iter=10)
+                               default=True, n_samples=0, n_iter=10)
       self._test_normal_normal(ed.ScoreRBKLqp,
-          default=True, n_samples=0, n_iter=10)
+                               default=True, n_samples=0, n_iter=10)
 
   def test_reparameterization_entropy_klqp(self):
     self._test_normal_normal(

--- a/tests/inferences/klqp_test.py
+++ b/tests/inferences/klqp_test.py
@@ -64,13 +64,20 @@ class test_klqp_class(tf.test.TestCase):
     with self.assertRaisesRegexp(ValueError,
                                  "n_samples should be greater than zero: 0"):
       self._test_normal_normal(ed.KLqp, default=True, n_samples=0, n_iter=10)
-      self._test_normal_normal(ed.ReparameterizationEntropyKLqp, default=True, n_samples=0, n_iter=10)
-      self._test_normal_normal(ed.ReparameterizationKLqp, default=True, n_samples=0, n_iter=10)
-      self._test_normal_normal(ed.ReparameterizationKLKLqp, default=True, n_samples=0, n_iter=10)
-      self._test_normal_normal(ed.ScoreEntropyKLqp, default=True, n_samples=0, n_iter=10)
-      self._test_normal_normal(ed.ScoreKLqp, default=True, n_samples=0, n_iter=10)
-      self._test_normal_normal(ed.ScoreKLKLqp, default=True, n_samples=0, n_iter=10)
-      self._test_normal_normal(ed.ScoreRBKLqp, default=True, n_samples=0, n_iter=10)
+      self._test_normal_normal(
+          ed.ReparameterizationEntropyKLqp, default=True, n_samples=0, n_iter=10)
+      self._test_normal_normal(
+          ed.ReparameterizationKLqp, default=True, n_samples=0, n_iter=10)
+      self._test_normal_normal(
+          ed.ReparameterizationKLKLqp, default=True, n_samples=0, n_iter=10)
+      self._test_normal_normal(
+          ed.ScoreEntropyKLqp, default=True, n_samples=0, n_iter=10)
+      self._test_normal_normal(
+          ed.ScoreKLqp, default=True, n_samples=0, n_iter=10)
+      self._test_normal_normal(
+          ed.ScoreKLKLqp, default=True, n_samples=0, n_iter=10)
+      self._test_normal_normal(
+          ed.ScoreRBKLqp, default=True, n_samples=0, n_iter=10)
 
   def test_reparameterization_entropy_klqp(self):
     self._test_normal_normal(


### PR DESCRIPTION

This Pull Request adds a check and a test to ensure that the `n_samples` parameter in klpq inference is always greater than zero.
Prior to this PR, passing `n_samples <= 0` throws the following error in tensorflow:

```
/usr/local/lib/python3.6/importlib/_bootstrap.py:205: RuntimeWarning: compiletime version 3.5 of module 'tensorflow.python.framework.fast_tensor_util' does not match runtime version 3.6
  return f(*args, **kwds)
2018-02-02 12:44:04.090261: I tensorflow/core/platform/cpu_feature_guard.cc:137] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA

Traceback (most recent call last):
  File "/home/ubuntu/klpq.py", line 15, in <module>
    inference.run(n_samples=0)
  File "/usr/local/lib/python3.6/site-packages/edward/inferences/inference.py", line 123, in run
    self.initialize(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/edward/inferences/klpq.py", line 57, in initialize
    return super(KLpq, self).initialize(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/edward/inferences/variational_inference.py", line 121, in initialize
    global_step=global_step)
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/training/optimizer.py", line 472, in apply_gradients
    ([str(v) for _, _, v in converted_grads_and_vars],))
ValueError: No gradients provided for any variable: ['<tensorflow.python.training.optimizer._RefVariableProcessor object at 0x7fc9945f3a20>', '<tensorflow.python.training.optimizer._RefVariableProcessor object at 0x7fc9945f3a58>', '<tensorflow.python.training.optimizer._RefVariableProcessor object at 0x7fc9945f3b00>', '<tensorflow.python.training.optimizer._RefVariableProcessor object at 0x7fc9945f3b38>'].
```