### PR TITLE
Remove dead code.

### DIFF
--- a/edward/util/random_variables.py
+++ b/edward/util/random_variables.py
@@ -12,7 +12,6 @@ from edward.models.random_variables import TransformedDistribution
 from edward.models import PointMass
 from edward.util.graphs import random_variables
 from tensorflow.core.framework import attr_value_pb2
-from tensorflow.python.framework.ops import set_shapes_for_outputs
 from tensorflow.python.util import compat
 
 tfb = tf.contrib.distributions.bijectors
@@ -401,8 +400,6 @@ def copy(org_instance, dict_swap=None, scope="copied",
     compute_device = True
     op_type = new_name
 
-    if compute_shapes:
-      set_shapes_for_outputs(new_op)
     graph._record_op_seen_by_control_dependencies(new_op)
 
     if compute_device:


### PR DESCRIPTION
_USE_C_SHAPES has been forced True for a while now
(since TensorFlow 1.9 in June, commit: https://github.com/tensorflow/tensorflow/commit/1d74a69443f741e69f9f52cb6bc2940b4d4ae3b7)