### PR TITLE
Fix typo: 'ponts' to 'points'

### DIFF
--- a/docs/tex/tutorials/bayesian-neural-network.tex
+++ b/docs/tex/tutorials/bayesian-neural-network.tex
@@ -35,7 +35,7 @@ def neural_network(x):
     h = tf.matmul(h, W_2) + b_2
     return tf.reshape(h, [-1])
 
-N = 40  # number of data ponts
+N = 40  # number of data points
 D = 1   # number of features
 
 W_0 = Normal(loc=tf.zeros([D, 10]), scale=tf.ones([D, 10]))

--- a/notebooks/getting_started.ipynb
+++ b/notebooks/getting_started.ipynb
@@ -70,7 +70,7 @@
    "source": [
     "ed.set_seed(42)\n",
     "\n",
-    "N = 50  # number of data ponts\n",
+    "N = 50  # number of data points\n",
     "D = 1   # number of features\n",
     "\n",
     "x_train, y_train = build_toy_dataset(N)"


### PR DESCRIPTION
- Fix typo In `docs/tex/tutorials/bayesian-neural-network.tex` and `notebooks/getting_started.ipynb`.