### PR TITLE
Fix errors in ReplicaExchangeMC

### DIFF
--- a/edward/inferences/monte_carlo.py
+++ b/edward/inferences/monte_carlo.py
@@ -78,7 +78,8 @@ class MonteCarlo(Inference):
     if isinstance(latent_vars, list):
       with tf.variable_scope(None, default_name="posterior"):
         latent_vars = {z: Empirical(params=tf.Variable(tf.zeros(
-            [1e4] + z.batch_shape.concatenate(z.event_shape).as_list())))
+            [1e4] + z.batch_shape.concatenate(z.event_shape).as_list(),
+            dtype=z.dtype)))
             for z in latent_vars}
     elif isinstance(latent_vars, dict):
       for qz in six.itervalues(latent_vars):

--- a/edward/inferences/replica_exchange_mc.py
+++ b/edward/inferences/replica_exchange_mc.py
@@ -59,8 +59,8 @@ class ReplicaExchangeMC(MonteCarlo):
     self.n_replica = len(inverse_temperatures)
     if inverse_temperatures[0] != 1:
       raise ValueError("inverse_temperatures[0] must be 1.")
-    self.inverse_temperatures = tf.constant(
-        inverse_temperatures, dtype=list(self.latent_vars)[0].dtype)
+    self.inverse_temperatures = tf.cast(inverse_temperatures,
+                                        dtype=list(self.latent_vars)[0].dtype)
 
     # Make replica.
     self.replica_vars = []

--- a/edward/inferences/replica_exchange_mc.py
+++ b/edward/inferences/replica_exchange_mc.py
@@ -81,7 +81,6 @@ class ReplicaExchangeMC(MonteCarlo):
     # Sample by Metropolis-Hastings for each replica.
     replica_sample = []
     replica_accept = []
-
     for i in range(self.n_replica):
       sample_, accept_ = self._mh_sample(self.replica_vars[i],
                                          self.inverse_temperatures[i])

--- a/tests/inferences/replicaexchangemc_test.py
+++ b/tests/inferences/replicaexchangemc_test.py
@@ -11,20 +11,28 @@ from edward.models import Normal, Empirical
 
 class test_metropolishastings_class(tf.test.TestCase):
 
-  def test_normalnormal_float32(self):
+  def _test_normal_normal(self, default, dtype):
     with self.test_session() as sess:
       x_data = np.array([0.0] * 50, dtype=np.float32)
 
-      mu = Normal(loc=0.0, scale=1.0)
-      x = Normal(loc=mu, scale=1.0, sample_shape=50)
+      mu = Normal(loc=tf.constant(0.0, dtype=dtype),
+                  scale=tf.constant(1.0, dtype=dtype))
+      x = Normal(loc=mu, scale=tf.constant(1.0, dtype=dtype),
+                 sample_shape=50)
 
       n_samples = 2000
-      qmu = Empirical(params=tf.Variable(tf.ones(n_samples)))
+      if not default:
+        qmu = Empirical(params=tf.Variable(tf.ones(n_samples, dtype=dtype)))
 
-      # analytic solution: N(loc=0.0, scale=\sqrt{1/51}=0.140)
-      inference = ed.ReplicaExchangeMC({mu: qmu},
-                                       {mu: mu},
-                                       data={x: x_data})
+        # analytic solution: N(loc=0.0, scale=\sqrt{1/51}=0.140)
+        inference = ed.ReplicaExchangeMC({mu: qmu},
+                                         {mu: mu},
+                                         data={x: x_data})
+      else:
+        inference = ed.ReplicaExchangeMC([mu],
+                                         {mu: mu},
+                                         data={x: x_data})
+        qmu = inference.latent_vars[mu]
       inference.run()
 
       self.assertAllClose(qmu.mean().eval(), 0, rtol=1e-1, atol=1e-1)
@@ -32,35 +40,80 @@ class test_metropolishastings_class(tf.test.TestCase):
                           rtol=1e-1, atol=1e-1)
 
       old_t, old_n_accept = sess.run([inference.t, inference.n_accept])
-      self.assertEqual(old_t, n_samples)
+      if not default:
+        self.assertEqual(old_t, n_samples)
+      else:
+        self.assertEqual(old_t, 1e4)
       self.assertGreater(old_n_accept, 0.1)
       sess.run(inference.reset)
       new_t, new_n_accept = sess.run([inference.t, inference.n_accept])
       self.assertEqual(new_t, 0)
       self.assertEqual(new_n_accept, 0)
 
-  def test_normalnormal_float64(self):
-    with self.test_session() as sess:
-      x_data = np.array([0.0] * 50, dtype=np.float32)
+  def _test_linear_regression(self, default, dtype):
+    def build_toy_dataset(N, w, noise_std=0.1):
+      D = len(w)
+      x = np.random.randn(N, D)
+      y = np.dot(x, w) + np.random.normal(0, noise_std, size=N)
+      return x, y
 
