### PR TITLE
Compatibility with TF >= 1.7.0

### DIFF
--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -12,9 +12,14 @@ from edward.models.random_variables import TransformedDistribution
 from edward.models import PointMass
 from edward.util.graphs import random_variables
 from tensorflow.core.framework import attr_value_pb2
-from tensorflow.python.framework.ops import set_shapes_for_outputs
+import sys
+try:
+  from tensorflow.python.framework.ops import set_shapes_for_outputs
+except ImportError as e:
+  print('Using newer version of Tensorflow where set_shapes_for_outputs has been deprecated')
 from tensorflow.python.util import compat
 
+set_shapes_module_ = 'set_shapes_for_outputs'
 tfb = tf.contrib.distributions.bijectors
 
 
@@ -401,7 +406,7 @@ def copy(org_instance, dict_swap=None, scope="copied",
     compute_device = True
     op_type = new_name
 
-    if compute_shapes:
+    if compute_shapes and set_shapes_module_ in sys.modules:
       set_shapes_for_outputs(new_op)
     graph._record_op_seen_by_control_dependencies(new_op)
 


### PR DESCRIPTION
Follows on https://github.com/blei-lab/edward/issues/882

Specifically 

![2018-05-01-221624_1600x1668_scrot](https://user-images.githubusercontent.com/6968573/39502316-828baa78-4d8d-11e8-8d66-63ca3a04b0e4.png)

I'm assuming your comment about "just removing it" was tongue in cheek but I figured I'd give it a shot anyways

Running ```pytest tests```

I got 

```
78 failed, 248 passed, 49 warnings
```

where the relevant errors (basically anywhere there was a copy) are as follows

```

../edward/util/random_variables.py:321: in copy                                                                                                                                                  
    new_op = copy(op, dict_swap, scope, True, copy_q, False)                                                                                                                                     
../edward/util/random_variables.py:374: in copy                                                                                                                                                  
    op_def)                                                                                                                                                                                      
/home/ian/.virtualenvs/edward/lib/python3.6/site-packages/tensorflow/python/framework/ops.py:1732: in __init__                                                                                   
    op_def, inputs, node_def.attr)                                                                                                                                                               
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
                                                                                                                                                                                                 
self = <[AttributeError("'Operation' object has no attribute '_c_op'") raised in repr()] Operation object at 0x7fef20988e48>                                                                     
op_def = name: "Mul"                                                                                                                                                                             
input_arg {                                                                                                                                                                                      
  name: "x"                                                                                                                                                                                      
  type_attr: "T"                                                                                                                                                                                 
}                                                                                                                                                                                                
input_arg {                                                                                                                                                                                      
  name: "y"                                                                                                                                                                                      
  type_attr: "T"                                                                                                                                                                                 
}                                                                                                                                                                                                
output_arg {                                                                                                                                                                                     
  name:...ype: DT_INT32                                                                                                                                                                          
      type: DT_INT64 
      type: DT_COMPLEX64                                                                                                                                                               
      type: DT_COMPLEX128
    }
  }
}
is_commutative: true

inputs = [], attrs = <google.protobuf.pyext._message.MessageMapContainer object at 0x7fef153103f0>                                                                                               

    def _reconstruct_sequence_inputs(self, op_def, inputs, attrs):
      """Regroups a flat list of input tensors into scalar and sequence inputs.
    
        Args:
          op_def: The `op_def_pb2.OpDef` (for knowing the input types)
          inputs: a list of input `Tensor`s to the op.
          attrs: mapping from attr name to `attr_value_pb2.AttrValue` (these define
            how long each sequence is)
    
        Returns:
          A list of `Tensor`s (corresponding to scalar inputs) and lists of
          `Tensor`s (corresponding to sequence inputs).
        """
      grouped_inputs = []
      i = 0
      for input_arg in op_def.input_arg:
        if input_arg.number_attr:
          input_len = attrs[input_arg.number_attr].i
          is_sequence = True
        elif input_arg.type_list_attr:
          input_len = len(attrs[input_arg.type_list_attr].list.type)
          is_sequence = True
        else:
          input_len = 1
          is_sequence = False
    
        if is_sequence:
          grouped_inputs.append(inputs[i:i + input_len])
        else:
>         grouped_inputs.append(inputs[i])
E         IndexError: list index out of range

/home/ian/.virtualenvs/edward/lib/python3.6/site-packages/tensorflow/python/framework/ops.py:1803: IndexError 
```