### PR TITLE
Implementing continuous ranked probability score as metric

### DIFF
--- a/tests/criticisms/metrics_test.py
+++ b/tests/criticisms/metrics_test.py
@@ -26,6 +26,8 @@ all_regression_metrics = [
     mean_squared_logarithmic_error,
     poisson,
     cosine_proximity,
+    continuous_ranked_probability_score
+  
 ]
 
 all_specialized_input_output_metrics = [


### PR DESCRIPTION
Recently I wrote my Bachelor's Thesis and I had to use Edward in order to build Bayesian Neural Network. In the evaluation I had to use CRPS (continuous ranked probability score) but the score is not one of the metrics. I've implemented it more or less the same was as in https://github.com/TheClimateCorporation/properscoring. 