-      mu = Normal(loc=tf.constant(0.0, dtype=tf.float64),
-                  scale=tf.constant(1.0, dtype=tf.float64))
-      x = Normal(loc=mu,
-                 scale=tf.constant(1.0, dtype=tf.float64),
-                 sample_shape=50)
+    with self.test_session() as sess:
+      N = 40  # number of data points
+      D = 10  # number of features
+
+      w_true = np.random.randn(D)
+      X_train, y_train = build_toy_dataset(N, w_true)
+      X_test, y_test = build_toy_dataset(N, w_true)
+
+      X = tf.placeholder(dtype, [N, D])
+      w = Normal(loc=tf.zeros(D, dtype=dtype), scale=tf.ones(D, dtype=dtype))
+      b = Normal(loc=tf.zeros(1, dtype=dtype), scale=tf.ones(1, dtype=dtype))
+      y = Normal(loc=ed.dot(X, w) + b, scale=0.1 * tf.ones(N, dtype=dtype))
+
+      proposal_w = Normal(loc=w, scale=0.5 * tf.ones(D, dtype=dtype))
+      proposal_b = Normal(loc=b, scale=0.5 * tf.ones(1, dtype=dtype))
 
       n_samples = 2000
-      qmu = Empirical(params=tf.Variable(tf.ones(n_samples, dtype=tf.float64)))
+      if not default:
+        qw = Empirical(tf.Variable(tf.zeros([n_samples, D], dtype=dtype)))
+        qb = Empirical(tf.Variable(tf.zeros([n_samples, 1], dtype=dtype)))
 
-      # analytic solution: N(loc=0.0, scale=\sqrt{1/51}=0.140)
-      inference = ed.ReplicaExchangeMC({mu: qmu},
-                                       {mu: mu},
-                                       data={x: x_data})
+        inference = ed.ReplicaExchangeMC(
+            {w: qw, b: qb}, {w: proposal_w, b: proposal_b},
+            data={X: X_train, y: y_train})
+      else:
+        inference = ed.ReplicaExchangeMC(
+            [w, b], {w: proposal_w, b: proposal_b},
+            data={X: X_train, y: y_train})
+        qw = inference.latent_vars[w]
+        qb = inference.latent_vars[b]
       inference.run()
 
-      self.assertAllClose(qmu.mean().eval(), 0, rtol=1e-1, atol=1e-1)
-      self.assertAllClose(qmu.stddev().eval(), np.sqrt(1 / 51),
-                          rtol=1e-1, atol=1e-1)
+      self.assertAllClose(qw.mean().eval(), w_true, rtol=5e-1, atol=5e-1)
+      self.assertAllClose(qb.mean().eval(), [0.0], rtol=5e-1, atol=5e-1)
+
+      old_t, old_n_accept = sess.run([inference.t, inference.n_accept])
+      if not default:
+        self.assertEqual(old_t, n_samples)
+      else:
+        self.assertEqual(old_t, 1e4)
+      self.assertGreater(old_n_accept, 0.1)
+      sess.run(inference.reset)
+      new_t, new_n_accept = sess.run([inference.t, inference.n_accept])
+      self.assertEqual(new_t, 0)
+      self.assertEqual(new_n_accept, 0)
+
+  def test_normalnormal(self):
+    self._test_normal_normal(True, tf.float32)
+    self._test_normal_normal(False, tf.float32)
+    self._test_normal_normal(True, tf.float64)
+    self._test_normal_normal(False, tf.float64)
+
+  def test_linearregression(self):
+    self._test_linear_regression(True, tf.float32)
+    self._test_linear_regression(False, tf.float32)
+    self._test_linear_regression(True, tf.float64)
+    self._test_linear_regression(False, tf.float64)
 
 if __name__ == '__main__':
   ed.set_seed(42)


### PR DESCRIPTION
Hi.

I implemented ReplicaExchangeMC in #865. But I found some errors and fixed.

<h3>multiple latent variables</h3>

A code which use multiple latent variables does not work, and this code does not work.
```python
inference = ed.ReplicaExchangeMC({w: q_w, b: q_b}, {w: proposal_w, b:proposal_b},
                                                              data={X: X_train, y: y_train})
inference.run()
```
The cause for this is that callable which return a dict cannot be used in `tf.case`.
The error occurs in this code. In this code `replica_sample[i]` is dict. (Exceptionally, It seem that a dict which has only one variable does work.)
```python
sample_i = tf.case({tf.equal(new_replica_idx[candi], i): _stateful_lambda(
                    replica_sample[i])for i in range(self.n_replica)},
                   default=lambda: replica_sample[0], exclusive=True)
```
Therefore, I fixed this error. I implemented to calculate rates at each replica first. And `tf.case` is not used.

<h3>list for `latent_vars`</h3>

When I use a list for `latent_vars`, an error occurs.
```Python
inference = ed.ReplicaExchangeMC(latent_vars=[x],
                             proposal_vars={x: proposal_x})
inference.run()
```
In `super(ReplicaExchangeMC, self).__init__(latent_vars, data)`, `latent_vars`(list) is converted to `latent_vars`(dict). But before this, `latent_vars`(dict) is needed. I also fixed this.

Thanks