### PR TITLE
[DOC]: fix typo in the number of iterations in supervised_classification notebook

### DIFF
--- a/notebooks/supervised_classification.ipynb
+++ b/notebooks/supervised_classification.ipynb
@@ -196,7 +196,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Run variational inference for `500` iterations."
+    "Run variational inference for `5000` iterations."
    ]
   },
   {


### PR DESCRIPTION
The actual number used in the notebook is `5000` instead of `500`.