### PR TITLE
constrain tensorflow version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ setup(
     install_requires=['numpy>=1.7',
                       'six>=1.10.0'],
     extras_require={
-        'tensorflow': ['tensorflow>=1.2.0rc0'],
-        'tensorflow with gpu': ['tensorflow-gpu>=1.2.0rc0'],
+        'tensorflow': ['tensorflow>=1.2.0rc0,<2.0.0'],
+        'tensorflow with gpu': ['tensorflow-gpu>=1.2.0rc0,<2.0.0'],
         'neural networks': ['keras>=2.0.0', 'prettytensor>=0.7.4'],
         'datasets': ['observations>=0.1.2'],
         'notebooks': ['jupyter>=1.0.0'],


### PR DESCRIPTION
When installing edward using the default method (`pip install edward`) and using the tensorflow versions specified in the setup.py (tensorflow>=1.2.0rc0), I get the following for some of the get started code:
```
ModuleNotFoundError: No module named 'tensorflow.contrib'
```

Since Tensorflow released a v2.0 that has a different API, looks like the tensorflow dependency should be constrained to be <2.0 as is done here. This seems to work as expected but https://github.com/blei-lab/edward/issues/882 is showing up when I run examples from the notebooks directory and elsewhere so perhaps this should be constrained further or that issue could be fixed in a separate PR.

<details>
<summary>Stacktrace</summary>
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-2-9240d2ad9677> in <module>
      1 import tensorflow as tf
----> 2 from edward.models import Normal
      3 
      4 W_0 = Normal(loc=tf.zeros([1, 2]), scale=tf.ones([1, 2]))
      5 W_1 = Normal(loc=tf.zeros([2, 1]), scale=tf.ones([2, 1]))

~/.local/share/virtualenvs/ed-61OcBILj/lib/python3.7/site-packages/edward/__init__.py in <module>
      3 from __future__ import print_function
      4 
----> 5 from edward import criticisms
      6 from edward import inferences
      7 from edward import models

~/.local/share/virtualenvs/ed-61OcBILj/lib/python3.7/site-packages/edward/criticisms/__init__.py in <module>
      5 from __future__ import print_function
      6 
----> 7 from edward.criticisms.evaluate import *
      8 from edward.criticisms.ppc import *
      9 from edward.criticisms.ppc_plots import *

~/.local/share/virtualenvs/ed-61OcBILj/lib/python3.7/site-packages/edward/criticisms/evaluate.py in <module>
      7 import tensorflow as tf
      8 
----> 9 from edward.models import RandomVariable
     10 from edward.util import check_data, get_session, compute_multinomial_mode, \
     11     with_binary_averaging

~/.local/share/virtualenvs/ed-61OcBILj/lib/python3.7/site-packages/edward/models/__init__.py in <module>
      5 from __future__ import print_function
      6 
----> 7 from edward.models.dirichlet_process import *
      8 from edward.models.empirical import *
      9 from edward.models.param_mixture import *

~/.local/share/virtualenvs/ed-61OcBILj/lib/python3.7/site-packages/edward/models/dirichlet_process.py in <module>
      6 
      7 from edward.models.random_variable import RandomVariable
----> 8 from tensorflow.contrib.distributions import Distribution
      9 
     10 try:

ModuleNotFoundError: No module named 'tensorflow.contrib'


</details>